### PR TITLE
Added capability to specify hash functions for manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
 script:
     - payu list
     - pylint --extension-pkg-whitelist=netCDF4 -E payu
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=$(pwd) coverage run --source payu -m py.test -s test/*.py; fi;
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 || $TRAVIS_PYTHON_VERSION == 3.7 ]]; then PYTHONPATH=. coverage run --source payu -m py.test -s test/*.py; fi;
     - cd docs && make html
 after_success:
     - coverage report -m

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -32,14 +32,14 @@ class PayuManifest(YaManifest):
     A manifest object sub-classed from yamanifest object with some payu
     specific additions and enhancements.
     """
-    def __init__(self, path, 
-                 ignore=None, 
-                 fast_hashes=fast_hashes, 
-                 full_hashes=full_hashes, 
+    def __init__(self, path,
+                 ignore=None,
+                 fast_hashes=fast_hashes,
+                 full_hashes=full_hashes,
                  **kwargs):
 
         super(PayuManifest, self).__init__(path=path, 
-                                           hashes=fast_hashes+full_hashes, 
+                                           hashes=fast_hashes+full_hashes,
                                            **kwargs)
         self.fast_hashes = fast_hashes
         self.full_hashes = full_hashes
@@ -412,9 +412,10 @@ class Manifest(object):
         code from directly calling anything in PayuManifest.
         """
         filepath = os.path.normpath(filepath)
-        if self.manifests[manifest].add_filepath(filepath=filepath, 
-                                                 fullpath=fullpath, 
-                                                 hashes=self.fast_hashes + self.full_hashes,
+        if self.manifests[manifest].add_filepath(filepath=filepath,
+                                                 fullpath=fullpath,
+                                                 hashes=self.fast_hashes+
+                                                        self.full_hashes,
                                                  copy=copy):
             # Only link if filepath was added
             self.manifests[manifest].make_link(filepath)

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -38,7 +38,7 @@ class PayuManifest(YaManifest):
                  full_hashes=full_hashes,
                  **kwargs):
 
-        super(PayuManifest, self).__init__(path=path, 
+        super(PayuManifest, self).__init__(path=path,
                                            hashes=fast_hashes+full_hashes,
                                            **kwargs)
         self.fast_hashes = fast_hashes
@@ -414,7 +414,7 @@ class Manifest(object):
         filepath = os.path.normpath(filepath)
         if self.manifests[manifest].add_filepath(filepath=filepath,
                                                  fullpath=fullpath,
-                                                 hashes=self.fast_hashes+
+                                                 hashes=self.fast_hashes +
                                                         self.full_hashes,
                                                  copy=copy):
             # Only link if filepath was added

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -32,8 +32,17 @@ class PayuManifest(YaManifest):
     A manifest object sub-classed from yamanifest object with some payu
     specific additions and enhancements.
     """
-    def __init__(self, path, hashes=None, ignore=None, **kwargs):
-        super(PayuManifest, self).__init__(path, hashes, **kwargs)
+    def __init__(self, path, 
+                 ignore=None, 
+                 fast_hashes=fast_hashes, 
+                 full_hashes=full_hashes, 
+                 **kwargs):
+
+        super(PayuManifest, self).__init__(path=path, 
+                                           hashes=fast_hashes+full_hashes, 
+                                           **kwargs)
+        self.fast_hashes = fast_hashes
+        self.full_hashes = full_hashes
 
         if ignore is not None:
             self.ignore = ignore
@@ -51,7 +60,7 @@ class PayuManifest(YaManifest):
         fast_check = self.check_file(
             filepaths=self.data.keys(),
             hashvals=hashvals,
-            hashfn=fast_hashes,
+            hashfn=self.fast_hashes,
             shortcircuit=True,
             **args
         )
@@ -71,7 +80,7 @@ class PayuManifest(YaManifest):
                     tmphash = {}
                     full_check = self.check_file(
                         filepaths=filepath,
-                        hashfn=full_hashes,
+                        hashfn=self.full_hashes,
                         hashvals=tmphash,
                         shortcircuit=False,
                         **args
@@ -80,7 +89,7 @@ class PayuManifest(YaManifest):
                     if full_check:
                         # File is still ok, so replace fast hashes
                         print('Full hashes ({0}) checked ok'
-                              ''.format(full_hashes))
+                              ''.format(self.full_hashes))
                         print('Updating fast hashes for {0} in {1}'
                               ''.format(filepath, self.path))
                         self.add_fast(filepath, force=True)
@@ -111,7 +120,7 @@ class PayuManifest(YaManifest):
                 # be written as null.
                 self.add(
                     filepaths=list(hashvals.keys()),
-                    hashfn=full_hashes,
+                    hashfn=self.full_hashes,
                     force=True,
                     fullpaths=[self.fullpath(fpath) for fpath
                                in list(hashvals.keys())]
@@ -120,7 +129,7 @@ class PayuManifest(YaManifest):
                 # Flag need to update version on disk
                 self.needsync = True
 
-    def add_filepath(self, filepath, fullpath, copy=False):
+    def add_filepath(self, filepath, fullpath, hashes, copy=False):
         """
         Bespoke function to add filepath & fullpath to manifest
         object without hashing. Can defer hashing until all files are
@@ -142,7 +151,7 @@ class PayuManifest(YaManifest):
 
         self.data[filepath]['fullpath'] = fullpath
         if 'hashes' not in self.data[filepath]:
-            self.data[filepath]['hashes'] = {hash: None for hash in all_hashes}
+            self.data[filepath]['hashes'] = {hash: None for hash in hashes}
 
         if copy:
             self.data[filepath]['copy'] = copy
@@ -159,7 +168,7 @@ class PayuManifest(YaManifest):
         one "fast" hashing function need be called for each filepath.
         """
         if hashfn is None:
-            hashfn = fast_hashes
+            hashfn = self.fast_hashes
         self.add(filepath, hashfn, force, shortcircuit=True)
 
     def copy_file(self, filepath):
@@ -231,6 +240,11 @@ class PayuManifest(YaManifest):
             files.append(self.fullpath(filepath))
         return files
 
+    def get_hashes(self, hashfn):
+        hashes = []
+        for filepath in self:
+            hashes.append(self.get(filepath, hashfn))
+        return hashes
 
 class Manifest(object):
     """
@@ -244,10 +258,13 @@ class Manifest(object):
         self.manifest_config = config
 
         # Not currently supporting specifying hash functions
-        # self.hash_functions = manifest_config.get(
-        #     'hashfns',
-        #     ['nchash','binhash','md5']
-        # )
+        self.fast_hashes = self.manifest_config.get('fasthash', fast_hashes)
+        self.full_hashes = self.manifest_config.get('fullhash', full_hashes)
+
+        if type(self.fast_hashes) is str:
+            self.fast_hashes = [self.fast_hashes, ]
+        if type(self.full_hashes) is str:
+            self.full_hashes = [self.full_hashes, ]
 
         self.ignore = self.manifest_config.get('ignore', ['.*'])
         if isinstance(self.ignore, str):
@@ -276,7 +293,9 @@ class Manifest(object):
         # Initialise a sub-manifest object
         self.manifests[mf] = PayuManifest(
             os.path.join('manifests', '{}.yaml'.format(mf)),
-            ignore=self.ignore
+            ignore=self.ignore,
+            fast_hashes=self.fast_hashes,
+            full_hashes=self.full_hashes
         )
         self.have_manifest[mf] = False
 
@@ -393,7 +412,10 @@ class Manifest(object):
         code from directly calling anything in PayuManifest.
         """
         filepath = os.path.normpath(filepath)
-        if self.manifests[manifest].add_filepath(filepath, fullpath, copy):
+        if self.manifests[manifest].add_filepath(filepath=filepath, 
+                                                 fullpath=fullpath, 
+                                                 hashes=self.fast_hashes + self.full_hashes,
+                                                 copy=copy):
             # Only link if filepath was added
             self.manifests[manifest].make_link(filepath)
 

--- a/test/common.py
+++ b/test/common.py
@@ -143,7 +143,7 @@ def make_restarts(fnames=None):
     restartdir = labdir / 'archive' / 'restarts'
     restartdir.mkdir(parents=True, exist_ok=True)
     if fnames is None:
-        fnames = ['restart_00{i}.bin'.format(i=i) for i in range(1,4)]
+        fnames = ['restart_00{i}.bin'.format(i=i) for i in range(1, 4)]
     for i, fname in enumerate(fnames):
         make_random_file(restartdir/fname, 5000**2 + i)
 

--- a/test/common.py
+++ b/test/common.py
@@ -106,7 +106,7 @@ def payu_setup(model_type=None,
                            reproduce)
 
 
-def write_config():
+def write_config(config):
     with (ctrldir / 'config.yaml').open('w') as file:
         file.write(yaml.dump(config, default_flow_style=False))
 
@@ -138,13 +138,14 @@ def make_inputs():
                          1000**2 + i)
 
 
-def make_restarts():
+def make_restarts(fnames=None):
     # Create some fake restart files
     restartdir = labdir / 'archive' / 'restarts'
     restartdir.mkdir(parents=True, exist_ok=True)
-    for i in range(1, 4):
-        make_random_file(restartdir/'restart_00{i}.bin'.format(i=i),
-                         5000**2 + i)
+    if fnames is None:
+        fnames = ['restart_00{i}.bin'.format(i=i) for i in range(1,4)]
+    for i, fname in enumerate(fnames):
+        make_random_file(restartdir/fname, 5000**2 + i)
 
 
 def make_all_files():

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -500,6 +500,7 @@ def test_get_hashes():
 
     assert(set(hashes) == set(allhashes))
 
+
 def test_set_hash():
 
     # Revert to original config
@@ -518,7 +519,7 @@ def test_set_hash():
 
     # Remove existing manifests. Don't support changing
     # hashes and retaining manifests
-    shutil.rmtree( ctrldir/ 'manifests')
+    shutil.rmtree(ctrldir/'manifests')
 
     # Change full hash from md5 to sha256
     config['manifest']['fullhash'] = 'sha256'
@@ -540,7 +541,7 @@ def test_set_hash():
 
     # Remove existing manifests. Don't support changing
     # hashes and retaining manifests
-    shutil.rmtree( ctrldir/ 'manifests')
+    shutil.rmtree(ctrldir / 'manifests')
 
     # Change full hash from md5 to binhash
     config['manifest']['fullhash'] = 'binhash'
@@ -563,4 +564,3 @@ def test_hard_sweep():
     # Check all the correct directories have been removed
     assert(not (labdir / 'archive' / 'ctrl').is_dir())
     assert(not (labdir / 'work' / 'ctrl').is_dir())
-

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -9,6 +9,8 @@ import yaml
 import payu
 import payu.models.test
 
+print('__file__={0:<35} | __name__={1:<20} | __package__={2:<20}'.format(__file__,__name__,str(__package__)))
+
 from .common import cd, make_random_file, get_manifests
 from .common import tmpdir, ctrldir, labdir, workdir
 from .common import sweep_work, payu_init, payu_setup

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -1,24 +1,24 @@
+import copy
 import os
 from pathlib import Path
-import shutil
-
+import pdb
 import pytest
+import shutil
 import yaml
 
 import payu
-
-import pdb
-
 import payu.models.test
 
-from common import cd, make_random_file, get_manifests
-from common import tmpdir, ctrldir, labdir, workdir
-from common import config, sweep_work, payu_init, payu_setup
-from common import write_config
-from common import make_exe, make_inputs, make_restarts, make_all_files
+from .common import cd, make_random_file, get_manifests
+from .common import tmpdir, ctrldir, labdir, workdir
+from .common import sweep_work, payu_init, payu_setup
+from .common import config as config_orig
+from .common import write_config
+from .common import make_exe, make_inputs, make_restarts, make_all_files
 
 verbose = True
 
+config = copy.deepcopy(config_orig)
 
 def make_config_files():
     """
@@ -51,7 +51,7 @@ def setup_module(module):
     except Exception as e:
         print(e)
 
-    write_config()
+    write_config(config)
 
 
 def teardown_module(module):
@@ -139,7 +139,7 @@ def test_setup_restartdir():
 
     # Set a restart directory in config
     config['restart'] = str(restartdir)
-    write_config()
+    write_config(config)
 
     make_restarts()
 
@@ -154,7 +154,7 @@ def test_exe_reproduce():
 
     # Set reproduce exe to True
     config['manifest']['reproduce']['exe'] = True
-    write_config()
+    write_config(config)
     manifests = get_manifests(ctrldir/'manifests')
 
     # Run setup with unchanged exe but reproduce exe set to True.
@@ -180,7 +180,7 @@ def test_exe_reproduce():
 
     # Delete exe path from config, should get it from manifest
     del(config['exe'])
-    write_config()
+    write_config(config)
 
     # Run setup with changed exe but reproduce exe set to False
     payu_setup(lab_path=str(labdir))
@@ -205,7 +205,7 @@ def test_exe_reproduce():
 
     # Change reproduce exe back to False
     config['manifest']['reproduce']['exe'] = False
-    write_config()
+    write_config(config)
 
     # Run setup with changed exe but reproduce exe set to False
     payu_setup(lab_path=str(labdir))
@@ -222,7 +222,7 @@ def test_input_reproduce():
     # Set reproduce input to True
     config['manifest']['reproduce']['exe'] = False
     config['manifest']['reproduce']['input'] = True
-    write_config()
+    write_config(config)
     manifests = get_manifests(ctrldir/'manifests')
 
     # Run setup with unchanged input reproduce input set to True
@@ -233,7 +233,7 @@ def test_input_reproduce():
     # Delete input directory from config, should still work from
     # manifest with input reproduce True
     input = config['input']
-    write_config()
+    write_config(config)
     del(config['input'])
 
     # Run setup, should work
@@ -270,7 +270,7 @@ def test_input_reproduce():
 
     # Change reproduce input back to False
     config['manifest']['reproduce']['input'] = False
-    write_config()
+    write_config(config)
 
     # Run setup with changed inputs but reproduce input set to False
     payu_setup(lab_path=str(labdir))
@@ -296,7 +296,7 @@ def test_input_reproduce():
 
     # Set input path back and recreate input manifest
     config['input'] = input
-    write_config()
+    write_config(config)
     payu_setup(lab_path=str(labdir))
 
 
@@ -311,7 +311,7 @@ def test_input_scaninputs():
 
     # Set scaninputs input to True
     config['manifest']['scaninputs'] = True
-    write_config()
+    write_config(config)
 
     # Run setup with unchanged input
     payu_setup(lab_path=str(labdir))
@@ -319,7 +319,7 @@ def test_input_scaninputs():
 
     # Set scaninputs input to False
     config['manifest']['scaninputs'] = False
-    write_config()
+    write_config(config)
 
     # Run setup, should work and manifests unchanged
     payu_setup(lab_path=str(labdir))
@@ -359,7 +359,7 @@ def test_input_scaninputs():
 
     # Set scaninputs input to True
     config['manifest']['scaninputs'] = True
-    write_config()
+    write_config(config)
 
     # Run setup again. Should be fine, but manifests changed now
     # as scaninputs=False
@@ -383,7 +383,7 @@ def test_restart_reproduce():
     config['manifest']['reproduce']['input'] = False
     config['manifest']['reproduce']['restart'] = True
     del(config['restart'])
-    write_config()
+    write_config(config)
     manifests = get_manifests(ctrldir/'manifests')
 
     # Run setup with unchanged restarts
@@ -415,7 +415,7 @@ def test_restart_reproduce():
 
     # Set reproduce restart to False
     config['manifest']['reproduce']['restart'] = False
-    write_config()
+    write_config(config)
 
     # Run setup with modified restarts reproduce set to False
     payu_setup(lab_path=str(labdir))
@@ -428,7 +428,7 @@ def test_all_reproduce():
 
     # Remove reproduce options from config
     del(config['manifest']['reproduce'])
-    write_config()
+    write_config(config)
 
     # Run setup
     payu_setup(lab_path=str(labdir))
@@ -476,6 +476,85 @@ def test_get_all_fullpaths():
     assert(set(files) == set(allfiles))
 
 
+def test_get_hashes():
+
+    make_all_files()
+    make_config_files()
+
+    # Run setup
+    payu_setup(lab_path=str(labdir))
+
+    manifests = get_manifests(ctrldir/'manifests')
+
+    sweep_work()
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        expt.setup()
+        hashes = expt.manifest.manifests['input'].get_hashes('md5')
+
+    allhashes = []
+    for f in manifests['input.yaml']:
+        allhashes.append(manifests['input.yaml'][f]['hashes']['md5'])
+
+    assert(set(hashes) == set(allhashes))
+
+def test_set_hash():
+
+    # Revert to original config
+    config = copy.deepcopy(config_orig)
+    write_config(config)
+
+    make_all_files()
+    make_config_files()
+
+    # Run setup
+    payu_setup(lab_path=str(labdir))
+
+    manifests = get_manifests(ctrldir/'manifests')
+
+    sweep_work()
+
+    # Remove existing manifests. Don't support changing
+    # hashes and retaining manifests
+    shutil.rmtree( ctrldir/ 'manifests')
+
+    # Change full hash from md5 to sha256
+    config['manifest']['fullhash'] = 'sha256'
+    write_config(config)
+
+    # Run setup
+    payu_setup(lab_path=str(labdir))
+
+    assert(not manifests == get_manifests(ctrldir/'manifests'))
+
+    manifests = get_manifests(ctrldir/'manifests')
+
+    for mf in manifests:
+        for f in manifests[mf]:
+            assert(manifests[mf][f]['hashes']['sha256'])
+            assert(len(manifests[mf][f]['hashes']['sha256']) == 64)
+
+    sweep_work()
+
+    # Remove existing manifests. Don't support changing
+    # hashes and retaining manifests
+    shutil.rmtree( ctrldir/ 'manifests')
+
+    # Change full hash from md5 to binhash
+    config['manifest']['fullhash'] = 'binhash'
+    write_config(config)
+
+    # Run setup
+    payu_setup(lab_path=str(labdir))
+
+    manifests = get_manifests(ctrldir/'manifests')
+
+    for mf in manifests:
+        for f in manifests[mf]:
+            assert(list(manifests[mf][f]['hashes'].keys()) == ['binhash'])
+
 def test_hard_sweep():
 
     # Sweep workdir
@@ -484,3 +563,4 @@ def test_hard_sweep():
     # Check all the correct directories have been removed
     assert(not (labdir / 'archive' / 'ctrl').is_dir())
     assert(not (labdir / 'work' / 'ctrl').is_dir())
+

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -12,11 +12,11 @@ from payu.laboratory import Laboratory
 from payu.scheduler.pbs import find_mounts
 
 
-from common import cd, make_random_file, get_manifests
-from common import tmpdir, ctrldir, labdir, workdir
-from common import config, sweep_work, payu_init, payu_setup
-from common import write_config
-from common import make_exe, make_inputs, make_restarts, make_all_files
+from .common import cd, make_random_file, get_manifests
+from .common import tmpdir, ctrldir, labdir, workdir
+from .common import config, sweep_work, payu_init, payu_setup
+from .common import write_config
+from .common import make_exe, make_inputs, make_restarts, make_all_files
 
 verbose = True
 
@@ -41,7 +41,7 @@ def setup_module(module):
     except Exception as e:
         print(e)
 
-    write_config()
+    write_config(config)
 
 
 def teardown_module(module):
@@ -74,7 +74,7 @@ def test_laboratory_basepath():
     # in config, so will fall through to default
     # depending on platform
     del(config['shortpath'])
-    write_config()
+    write_config(config)
     with cd(ctrldir):
         lab = Laboratory(None, None, None)
 
@@ -96,7 +96,7 @@ def test_laboratory_path():
     # Set a relative laboratory name
     labname = 'testlab'
     config['laboratory'] = labname
-    write_config()
+    write_config(config)
     with cd(ctrldir):
         lab = Laboratory(None, None, None)
 

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -16,12 +16,12 @@ from payu.laboratory import Laboratory
 from payu.scheduler import pbs
 
 
-from common import cd, make_random_file, get_manifests
-from common import tmpdir, ctrldir, labdir, workdir, payudir
-from common import config, sweep_work, payu_init, payu_setup
-from common import write_config
-from common import make_exe, make_inputs, make_restarts
-from common import make_payu_exe, make_all_files
+from .common import cd, make_random_file, get_manifests
+from .common import tmpdir, ctrldir, labdir, workdir, payudir
+from .common import config, sweep_work, payu_init, payu_setup
+from .common import write_config
+from .common import make_exe, make_inputs, make_restarts
+from .common import make_payu_exe, make_all_files
 
 verbose = True
 
@@ -48,7 +48,7 @@ def setup_module(module):
     except Exception as e:
         print(e)
 
-    write_config()
+    write_config(config)
 
 
 def teardown_module(module):


### PR DESCRIPTION
Added tests for specifying hashes.

Fixed bug with test/models/test_mitgcm.py that globally changed
config. Now specify config to write and make deep copies where
appropriate.

Changed common input in tests to make local import.

Fixes #233 