### PR TITLE
Previous restarts polluting restart manifests with subruns

### DIFF
--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -135,6 +135,10 @@ def runscript():
         # Need to manually increment the run counter if still looping
         if n_runs_per_submit > 1 and subrun < n_runs_per_submit:
             expt.counter += 1
+            # Re-initialize manifest: important to clear out restart manifest
+            # note no attempt to preserve reproduce flag, it makes no sense
+            # to on subsequent runs
+            expt.manifest = Manifest(expt)
             expt.set_output_paths()
             # Does not make sense to reproduce a multiple run.
             # Take care of this with argument processing?

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -7,6 +7,7 @@ from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu import fsops
+from payu.manifest import Manifest
 
 title = 'run'
 parameters = {'description': 'Run the model experiment'}
@@ -138,7 +139,7 @@ def runscript():
             # Re-initialize manifest: important to clear out restart manifest
             # note no attempt to preserve reproduce flag, it makes no sense
             # to on subsequent runs
-            expt.manifest = Manifest(expt)
+            expt.manifest = Manifest(expt, reproduce=False)
             expt.set_output_paths()
             # Does not make sense to reproduce a multiple run.
             # Take care of this with argument processing?


### PR DESCRIPTION
Initialise manifest in run_cmd for subruns, otherwise previous restart can remain in the manifest.

Addresses https://github.com/payu-org/payu/issues/188