### PR TITLE
Fine-grained reproduce flags and testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
             - run: |
                 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda.sh
                 bash conda.sh -b -p ~/conda
+                ~/conda/bin/conda update conda
                 ~/conda/bin/conda config --system --add channels conda-forge
                 ~/conda/bin/conda config --system --add channels coecms
-                ~/conda/bin/conda update conda
                 ~/conda/bin/conda install --yes conda-build conda-verify
 
             - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             - run: |
                 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda.sh
                 bash conda.sh -b -p ~/conda
-                ~/conda/bin/conda update -all
+                ~/conda/bin/conda update --all
                 ~/conda/bin/conda config --system --add channels conda-forge
                 ~/conda/bin/conda config --system --add channels coecms
                 ~/conda/bin/conda install --yes conda-build conda-verify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             - run: |
                 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda.sh
                 bash conda.sh -b -p ~/conda
-                ~/conda/bin/conda update conda
+                # ~/conda/bin/conda update conda
                 ~/conda/bin/conda config --system --add channels conda-forge
                 ~/conda/bin/conda config --system --add channels coecms
                 ~/conda/bin/conda install --yes conda-build conda-verify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             - run: |
                 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O conda.sh
                 bash conda.sh -b -p ~/conda
-                # ~/conda/bin/conda update conda
+                ~/conda/bin/conda update -all
                 ~/conda/bin/conda config --system --add channels conda-forge
                 ~/conda/bin/conda config --system --add channels coecms
                 ~/conda/bin/conda install --yes conda-build conda-verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
     - pip install -r test/requirements_test.txt
 script:
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then payu list; fi;
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu bin/payu; fi;
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu payu -m py.test test/test_manifest.py; fi;
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
     - pip install -r test/requirements_test.txt
 script:
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then payu list; fi;
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]] then PYTHONPATH=$(pwd) coverage run --source payu bin/payu
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu bin/payu
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ install:
 before_script:
     - pip install -r test/requirements_test.txt
 script:
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then payu list; fi;
+    - payu list
+    - pylint --extension-pkg-whitelist=netCDF4 -E payu
     - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu -m py.test test/test_manifest.py; fi;
 after_success:
     - coverage report -m

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
     - "3.6"
     - "3.7"
 # Disabling Torque setup until we can get this working on Travis
-before_install:
-    - sudo apt-get install torque-server torque-client torque-mom torque-pam
-    - sudo ./test/setup_torque.sh
+# before_install:
+#     - sudo apt-get install torque-server torque-client torque-mom torque-pam
+#     - sudo ./test/setup_torque.sh
 install:
     - pip install .
 before_script:
@@ -14,7 +14,7 @@ before_script:
 script:
     - payu list
     - pylint --extension-pkg-whitelist=netCDF4 -E payu
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu -m py.test test/test_manifest.py; fi;
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu -m py.test test/test_payu.py test/test_manifest.py; fi;
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
+    - "2.7"
     - "3.6"
+    - "3.7"
 # Disabling Torque setup until we can get this working on Travis
 before_install:
     - sudo apt-get install torque-server torque-client torque-mom torque-pam
@@ -10,7 +12,8 @@ install:
 before_script:
     - pip install -r test/requirements_test.txt
 script:
-    - PYTHONPATH=$(pwd) coverage run --source payu -m py.test test/test_manifest.py
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then payu list; fi;
+    - if [[ $TRAVIS_PYTHON_VERSION >= 3.6 ]]; then PYTHONPATH=$(pwd) coverage run --source payu bin/payu
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
     - pip install -r test/requirements_test.txt
 script:
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then payu list; fi;
-    - if [[ $TRAVIS_PYTHON_VERSION >= 3.6 ]]; then PYTHONPATH=$(pwd) coverage run --source payu bin/payu
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]] then PYTHONPATH=$(pwd) coverage run --source payu bin/payu
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
     - pip install -r test/requirements_test.txt
 script:
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then payu list; fi;
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu bin/payu
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu bin/payu; fi;
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 before_script:
     - pip install -r test/requirements_test.txt
 script:
-    - PYTHONPATH=$(pwd) coverage run --source payu pytest test/test_manifest.py
+    - PYTHONPATH=$(pwd) coverage run --source payu -m py.test test/test_manifest.py
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ install:
 before_script:
     - pip install -r test/requirements_test.txt
 script:
-    - pytest -s test/test_manifest.py
-    - PYTHONPATH=$(pwd) coverage run --source payu bin/payu
+    - PYTHONPATH=$(pwd) coverage run --source payu pytest test/test_manifest.py
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
     - pip install -r test/requirements_test.txt
 script:
     - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then payu list; fi;
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu payu -m py.test test/test_manifest.py; fi;
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu -m py.test test/test_manifest.py; fi;
 after_success:
     - coverage report -m
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-    - "2.7"
-    - "3.5"
     - "3.6"
 # Disabling Torque setup until we can get this working on Travis
 before_install:
@@ -12,6 +10,7 @@ install:
 before_script:
     - pip install -r test/requirements_test.txt
 script:
+    - pytest -s test/test_manifest.py
     - PYTHONPATH=$(pwd) coverage run --source payu bin/payu
 after_success:
     - coverage report -m

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,11 @@ Payu
 
 .. image:: https://travis-ci.org/payu-org/payu.svg?branch=master
     :target: https://travis-ci.org/payu-org/payu
+.. image:: https://coveralls.io/repos/github/payu-org/payu/badge.svg?branch=master
+    :target: https://coveralls.io/github/payu-org/payu?branch=master
+
+
+
 
 Payu is a climate model workflow management tool for supercomputing
 environments.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Payu
 ====
 
-.. image:: https://travis-ci.org/marshallward/payu.svg?branch=master
-   :target: https://travis-ci.org/marshallward/payu
+.. image:: https://travis-ci.org/payu-org/payu.svg?branch=master
+    :target: https://travis-ci.org/payu-org/payu
 
 Payu is a climate model workflow management tool for supercomputing
 environments.

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     build:
         - python
         - pbr
+        - setuptools
     run:
         - python
         - f90nml >=0.16

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -124,6 +124,8 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
 def submit_job(pbs_script, pbs_config, pbs_vars=None):
     """Submit a userscript the scheduler."""
 
+    pbs_env_init()
+
     # Initialisation
     if pbs_vars is None:
         pbs_vars = {}

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -20,6 +20,7 @@ import payu
 import payu.envmod as envmod
 from payu.models import index as supported_models
 import payu.subcommands
+from payu.scheduler.pbs import pbs_env_init
 
 # Default configuration
 DEFAULT_CONFIG = 'config.yaml'

--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -98,6 +98,7 @@ def lib_update(bin_path, lib_name):
         if lib_name in lib_entry:
             lib_path = lib_entry.split()[2]
 
+            # pylint: disable=unbalanced-tuple-unpacking
             mod_name, mod_version = fsops.splitpath(lib_path)[2:4]
 
             module('unload', mod_name)

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -116,8 +116,6 @@ class Experiment(object):
 
         self.run_id = None
 
-        pbs_env_init()
-
     def init_models(self):
 
         self.model_name = self.config.get('model')

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -655,7 +655,7 @@ class Experiment(object):
             job_id = get_job_id(short=False)
 
             if job_id == '':
-                job_id = self.run_id[:6]
+                job_id = str(self.run_id)[:6]
 
             for fname in self.output_fnames:
 

--- a/payu/laboratory.py
+++ b/payu/laboratory.py
@@ -48,11 +48,11 @@ class Laboratory(object):
         self.input_basepath = os.path.join(self.basepath, 'input')
         self.work_path = os.path.join(self.basepath, 'work')
 
-        print("laboratory path: ",self.basepath)
-        print("binary path: ",self.bin_path)
-        print("input path: ",self.input_basepath)
-        print("work path: ",self.work_path)
-        print("archive path: ",self.archive_path)
+        print("laboratory path: ", self.basepath)
+        print("binary path: ", self.bin_path)
+        print("input path: ", self.input_basepath)
+        print("work path: ", self.work_path)
+        print("archive path: ", self.archive_path)
 
     def get_default_lab_path(self, config):
         """Generate a default laboratory path based on user environment."""

--- a/payu/laboratory.py
+++ b/payu/laboratory.py
@@ -48,6 +48,12 @@ class Laboratory(object):
         self.input_basepath = os.path.join(self.basepath, 'input')
         self.work_path = os.path.join(self.basepath, 'work')
 
+        print("laboratory path: ",self.basepath)
+        print("binary path: ",self.bin_path)
+        print("input path: ",self.input_basepath)
+        print("work path: ",self.work_path)
+        print("archive path: ",self.archive_path)
+
     def get_default_lab_path(self, config):
         """Generate a default laboratory path based on user environment."""
         # Default path settings

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -282,7 +282,6 @@ class Manifest(object):
         return len(self.manifests)
 
     def setup(self):
-   
         if (os.path.exists(self.manifests['input'].path) and
                 not self.manifest_config.get('overwrite', False)):
             # Always read input manifest if available
@@ -297,7 +296,7 @@ class Manifest(object):
                     self.manifests['input'].existing_filepaths = \
                         set(self.manifests['input'].data.keys())
                 else:
-                    # Input directories not scanned. Populate 
+                    # Input directories not scanned. Populate
                     # inputs in workdir using input manifest
                     print('Making input links from manifest'
                           '(scaninputs=False)')
@@ -305,7 +304,7 @@ class Manifest(object):
 
         if self.reproduce['exe']:
             # Only load existing exe manifest if reproduce. Trivial to
-            # recreate and means no check required for changed 
+            # recreate and means no check required for changed
             # executable paths
             if os.path.exists(self.manifests['exe'].path):
                 # Read manifest
@@ -321,8 +320,8 @@ class Manifest(object):
             self.manifests['exe'].make_links()
 
         if self.reproduce['restart']:
-            # Only load restart manifest if reproduce. Normally want to 
-            # scan for new restarts 
+            # Only load restart manifest if reproduce. Normally want to
+            # scan for new restarts
 
             # Read restart manifest
             print('Loading restart manifest: {}'
@@ -344,7 +343,7 @@ class Manifest(object):
         for mf in self.manifests.keys():
             if self.reproduce[mf] and not self.have_manifest[mf]:
                 print('{} manifest must exist if reproduce is True'
-                        ''.format(mf.capitalize()))
+                      ''.format(mf.capitalize()))
                 exit(1)
 
     def check_manifests(self):
@@ -357,7 +356,7 @@ class Manifest(object):
                 # Delete missing filepaths from input manifest
                 for filepath in self.manifests['input'].existing_filepaths:
                     print('File no longer in input directory: {file} '
-                        'removing from manifest'.format(file=filepath))
+                          'removing from manifest'.format(file=filepath))
                     self.manifests['input'].delete(filepath)
                 self.manifests['input'].needsync = True
 
@@ -368,7 +367,8 @@ class Manifest(object):
         else:
             print("Creating restart manifest")
             self.manifests['restart'].needsync = True
-        self.manifests['restart'].check_fast(reproduce=self.reproduce['restart'])
+        self.manifests['restart'].check_fast(
+                reproduce=self.reproduce['restart'])
 
         # Write updates to version on disk
         for mf in self.manifests:

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -282,25 +282,31 @@ class Manifest(object):
         return len(self.manifests)
 
     def setup(self):
-        if (os.path.exists(self.manifests['input'].path) and
-                not self.manifest_config.get('overwrite', False)):
-            # Always read input manifest if available
-            print('Loading input manifest: {path}'
-                  ''.format(path=self.manifests['input'].path))
-            self.manifests['input'].load()
 
-            if len(self.manifests['input']) > 0:
-                self.have_manifest['input'] = True
-                if self.scaninputs:
-                    # Save existing filepath information
-                    self.manifests['input'].existing_filepaths = \
-                        set(self.manifests['input'].data.keys())
-                else:
-                    # Input directories not scanned. Populate
-                    # inputs in workdir using input manifest
-                    print('Making input links from manifest'
-                          '(scaninputs=False)')
-                    self.manifests['input'].make_links()
+        if (os.path.exists(self.manifests['input'].path)):
+            # Always read input manifest if available
+            try:
+                print('Loading input manifest: {path}'
+                    ''.format(path=self.manifests['input'].path))
+                self.manifests['input'].load()
+
+                if len(self.manifests['input']) > 0:
+                    self.have_manifest['input'] = True
+                    if self.scaninputs:
+                        # Save existing filepath information
+                        self.manifests['input'].existing_filepaths = \
+                            set(self.manifests['input'].data.keys())
+                    else:
+                        # Input directories not scanned. Populate
+                        # inputs in workdir using input manifest
+                        print('Making input links from manifest'
+                                '(scaninputs=False)')
+                        self.manifests['input'].make_links()
+            except Exception as e:
+                print("Error loading input manifest: {}".format(e))
+                self.manifests['input'].have_manifest = False
+            finally:
+                self.manifests['input'].have_manifest = True
 
         if self.reproduce['exe']:
             # Only load existing exe manifest if reproduce. Trivial to
@@ -318,6 +324,8 @@ class Manifest(object):
             # Must make links as no files will be added to the manifest
             print('Making exe links')
             self.manifests['exe'].make_links()
+        else:
+            self.have_manifest['exe'] = False
 
         if self.reproduce['restart']:
             # Only load restart manifest if reproduce. Normally want to

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -287,7 +287,7 @@ class Manifest(object):
             # Always read input manifest if available
             try:
                 print('Loading input manifest: {path}'
-                    ''.format(path=self.manifests['input'].path))
+                      ''.format(path=self.manifests['input'].path))
                 self.manifests['input'].load()
 
                 if len(self.manifests['input']) > 0:
@@ -300,7 +300,7 @@ class Manifest(object):
                         # Input directories not scanned. Populate
                         # inputs in workdir using input manifest
                         print('Making input links from manifest'
-                                '(scaninputs=False)')
+                              '(scaninputs=False)')
                         self.manifests['input'].make_links()
             except Exception as e:
                 print("Error loading input manifest: {}".format(e))

--- a/payu/models/__init__.py
+++ b/payu/models/__init__.py
@@ -9,6 +9,7 @@ from payu.models.mom import Mom
 from payu.models.mom6 import Mom6
 from payu.models.nemo import Nemo
 from payu.models.oasis import Oasis
+from payu.models.test import Test
 from payu.models.um import UnifiedModel
 from payu.models.ww3 import WW3
 from payu.models.qgcm import Qgcm
@@ -28,6 +29,7 @@ index = {
     'mom':      Mom,
     'nemo':     Nemo,
     'oasis':    Oasis,
+    'test':     Test,
     'um':       UnifiedModel,
     'ww3':      WW3,
     'mom6':     Mom6,

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -78,7 +78,7 @@ class Mitgcm(Model):
         if self.prior_restart_path and not self.expt.repeat_run:
             # Determine total number of timesteps since initialisation
             core_restarts = [f for f in os.listdir(self.prior_restart_path)
-                            if f.startswith('pickup.')]
+                             if f.startswith('pickup.')]
             try:
                 # NOTE: Use the most recent, in case of multiple restarts
                 n_iter0 = max([int(f.split('.')[1]) for f in core_restarts])
@@ -125,7 +125,8 @@ class Mitgcm(Model):
                 # Assume n_timesteps and dt set correctly
                 pass
 
-        if t_start is None or (self.prior_restart_path and not self.expt.repeat_run):
+        if t_start is None or (self.prior_restart_path
+           and not self.expt.repeat_run):
             # Look for a restart file from a previous run
             if os.path.exists(restart_calendar_path):
                 with open(restart_calendar_path, 'r') as restart_file:
@@ -139,23 +140,23 @@ class Mitgcm(Model):
         # Check if deltat has changed
         if n_iter0 != t_start // dt:
 
-            n_iter0_previous = n_iter0
-            
             # Specify a pickup suffix using previous niter0
-            data_nml['parm03']['pickupsuff'] = '{:010d}'.format(n_iter0_previous)
+            data_nml['parm03']['pickupsuff'] = '{:010d}'.format(n_iter0)
+
+            n_iter0_previous = n_iter0
 
             n_iter0 = t_start // dt
 
             if n_iter0 * dt != t_start:
-                print('payu : error: Timestep changed to {dt}. New timestep not'
-                      ' integer multiple of start time: {start}'.format(dt=dt, 
-                      start=t_start))
+                print('payu : error: Timestep changed to {dt}. New timestep '
+                      'not integer multiple of start time: '
+                      '{start}'.format(dt=dt, start=t_start))
                 sys.exit(1)
 
             if n_iter0 + n_timesteps == n_iter0_previous:
-                print('payu : error: Timestep changed to {dt}. Timestep at end'
-                      ' identical to previous pickups: {niter}'.format(dt=dt, 
-                      niter=(n_iter0 + n_timesteps)))
+                print('payu : error: Timestep changed to {dt}. '
+                      'Timestep at end identical to previous pickups: '
+                      '{niter}'.format(dt=dt, niter=(n_iter0 + n_timesteps)))
                 print('This would overwrite previous pickups')
                 sys.exit(1)
 
@@ -180,8 +181,8 @@ class Mitgcm(Model):
 
         # NOTE: Consider permitting pchkpt_freq < dt * n_timesteps
         if t_end % pchkpt_freq != 0:
-            # Terrible hack for when we change dt, the pickup frequency no longer
-            # make sense, so have to set it to the total runtime
+            # Terrible hack for when we change dt, the pickup frequency
+            # no longer make sense, so have to set it to the total runtime
             data_nml['parm03']['pchkptfreq'] = t_end
         else:
             data_nml['parm03']['pchkptfreq'] = pchkpt_freq
@@ -224,8 +225,8 @@ class Mitgcm(Model):
         # Save model time to restart next run
         with open(os.path.join(self.restart_path,
                   self.restart_calendar_file), 'w') as restart_file:
-            restart_file.write(yaml.dump({'endtime': data_nml['parm03']['endTime']},
-                               default_flow_style=False))
+            restart = {'endtime': data_nml['parm03']['endTime']},
+            restart_file.write(yaml.dump(restart, default_flow_style=False))
 
         # Remove symbolic links to input or pickup files:
         for f in os.listdir(self.work_path):

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -209,9 +209,8 @@ class Mitgcm(Model):
                     'mnc_outdir_date':  True,
                     'monitor_mnc':      True
                 }
-                data_mnc_nml = {'mnc_01': mnc_01_grp}
-
-                nml_parser.write(data_mnc_nml, data_mnc_path)
+                data_mnc_nml = f90nml.Namelist(mnc_01=mnc_01_grp)
+                data_mnc_nml.write(data_mnc_path)
             else:
                 raise
 

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -190,8 +190,9 @@ class Model(object):
     def get_prior_restart_files(self):
 
         try:
-            return [f for f in os.listdir(self.prior_restart_path)
-                    if os.path.isfile(os.path.join(self.prior_restart_path, f))]
+            path = self.restart_path
+            return [f for f in os.listdir(path)
+                    if os.path.isfile(os.path.join(path, f))]
         except Exception as e:
             print("No prior restart files found: {error}".format(error=str(e)))
             return []

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -236,7 +236,7 @@ class Model(object):
                 )
 
         # Add input files to manifest if we don't already have a populated
-        # input manifest, or we specify scan_inputs is True (default)
+        # input manifest, or we specify scaninputs is True (default)
         if (not self.expt.manifest.have_manifest['input'] or
                 self.expt.manifest.scaninputs):
             for input_path in self.input_paths:

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -190,9 +190,9 @@ class Model(object):
     def get_prior_restart_files(self):
 
         try:
-            path = self.restart_path
-            return [f for f in os.listdir(path)
-                    if os.path.isfile(os.path.join(path, f))]
+            respath = self.prior_restart_path
+            return [f for f in os.listdir(respath)
+                    if os.path.isfile(os.path.join(respath, f))]
         except Exception as e:
             print("No prior restart files found: {error}".format(error=str(e)))
             return []

--- a/payu/models/mom.py
+++ b/payu/models/mom.py
@@ -136,7 +136,7 @@ class Mom(Fms):
 
     def create_mask_table(self, input_nml):
         import netCDF4
-     
+
         # Disable E1136 which is tripped below when accessing grid_vars
         # pylint: disable=unsubscriptable-object
 
@@ -165,6 +165,8 @@ class Mom(Fms):
             if ocn_topog_fname in os.listdir(input_dir):
                 ocn_topog_path = os.path.join(input_dir, ocn_topog_fname)
                 break
+
+        # pylint: enable=unsubscriptable-object
 
         grid_spec_nc.close()
 

--- a/payu/models/mom.py
+++ b/payu/models/mom.py
@@ -136,6 +136,9 @@ class Mom(Fms):
 
     def create_mask_table(self, input_nml):
         import netCDF4
+     
+        # Disable E1136 which is tripped below when accessing grid_vars
+        # pylint: disable=unsubscriptable-object
 
         # Get the grid spec path
         grid_spec_fname = 'grid_spec.nc'

--- a/payu/models/test.py
+++ b/payu/models/test.py
@@ -16,8 +16,8 @@ config_files = [
             'input.nml'
         ]
 
-class Test(Model):
 
+class Test(Model):
 
     def __init__(self, expt, name, config):
 

--- a/payu/models/test.py
+++ b/payu/models/test.py
@@ -18,6 +18,7 @@ config_files = [
 
 class Test(Model):
 
+
     def __init__(self, expt, name, config):
 
         # payu initialisation

--- a/payu/models/test.py
+++ b/payu/models/test.py
@@ -1,0 +1,30 @@
+"""Test driver interface
+
+:copyright: Copyright 2019 Marshall Ward, see AUTHORS for details
+:license: Apache License, Version 2.0, see LICENSE for details
+"""
+import os
+import shlex
+import shutil
+import subprocess
+
+from payu.models.model import Model
+
+config_files = [
+            'data',
+            'diag',
+            'input.nml'
+        ]
+
+class Test(Model):
+
+    def __init__(self, expt, name, config):
+
+        # payu initialisation
+        super(Test, self).__init__(expt, name, config)
+
+        # Model-specific configuration
+        self.model_type = 'test'
+        self.default_exec = 'test.exe'
+
+        self.config_files = config_files

--- a/payu/scheduler/pbs.py
+++ b/payu/scheduler/pbs.py
@@ -16,6 +16,7 @@ import subprocess
 
 from tenacity import retry, stop_after_delay
 
+
 def get_job_id(short=True):
     """
     Return PBS job id
@@ -29,6 +30,7 @@ def get_job_id(short=True):
 
     return(jobid)
 
+
 def get_job_info():
     """
     Get information about the job from the PBS server
@@ -41,7 +43,7 @@ def get_job_info():
         info = get_qstat_info('-ft {0}'.format(jobid), 'Job Id:')
 
     if info is not None:
-        # Select the dict for this job (there should only be one 
+        # Select the dict for this job (there should only be one
         # entry in any case)
         info = info['Job Id: {}'.format(jobid)]
 

--- a/payu/subcommands/profile_cmd.py
+++ b/payu/subcommands/profile_cmd.py
@@ -8,6 +8,7 @@ import os
 from payu import cli
 from payu.experiment import Experiment
 from payu.laboratory import Laboratory
+from payu import fsops
 import payu.subcommands.args as args
 
 title = 'profile'
@@ -19,7 +20,7 @@ arguments = [args.model, args.config, args.initial, args.nruns,
 
 def runcmd(model_type, config_path, init_run, n_runs, lab_path):
 
-    pbs_config = cli.get_config(config_path)
+    pbs_config = fsops.read_config(config_path)
     pbs_vars = cli.set_env_vars(init_run, n_runs, lab_path)
 
     pbs_config['queue'] = pbs_config.get('profile_queue', 'normal')

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -41,7 +41,7 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path, reproduce):
         # TODO: Is control_path defined at this stage?
         mask_table_fname = None
         for fname in os.listdir(os.curdir):
-            if f.startswith('mask_table'):
+            if fname.startswith('mask_table'):
                 mask_table_fname = fname
 
         # TODO TODO

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
         'python-dateutil',
         'tenacity',
     ],
+    tests_require=[
+        'pytest',
+    ]
     entry_points={
         'console_scripts': [
             'payu = payu.cli:parse',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'yamanifest',
         'dateutil',
         'tenacity',
+        'scipy',
     ],
     install_requires=[
         'f90nml >= 0.16',

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     ],
     tests_require=[
         'pytest',
+        'pylint',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     ],
     tests_require=[
         'pytest',
-    ]
+    ],
     entry_points={
         'console_scripts': [
             'payu = payu.cli:parse',

--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,37 @@
+from contextlib import contextmanager
+import os
+from pathlib import Path
+
+import yaml
+
+@contextmanager
+def cd(directory):
+    """
+    Context manager to change into a directory and
+    change back to original directory when complete
+    """
+    old_dir = Path.cwd()
+    os.chdir(directory)
+    try:
+        yield
+    finally:
+        os.chdir(old_dir)
+
+def make_random_file(filename, size=1000**2):
+    """
+    Make a file of specified size filled with some 
+    random content
+    """
+    with open(filename, 'wb') as fout:
+        fout.write(os.urandom(size))
+
+def get_manifests(mfdir):
+    """
+    Read in all manifests and return as a dict
+    """
+    manifests = {}
+    for mf in ['exe', 'input', 'restart']:
+        mfpath = Path(mfdir)/"{}.yaml".format(mf)
+        with mfpath.open() as fh:
+            manifests[mfpath.name] = list(yaml.safe_load_all(fh))[1]
+    return manifests

--- a/test/common.py
+++ b/test/common.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import yaml
 
+
 @contextmanager
 def cd(directory):
     """
@@ -17,13 +18,15 @@ def cd(directory):
     finally:
         os.chdir(old_dir)
 
+
 def make_random_file(filename, size=1000**2):
     """
-    Make a file of specified size filled with some 
+    Make a file of specified size filled with some
     random content
     """
     with open(filename, 'wb') as fout:
         fout.write(os.urandom(size))
+
 
 def get_manifests(mfdir):
     """

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -3,3 +3,4 @@ coverage ; python_version != '3.2'
 coveralls
 pytest
 pylint
+mnctools

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -1,3 +1,4 @@
 coverage == 3.7.1 ; python_version == '3.2'
 coverage ; python_version != '3.2'
 coveralls
+pytest

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -4,3 +4,4 @@ coveralls
 pytest
 pylint
 mnctools
+scipy

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -2,3 +2,4 @@ coverage == 3.7.1 ; python_version == '3.2'
 coverage ; python_version != '3.2'
 coveralls
 pytest
+pylint

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -337,7 +337,7 @@ def test_input_reproduce():
     # Sweep workdir
     sweep_work()
 
-    # Delete input directory from config, should still work from 
+    # Delete input directory from config, should still work from
     # manifest with input reproduce True
     input = config['input']
     write_config()
@@ -431,7 +431,7 @@ def test_input_scaninputs():
     config['manifest']['scaninputs'] = True
     write_config()
 
-    # Run setup with unchanged input 
+    # Run setup with unchanged input
     payu_setup(lab_path=str(labdir))
     manifests = get_manifests(ctrldir/'manifests')
 
@@ -494,7 +494,7 @@ def test_input_scaninputs():
     config['manifest']['scaninputs'] = True
     write_config()
 
-    # Run setup again. Should be fine, but manifests changed now 
+    # Run setup again. Should be fine, but manifests changed now
     # as scaninputs=False
     payu_setup(lab_path=str(labdir))
     assert(not manifests == get_manifests(ctrldir/'manifests'))

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -139,10 +139,11 @@ def teardown_module(module):
 # These are integration tests. They have an undesirable dependence on each
 # other. It would be possible to make them independent, but then they'd
 # be reproducing previous "tests", like init. So this design is deliberate
-# but compromised. It means when running an error in one test can cascade 
+# but compromised. It means when running an error in one test can cascade
 # and cause other tests to fail.
 #
 # Unfortunate but there you go.
+
 
 def test_init():
 
@@ -153,6 +154,7 @@ def test_init():
     # Check all the correct directories have been created
     for subdir in ['bin', 'input', 'archive', 'codebase']:
         assert((labdir / subdir).is_dir())
+
 
 def test_setup():
 
@@ -165,12 +167,12 @@ def test_setup():
 
     config_files = payu.models.test.config_files
     for file in config_files:
-        make_random_file( ctrldir/file, 29)
+        make_random_file(ctrldir/file, 29)
 
     # Run setup
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     workdir = ctrldir / 'work'
     assert(workdir.is_symlink())
     assert(workdir.is_dir())
@@ -180,25 +182,26 @@ def test_setup():
     for f in config_files + ['config.yaml']:
         assert((workdir/f).is_file())
 
-    for i in range(1,4):
-        assert((workdir/'input_00{i}.bin'.format(i=i)).stat().st_size == 1000**2 + i)
+    for i in range(1, 4):
+        assert((workdir/'input_00{i}.bin'.format(i=i)).stat().st_size 
+                == 1000**2 + i)
 
     manifests = get_manifests(ctrldir/'manifests')
     for mfpath in manifests:
-        assert( (ctrldir/'manifests'/mfpath).is_file() )
+        assert((ctrldir/'manifests'/mfpath).is_file())
 
     # Check manifest in work directory is the same as control directory
     assert(manifests == get_manifests(workdir/'manifests'))
 
     # Sweep workdir and recreate
     sweep_work()
-    
+
     assert(not workdir.is_dir())
     assert(not workdirfull.is_dir())
 
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     assert(manifests == get_manifests(workdir/'manifests'))
 
     # Sweep workdir
@@ -224,6 +227,7 @@ def test_setup_restartdir():
     # Sweep workdir
     sweep_work()
 
+
 def test_exe_reproduce():
 
     # Set reproduce exe to True
@@ -231,10 +235,11 @@ def test_exe_reproduce():
     write_config()
     manifests = get_manifests(ctrldir/'manifests')
 
-    # Run setup with unchanged exe but reproduce exe set to True. Should run without error
+    # Run setup with unchanged exe but reproduce exe set to True. 
+    # Should run without error
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     assert(manifests == get_manifests(ctrldir/'manifests'))
 
     # Sweep workdir
@@ -243,13 +248,13 @@ def test_exe_reproduce():
     bindir = labdir / 'bin'
     exe = config['exe']
 
-    # Update the modification time of the executable, should run ok 
+    # Update the modification time of the executable, should run ok
     (bindir/exe).touch()
 
     # Run setup with changed exe but reproduce exe set to False
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     # Manifests will have changed as fasthash is altered
     assert(not manifests == get_manifests(ctrldir/'manifests'))
 
@@ -264,7 +269,7 @@ def test_exe_reproduce():
         # Run setup with unchanged exe but reproduce exe set to True
         with cd(ctrldir):
             payu_setup(lab_path=str(labdir))
-            
+
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
 
@@ -278,12 +283,13 @@ def test_exe_reproduce():
     # Run setup with changed exe but reproduce exe set to False
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     # Check manifests have changed as expected
     assert(not manifests == get_manifests(ctrldir/'manifests'))
 
     # Sweep workdir
     sweep_work()
+
 
 def test_input_reproduce():
 
@@ -299,21 +305,21 @@ def test_input_reproduce():
     # Run setup with unchanged exe but reproduce exe set to True
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     assert(manifests == get_manifests(ctrldir/'manifests'))
 
     # Sweep workdir
     sweep_work()
 
     # Update modification times for input files
-    for i in range(1,4):
+    for i in range(1, 4):
         (inputdir/'input_00{i}.bin'.format(i=i)).touch()
 
-    # Run setup, should work as only fasthash will differ, code then checks full hash and
-    # updates fasthash if fullhash matches
+    # Run setup, should work as only fasthash will differ, code then 
+    # checks full hash and updates fasthash if fullhash matches
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     # Manifests should no longer match as fasthashes have been updated
     assert(not manifests == get_manifests(ctrldir/'manifests'))
 
@@ -328,7 +334,7 @@ def test_input_reproduce():
         # Run setup with unchanged exe but reproduce exe set to True
         with cd(ctrldir):
             payu_setup(lab_path=str(labdir))
-        
+
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
 
@@ -362,13 +368,13 @@ def test_restart_reproduce():
     # Run setup with unchanged restarts
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+ 
     assert(manifests == get_manifests(ctrldir/'manifests'))
 
     restartdir = labdir / 'archive' / 'restarts'
 
     # Change modification times on restarts
-    for i in range(1,4):
+    for i in range(1, 4):
         (restartdir/'restart_00{i}.bin'.format(i=i)).touch()
 
     # Sweep workdir
@@ -377,7 +383,7 @@ def test_restart_reproduce():
     # Run setup with touched restarts
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     # Manifests should have changed
     assert(not manifests == get_manifests(ctrldir/'manifests'))
 
@@ -416,13 +422,14 @@ def test_restart_reproduce():
     # Sweep workdir
     sweep_work()
 
+
 def test_all_reproduce():
 
     # Remove reproduce options from config
     del(config['manifest']['reproduce'])
     write_config()
 
-    # Run setup 
+    # Run setup
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
 
@@ -433,7 +440,8 @@ def test_all_reproduce():
 
     make_all_files()
 
-    # Run setup with reproduce=True, which should raise an error as all files changed
+    # Run setup with reproduce=True, which should raise an error as 
+    # all files changed
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         # Run setup with unchanged exe but reproduce exe set to True
         with cd(ctrldir):
@@ -442,7 +450,7 @@ def test_all_reproduce():
     # Sweep workdir
     sweep_work()
 
-    # Run setup 
+    # Run setup
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
 

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -53,6 +53,15 @@ config = {
             }
 
 
+def sweep_work(hard_sweep=False):
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None,
+                   config_path=None,
+                   hard_sweep=hard_sweep,
+                   lab_path=str(labdir))
+
+
 def payu_setup(model_type=None,
                config_path=None,
                lab_path=None,
@@ -63,20 +72,15 @@ def payu_setup(model_type=None,
     and run in ctrldir
     """
     with cd(ctrldir):
+        payu_sweep(model_type=None,
+                   config_path=None,
+                   hard_sweep=False,
+                   lab_path=str(labdir))
         payu_setup_orignal(model_type,
                            config_path,
                            lab_path,
                            force_archive,
                            reproduce)
-
-
-def sweep_work(hard_sweep=False):
-    # Sweep workdir
-    with cd(ctrldir):
-        payu_sweep(model_type=None,
-                   config_path=None,
-                   hard_sweep=hard_sweep,
-                   lab_path=str(labdir))
 
 
 def write_config():
@@ -218,9 +222,6 @@ def test_setup():
 
     assert(manifests == get_manifests(workdir/'manifests'))
 
-    # Sweep workdir
-    sweep_work()
-
 
 def test_setup_restartdir():
 
@@ -238,9 +239,6 @@ def test_setup_restartdir():
     # Manifests should not match, as have added restarts
     assert(not manifests == get_manifests(ctrldir/'manifests'))
 
-    # Sweep workdir
-    sweep_work()
-
 
 def test_exe_reproduce():
 
@@ -254,9 +252,6 @@ def test_exe_reproduce():
     payu_setup(lab_path=str(labdir))
 
     assert(manifests == get_manifests(ctrldir/'manifests'))
-
-    # Sweep workdir
-    sweep_work()
 
     bindir = labdir / 'bin'
     exe = config['exe']
@@ -272,9 +267,6 @@ def test_exe_reproduce():
 
     # Reset manifests "truth"
     manifests = get_manifests(ctrldir/'manifests')
-
-    # Sweep workdir
-    sweep_work()
 
     # Delete exe path from config, should get it from manifest
     del(config['exe'])
@@ -301,9 +293,6 @@ def test_exe_reproduce():
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
 
-    # Sweep workdir
-    sweep_work()
-
     # Change reproduce exe back to False
     config['manifest']['reproduce']['exe'] = False
     write_config()
@@ -313,9 +302,6 @@ def test_exe_reproduce():
 
     # Check manifests have changed as expected
     assert(not manifests == get_manifests(ctrldir/'manifests'))
-
-    # Sweep workdir
-    sweep_work()
 
 
 def test_input_reproduce():
@@ -334,9 +320,6 @@ def test_input_reproduce():
     payu_setup(lab_path=str(labdir))
     assert(manifests == get_manifests(ctrldir/'manifests'))
 
-    # Sweep workdir
-    sweep_work()
-
     # Delete input directory from config, should still work from
     # manifest with input reproduce True
     input = config['input']
@@ -347,9 +330,6 @@ def test_input_reproduce():
     payu_setup(lab_path=str(labdir))
 
     assert(manifests == get_manifests(ctrldir/'manifests'))
-
-    # Sweep workdir
-    sweep_work()
 
     # Update modification times for input files
     for i in range(1, 4):
@@ -378,9 +358,6 @@ def test_input_reproduce():
         assert pytest_wrapped_e.type == SystemExit
         assert pytest_wrapped_e.value.code == 1
 
-    # Sweep workdir
-    sweep_work()
-
     # Change reproduce input back to False
     config['manifest']['reproduce']['input'] = False
     write_config()
@@ -397,9 +374,6 @@ def test_input_reproduce():
     # Reset manifest "truth"
     manifests = get_manifests(ctrldir/'manifests')
 
-    # Sweep workdir
-    sweep_work()
-
     # Delete input manifest
     (ctrldir/'manifests'/'input.yaml').unlink()
 
@@ -410,16 +384,10 @@ def test_input_reproduce():
     for i in range(1, 4):
         assert(not (workdir/'input_00{i}.bin'.format(i=i)).is_file())
 
-    # Sweep workdir
-    sweep_work()
-
     # Set input path back and recreate input manifest
     config['input'] = input
     write_config()
     payu_setup(lab_path=str(labdir))
-
-    # Sweep workdir
-    sweep_work()
 
 
 def test_input_scaninputs():
@@ -435,9 +403,6 @@ def test_input_scaninputs():
     payu_setup(lab_path=str(labdir))
     manifests = get_manifests(ctrldir/'manifests')
 
-    # Sweep workdir
-    sweep_work()
-
     # Set scaninputs input to False
     config['manifest']['scaninputs'] = False
     write_config()
@@ -445,9 +410,6 @@ def test_input_scaninputs():
     # Run setup, should work and manifests unchanged
     payu_setup(lab_path=str(labdir))
     assert(manifests == get_manifests(ctrldir/'manifests'))
-
-    # Sweep workdir
-    sweep_work()
 
     # Update modification times for input files
     for i in range(1, 4):
@@ -463,9 +425,6 @@ def test_input_scaninputs():
     # Reset manifest "truth"
     manifests = get_manifests(ctrldir/'manifests')
 
-    # Sweep workdir
-    sweep_work()
-
     # Re-create input files
     make_inputs()
 
@@ -476,9 +435,6 @@ def test_input_scaninputs():
     # Reset manifest "truth"
     manifests = get_manifests(ctrldir/'manifests')
 
-    # Sweep workdir
-    sweep_work()
-
     # Make a new input file
     (inputdir/'lala').touch()
 
@@ -486,9 +442,6 @@ def test_input_scaninputs():
     # scaninputs=False
     payu_setup(lab_path=str(labdir))
     assert(manifests == get_manifests(ctrldir/'manifests'))
-
-    # Sweep workdir
-    sweep_work()
 
     # Set scaninputs input to True
     config['manifest']['scaninputs'] = True
@@ -500,9 +453,6 @@ def test_input_scaninputs():
     assert(not manifests == get_manifests(ctrldir/'manifests'))
     assert((workdir/'lala').is_file())
 
-    # Sweep workdir
-    sweep_work()
-
     # Delete silly input file
     (inputdir/'lala').unlink()
 
@@ -511,9 +461,6 @@ def test_input_scaninputs():
 
     # Reset manifest "truth"
     manifests = get_manifests(ctrldir/'manifests')
-
-    # Sweep workdir
-    sweep_work()
 
 
 def test_restart_reproduce():
@@ -534,9 +481,6 @@ def test_restart_reproduce():
     for i in range(1, 4):
         (restartdir/'restart_00{i}.bin'.format(i=i)).touch()
 
-    # Sweep workdir
-    sweep_work()
-
     # Run setup with touched restarts, should work with modified
     # manifest
     payu_setup(lab_path=str(labdir))
@@ -547,9 +491,6 @@ def test_restart_reproduce():
     # Reset manifest "truth"
     manifests = get_manifests(ctrldir/'manifests')
 
-    # Sweep workdir
-    sweep_work()
-
     # Modify restart files
     make_restarts()
 
@@ -557,9 +498,6 @@ def test_restart_reproduce():
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         # Run setup with unchanged exe but reproduce exe set to True
         payu_setup(lab_path=str(labdir))
-
-    # Sweep workdir
-    sweep_work()
 
     # Set reproduce restart to False
     config['manifest']['reproduce']['restart'] = False
@@ -570,9 +508,6 @@ def test_restart_reproduce():
 
     # Manifests should have changed
     assert(not manifests == get_manifests(ctrldir/'manifests'))
-
-    # Sweep workdir
-    sweep_work()
 
 
 def test_all_reproduce():
@@ -586,9 +521,6 @@ def test_all_reproduce():
 
     manifests = get_manifests(ctrldir/'manifests')
 
-    # Sweep workdir
-    sweep_work()
-
     make_all_files()
 
     # Run setup with reproduce=True, which should raise an error as
@@ -596,9 +528,6 @@ def test_all_reproduce():
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         # Run setup with unchanged exe but reproduce exe set to True
         payu_setup(lab_path=str(labdir), reproduce=True)
-
-    # Sweep workdir
-    sweep_work()
 
     # Run setup
     payu_setup(lab_path=str(labdir))
@@ -609,7 +538,6 @@ def test_all_reproduce():
 
 def test_hard_sweep():
 
-    pass
     # Sweep workdir
     sweep_work(hard_sweep=True)
 

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -93,12 +93,12 @@ def make_all_files():
     make_exe()
     make_restarts()
 
-def sweep_work():
+def sweep_work(hard_sweep=False):
     # Sweep workdir
     with cd(ctrldir):
         payu_sweep(model_type=None, 
                    config_path=None, 
-                   hard_sweep=False, 
+                   hard_sweep=hard_sweep, 
                    lab_path=str(labdir))
 
 def setup_module(module):
@@ -131,7 +131,7 @@ def teardown_module(module):
         print ("teardown_module   module:%s" % module.__name__)
 
     try:
-        shutil.rmtree(tmpdir)
+        # shutil.rmtree(tmpdir)
         print('removing tmp')
     except Exception as e:
         print(e)
@@ -448,3 +448,13 @@ def test_all_reproduce():
 
     # Manifests should have changed
     assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+def test_hard_sweep():
+
+    pass
+    # Sweep workdir
+    sweep_work(hard_sweep=True)
+
+    # Check all the correct directories have been removed
+    assert(not (labdir / 'archive' / 'ctrl' ).is_dir())
+    assert(not (labdir / 'work' / 'ctrl' ).is_dir())

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -1,0 +1,442 @@
+import os
+from pathlib import Path
+import shutil
+
+import pytest
+import yaml
+
+import payu
+
+import pdb
+
+# Namespace clash if import setup_cmd.runcmd as setup. For
+# consistency use payu_ prefix for all commands
+from payu.subcommands.init_cmd import runcmd as payu_init
+from payu.subcommands.setup_cmd import runcmd as payu_setup
+from payu.subcommands.sweep_cmd import runcmd as payu_sweep
+
+import payu.models.test
+
+from common import cd, make_random_file, get_manifests
+
+verbose = True
+
+tmpdir = Path().cwd() / Path('test') / 'tmp'
+ctrldir = tmpdir / 'ctrl'
+labdir = tmpdir / 'lab'
+
+print(tmpdir) 
+print(ctrldir) 
+print(labdir) 
+
+config = {
+            'shortpath': '..', 
+            'laboratory': 'lab', 
+            'queue': 'normal', 
+            'project': 'aa30', 
+            'walltime': '0:30:00', 
+            'ncpus': 64, 
+            'mem': '64GB', 
+            'jobname': 'testrun', 
+            'model': 'test', 
+            'exe': 'test.exe', 
+            'input': 'testrun_1', 
+            'manifest': {
+                        'scaninputs': False, 
+                        'reproduce': {
+                                        'input': False,
+                                        'exe': False
+                                        }
+                        }
+            }
+
+def write_config():
+    with (ctrldir / 'config.yaml').open('w') as file:
+        file.write(yaml.dump(config, default_flow_style=False))
+
+def make_exe():
+    # Create a fake executable file
+    bindir = labdir / 'bin'
+    bindir.mkdir(parents=True, exist_ok=True)
+    exe = config['exe']
+    exe_size = 199
+    make_random_file( bindir/exe, exe_size)
+
+def make_inputs():
+    # Create some fake input files
+    inputdir = labdir / 'input' / config['input']
+    inputdir.mkdir(parents=True, exist_ok=True)
+    for i in range(1,4):
+        make_random_file( inputdir/'input_00{i}.bin'.format(i=i), 1000**2 + i)
+
+def make_restarts():
+    # Create some fake restart files
+    restartdir = labdir / 'archive' / 'restarts'
+    restartdir.mkdir(parents=True, exist_ok=True)
+    for i in range(1,4):
+        make_random_file( restartdir/'restart_00{i}.bin'.format(i=i), 5000**2 + i)
+
+def make_all_files():
+    make_inputs()
+    make_exe()
+    make_restarts()
+
+def setup_module(module):
+    """
+    Put any test-wide setup code in here, e.g. creating test files
+    """
+    if verbose: print ("setup_module      module:%s" % module.__name__)
+        
+    # Should be taken care of by teardown, in case remnants lying around
+    try:
+        shutil.rmtree(tmpdir)
+    except:
+        pass
+
+    try:
+        tmpdir.mkdir()
+        labdir.mkdir()
+        ctrldir.mkdir()
+    except Exception as e:
+        print(e)
+
+    write_config()
+
+def teardown_module(module):
+    """
+    Put any test-wide teardown code in here, e.g. removing test outputs
+    """
+    if verbose: print ("teardown_module   module:%s" % module.__name__)
+
+    try:
+        shutil.rmtree(tmpdir)
+        print('removing tmp')
+    except Exception as e:
+        print(e)
+
+# These are integration tests. They have an undesirable dependence on each
+# other. It would be possible to make them independent, but then they'd
+# be reproducing previous "tests", like init. So this design is deliberate
+# but compromised. It means when running an error in one test can cascade 
+# and cause other tests to fail.
+#
+# Unfortunate but there you go.
+
+def test_init():
+
+    # Initialise a payu laboratory
+    with cd(ctrldir):
+        payu_init(None, None, str(labdir))
+
+    # Check all the correct directories have been created
+    for subdir in ['bin', 'input', 'archive', 'codebase']:
+        assert((labdir / subdir).is_dir())
+
+def test_setup():
+
+    # Create some input and executable files
+    make_inputs()
+    make_exe()
+
+    bindir = labdir / 'bin'
+    exe = config['exe']
+
+    config_files = payu.models.test.config_files
+    for file in config_files:
+        make_random_file( ctrldir/file, 29)
+
+    # Run setup
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    workdir = ctrldir / 'work'
+    assert(workdir.is_symlink())
+    assert(workdir.is_dir())
+    assert((workdir/exe).resolve() == (bindir/exe).resolve())
+    workdirfull = workdir.resolve()
+
+    for f in config_files + ['config.yaml']:
+        assert((workdir/f).is_file())
+
+    for i in range(1,4):
+        assert( (workdir/'input_00{i}.bin'.format(i=i)).stat().st_size == 1000**2 + i)
+
+    manifests = get_manifests(ctrldir/'manifests')
+    for mfpath in manifests:
+        assert( (ctrldir/'manifests'/mfpath).is_file() )
+
+    # Check manifest in work directory is the same as control directory
+    assert(manifests == get_manifests(workdir/'manifests'))
+
+    # Sweep workdir and recreate
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+    assert( not workdir.is_dir() )
+    assert( not workdirfull.is_dir() )
+
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    assert(manifests == get_manifests(workdir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+def test_setup_restartdir():
+
+    restartdir = labdir / 'archive' / 'restarts'
+
+    # Set a restart directory in config
+    config['restart'] = str(restartdir)
+    write_config()
+
+    make_restarts()
+
+    manifests = get_manifests(ctrldir/'manifests')
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Manifests should not match, as have added restarts
+    assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+def test_exe_reproduce():
+
+    # Set reproduce exe to True
+    config['manifest']['reproduce']['exe'] = True
+    write_config()
+    manifests = get_manifests(ctrldir/'manifests')
+
+    # Run setup with unchanged exe but reproduce exe set to True. Should run without error
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    assert(manifests == get_manifests(ctrldir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    bindir = labdir / 'bin'
+    exe = config['exe']
+
+    # Update the modification time of the executable, should run ok 
+    (bindir/exe).touch()
+
+    # Run setup with changed exe but reproduce exe set to False
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Manifests will have changed as fasthash is altered
+    assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+    # Reset manifests "truth"
+    manifests = get_manifests(ctrldir/'manifests')
+
+    # Recreate fake executable file
+    make_exe()
+
+    # Run setup again, which should raise an error due to changed executable
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        # Run setup with unchanged exe but reproduce exe set to True
+        with cd(ctrldir):
+            payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    # Change reproduce exe back to False
+    config['manifest']['reproduce']['exe'] = False
+    write_config()
+
+    # Run setup with changed exe but reproduce exe set to False
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Check manifests have changed as expected
+    assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+def test_input_reproduce():
+
+    inputdir = labdir / 'input' / config['input']
+    inputdir.mkdir(parents=True, exist_ok=True)
+
+    # Set reproduce exe to True
+    config['manifest']['reproduce']['exe'] = True
+    config['manifest']['reproduce']['input'] = True
+    write_config()
+    manifests = get_manifests(ctrldir/'manifests')
+
+    # Run setup with unchanged exe but reproduce exe set to True
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    assert(manifests == get_manifests(ctrldir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    # Update modification times for input files
+    for i in range(1,4):
+        (inputdir/'input_00{i}.bin'.format(i=i)).touch()
+
+    # Run setup, should work as only fasthash will differ, code then checks full hash and
+    # updates fasthash if fullhash matches
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Manifests should no longer match as fasthashes have been updated
+    assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+    # Reset manifest "truth"
+    manifests = get_manifests(ctrldir/'manifests')
+
+    # Re-create input files
+    make_inputs()
+
+    # Run setup again, which should raise an error due to changed executable
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        # Run setup with unchanged exe but reproduce exe set to True
+        with cd(ctrldir):
+            payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+        assert pytest_wrapped_e.type == SystemExit
+        assert pytest_wrapped_e.value.code == 1
+
+    assert(manifests == get_manifests(ctrldir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    # Change reproduce exe back to False
+    config['manifest']['reproduce']['input'] = False
+    write_config()
+
+    # Run setup with changed exe but reproduce exe set to False
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Check manifests have changed as expected
+    assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+def test_restart_reproduce():
+
+    # Set reproduce restart to True
+    config['manifest']['reproduce']['restart'] = True
+    del(config['restart'])
+    write_config()
+    manifests = get_manifests(ctrldir/'manifests')
+
+    # Run setup with unchanged restarts
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    assert(manifests == get_manifests(ctrldir/'manifests'))
+
+    restartdir = labdir / 'archive' / 'restarts'
+
+    # Change modification times on restarts
+    for i in range(1,4):
+        (restartdir/'restart_00{i}.bin'.format(i=i)).touch()
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    # Run setup with touched restarts
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Manifests should have changed
+    assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+    # Reset manifest "truth"
+    manifests = get_manifests(ctrldir/'manifests')
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    # Modify restart files
+    make_restarts()
+
+    # Run setup again, which should raise an error due to changed restarts
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        # Run setup with unchanged exe but reproduce exe set to True
+        with cd(ctrldir):
+            payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Manifests not should have changed
+    assert(manifests == get_manifests(ctrldir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    # Set reproduce restart to False
+    config['manifest']['reproduce']['restart'] = False
+    write_config()
+
+    # Run setup with modified restarts reproduce set to False
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Manifests should have changed
+    assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+def test_all_reproduce():
+
+    # Remove reproduce options from config
+    del(config['manifest']['reproduce'])
+    write_config()
+
+    # Run setup 
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    manifests = get_manifests(ctrldir/'manifests')
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    make_all_files()
+
+    # Run setup with reproduce=True, which should raise an error as all files changed
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        # Run setup with unchanged exe but reproduce exe set to True
+        with cd(ctrldir):
+            payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=True)
+
+    # Sweep workdir
+    with cd(ctrldir):
+        payu_sweep(model_type=None, config_path=None, hard_sweep=False, lab_path=str(labdir))
+
+    # Run setup 
+    with cd(ctrldir):
+        payu_setup(model_type=None, config_path=None, lab_path=str(labdir), force_archive=False, reproduce=False)
+
+    # Manifests should have changed
+    assert(not manifests == get_manifests(ctrldir/'manifests'))

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -19,15 +19,6 @@ import payu.models.test
 
 from common import cd, make_random_file, get_manifests
 
-def payu_setup(model_type=None, 
-               config_path=None, 
-               lab_path=None, 
-               force_archive=None, 
-               reproduce=None):
-    """
-    Wrapper around original setup command to provide default arguments
-    """
-    payu_setup_orignal(model_type, config_path, lab_path, force_archive, reproduce)
 
 verbose = True
 
@@ -60,9 +51,26 @@ config = {
                         }
             }
 
+
+def payu_setup(model_type=None,
+               config_path=None,
+               lab_path=None,
+               force_archive=None,
+               reproduce=None):
+    """
+    Wrapper around original setup command to provide default arguments
+    """
+    payu_setup_orignal(model_type,
+                       config_path,
+                       lab_path,
+                       force_archive,
+                       reproduce)
+
+
 def write_config():
     with (ctrldir / 'config.yaml').open('w') as file:
         file.write(yaml.dump(config, default_flow_style=False))
+
 
 def make_exe():
     # Create a fake executable file
@@ -72,46 +80,51 @@ def make_exe():
     exe_size = 199
     make_random_file(bindir/exe, exe_size)
 
+
 def make_inputs():
     # Create some fake input files
     inputdir = labdir / 'input' / config['input']
     inputdir.mkdir(parents=True, exist_ok=True)
     for i in range(1, 4):
-        make_random_file(inputdir/'input_00{i}.bin'.format(i=i), 
+        make_random_file(inputdir/'input_00{i}.bin'.format(i=i),
                          1000**2 + i)
+
 
 def make_restarts():
     # Create some fake restart files
     restartdir = labdir / 'archive' / 'restarts'
     restartdir.mkdir(parents=True, exist_ok=True)
     for i in range(1, 4):
-        make_random_file(restartdir/'restart_00{i}.bin'.format(i=i), 
+        make_random_file(restartdir/'restart_00{i}.bin'.format(i=i),
                          5000**2 + i)
+
 
 def make_all_files():
     make_inputs()
     make_exe()
     make_restarts()
 
+
 def sweep_work(hard_sweep=False):
     # Sweep workdir
     with cd(ctrldir):
-        payu_sweep(model_type=None, 
-                   config_path=None, 
-                   hard_sweep=hard_sweep, 
+        payu_sweep(model_type=None,
+                   config_path=None,
+                   hard_sweep=hard_sweep,
                    lab_path=str(labdir))
+
 
 def setup_module(module):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose: 
-        print ("setup_module      module:%s" % module.__name__)
-        
+    if verbose:
+        print("setup_module      module:%s" % module.__name__)
+
     # Should be taken care of by teardown, in case remnants lying around
     try:
         shutil.rmtree(tmpdir)
-    except:
+    except FileNotFoundError:
         pass
 
     try:
@@ -123,12 +136,13 @@ def setup_module(module):
 
     write_config()
 
+
 def teardown_module(module):
     """
     Put any test-wide teardown code in here, e.g. removing test outputs
     """
-    if verbose: 
-        print ("teardown_module   module:%s" % module.__name__)
+    if verbose:
+        print("teardown_module   module:%s" % module.__name__)
 
     try:
         # shutil.rmtree(tmpdir)
@@ -183,8 +197,8 @@ def test_setup():
         assert((workdir/f).is_file())
 
     for i in range(1, 4):
-        assert((workdir/'input_00{i}.bin'.format(i=i)).stat().st_size 
-                == 1000**2 + i)
+        assert((workdir/'input_00{i}.bin'.format(i=i)).stat().st_size
+               == 1000**2 + i)
 
     manifests = get_manifests(ctrldir/'manifests')
     for mfpath in manifests:
@@ -207,6 +221,7 @@ def test_setup():
     # Sweep workdir
     sweep_work()
 
+
 def test_setup_restartdir():
 
     restartdir = labdir / 'archive' / 'restarts'
@@ -220,7 +235,7 @@ def test_setup_restartdir():
     manifests = get_manifests(ctrldir/'manifests')
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     # Manifests should not match, as have added restarts
     assert(not manifests == get_manifests(ctrldir/'manifests'))
 
@@ -235,7 +250,7 @@ def test_exe_reproduce():
     write_config()
     manifests = get_manifests(ctrldir/'manifests')
 
-    # Run setup with unchanged exe but reproduce exe set to True. 
+    # Run setup with unchanged exe but reproduce exe set to True.
     # Should run without error
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
@@ -315,7 +330,7 @@ def test_input_reproduce():
     for i in range(1, 4):
         (inputdir/'input_00{i}.bin'.format(i=i)).touch()
 
-    # Run setup, should work as only fasthash will differ, code then 
+    # Run setup, should work as only fasthash will differ, code then
     # checks full hash and updates fasthash if fullhash matches
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
@@ -350,12 +365,13 @@ def test_input_reproduce():
     # Run setup with changed exe but reproduce exe set to False
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
-        
+
     # Check manifests have changed as expected
     assert(not manifests == get_manifests(ctrldir/'manifests'))
 
     # Sweep workdir
     sweep_work()
+
 
 def test_restart_reproduce():
 
@@ -368,7 +384,7 @@ def test_restart_reproduce():
     # Run setup with unchanged restarts
     with cd(ctrldir):
         payu_setup(lab_path=str(labdir))
- 
+
     assert(manifests == get_manifests(ctrldir/'manifests'))
 
     restartdir = labdir / 'archive' / 'restarts'
@@ -440,7 +456,7 @@ def test_all_reproduce():
 
     make_all_files()
 
-    # Run setup with reproduce=True, which should raise an error as 
+    # Run setup with reproduce=True, which should raise an error as
     # all files changed
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         # Run setup with unchanged exe but reproduce exe set to True
@@ -457,6 +473,7 @@ def test_all_reproduce():
     # Manifests should have changed
     assert(not manifests == get_manifests(ctrldir/'manifests'))
 
+
 def test_hard_sweep():
 
     pass
@@ -464,5 +481,5 @@ def test_hard_sweep():
     sweep_work(hard_sweep=True)
 
     # Check all the correct directories have been removed
-    assert(not (labdir / 'archive' / 'ctrl' ).is_dir())
-    assert(not (labdir / 'work' / 'ctrl' ).is_dir())
+    assert(not (labdir / 'archive' / 'ctrl').is_dir())
+    assert(not (labdir / 'work' / 'ctrl').is_dir())

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -17,6 +17,7 @@ import payu
 import payu.fsops
 import payu.laboratory
 
+
 class Test(unittest.TestCase):
 
     def setUp(self):
@@ -114,6 +115,7 @@ class Test(unittest.TestCase):
         sys.stdout = StringIO()
         lab = payu.laboratory.Laboratory('model')
         sys.stdout = sys.__stdout__
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -42,7 +42,7 @@ class Test(unittest.TestCase):
         os.rmdir(tmp_dir)
 
     def test_read_config(self):
-        config_path = os.path.join('test','config_mom5.yaml')
+        config_path = os.path.join('test', 'config_mom5.yaml')
         config = payu.fsops.read_config(config_path)
 
         # Raise a non-ENOENT error (e.g. EACCES)

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -42,7 +42,7 @@ class Test(unittest.TestCase):
         os.rmdir(tmp_dir)
 
     def test_read_config(self):
-        config_path = 'config_mom5.yaml'
+        config_path = os.path.join('test','config_mom5.yaml')
         config = payu.fsops.read_config(config_path)
 
         # Raise a non-ENOENT error (e.g. EACCES)


### PR DESCRIPTION
Added test model for ... testing. Has minimal requirements and means
tests can be independent of model driver implementation. A platonic
ideal if you will.
    
Added config options for fine-grained reproduce options. Input, exe
and restart reproduce can be turned on independently of each other.
    
Added extensive testing of init/setup and reproduce.

Fixes https://github.com/payu-org/payu/issues/203