### PR TITLE
Remove duplicate key

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -179,13 +179,6 @@ latex_documents = [
 
 # -- Options for manual page output --------------------------------------------
 
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [
-    ('index', 'payu', u'payu Documentation',
-     [u'Marshall Ward'], 1)
-]
-
 # If true, show URL addresses after external links.
 #man_show_urls = False
 


### PR DESCRIPTION
`man_pages` is being declared twice, so one of the values is not used. I left the last one, as that's probably what's being used now.