### PR TITLE
Make get_qstat_info more robust

### DIFF
--- a/payu/scheduler/pbs.py
+++ b/payu/scheduler/pbs.py
@@ -41,7 +41,8 @@ def get_job_info():
         info = get_qstat_info('-ft {0}'.format(jobid), 'Job Id:')
 
     if info is not None:
-        # Select the dict for this job (there should only be one entry in any case)
+        # Select the dict for this job (there should only be one 
+        # entry in any case)
         info = info['Job Id: {}'.format(jobid)]
 
         # Add the jobid to the dict and then return

--- a/payu/scheduler/pbs.py
+++ b/payu/scheduler/pbs.py
@@ -14,7 +14,7 @@ import sys
 import shlex
 import subprocess
 
-import tenacity
+from tenacity import retry, stop_after_delay
 
 def get_job_id(short=True):
     """

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         'PyYAML',
         'requests',
         'yamanifest',
-        'dateutil'
+        'dateutil',
+        'tenacity',
     ],
     install_requires=[
         'f90nml >= 0.16',
@@ -42,6 +43,7 @@ setup(
         'PyYAML',
         'requests[security]',
         'python-dateutil',
+        'tenacity',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Added retry decorator (from tenacity) to get_qstat_info as calls to qstat were timing out and bringing down simulations with multiple runs per submit.