### PR TITLE
Check for MODULESHOME environment variable for gadi support

### DIFF
--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -22,7 +22,11 @@ def setup(basepath=DEFAULT_BASEPATH):
     """Set the environment modules used by the Environment Module system."""
 
     module_version = os.environ.get('MODULE_VERSION', DEFAULT_VERSION)
-    moduleshome = os.path.join(basepath, module_version)
+
+    moduleshome = os.environ.get('MODULESHOME', None)
+
+    if moduleshome is None:
+        moduleshome = os.path.join(basepath, module_version)
 
     # Abort if MODULESHOME does not exist
     if not os.path.isdir(moduleshome):

--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -15,7 +15,7 @@ if not hasattr(subprocess, 'check_output'):
     subprocess.check_output = check_output
 
 DEFAULT_BASEPATH = '/opt/Modules'
-DEFAULT_VERSION = '3.2.6'
+DEFAULT_VERSION = 'v4.3.0'
 
 
 def setup(basepath=DEFAULT_BASEPATH):


### PR DESCRIPTION
Fixes https://github.com/payu-org/payu/issues/209

On `gadi` `MODULE_VERSION` environment variable is no longer set by default, but `MODULESHOME` is. This change checks for `MODULESHOME` before trying to generate it from `MODULE_VERSION`.