### PR TITLE
Move work directory contents to new output directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.0
 jobs:
-    py37:
+    py36:
         working_directory: ~/circleci
         docker:
-            - image: circleci/python
+            - image: circleci/python:3.6.9
               environment:
-                PYTHON_VER: 3.7
+                PYTHON_VER: 3.6.9
 
         steps:
             - checkout
@@ -44,14 +44,14 @@ workflows:
     version: 2
     build_and_publsh:
         jobs:
-            - py37:
+            - py36:
                 filters:
                     tags:
                         only: /.*/
 
             - publish:
                 requires:
-                    - py37
+                    - py36
                 filters:
                     tags:
                         only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.0
 jobs:
-    py36:
+    py37:
         working_directory: ~/circleci
         docker:
             - image: circleci/python
               environment:
-                PYTHON_VER: 3.6
+                PYTHON_VER: 3.7
 
         steps:
             - checkout
@@ -44,7 +44,7 @@ workflows:
     version: 2
     build_and_publsh:
         jobs:
-            - py36:
+            - py37:
                 filters:
                     tags:
                         only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ workflows:
 
             - publish:
                 requires:
-                    - py36
+                    - py37
                 filters:
                     tags:
                         only: /.*/

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -31,8 +31,8 @@ requirements:
 test:
     imports:
         - payu
-    commands:
-        - payu list
+    # commands:
+    #     - payu list
 
 
 about:

--- a/docs/source/manifests.rst
+++ b/docs/source/manifests.rst
@@ -1,11 +1,11 @@
 .. _manifests:
 
-=====
+=========
 Manifests
-=====
+=========
 
 Introduction
-========
+============
 
 payu automatically generates and updates manifest files in the ``manifest``
 subdirectory in the control directory. The manifests are stored in YAML_ 
@@ -18,6 +18,8 @@ tracks restart files.
 Only files in the temporary ``work`` directory are tracked by manifests. Any
 files that are directly accessed from other locations in the filesystem
 within models or other programs **are not tracked**
+
+.. _YAML: http://www.yaml.org/
 
 Manifest contents
 =================

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -26,7 +26,7 @@ import yaml
 
 # Local
 from payu import envmod
-from payu.fsops import mkdir_p, make_symlink, read_config
+from payu.fsops import mkdir_p, make_symlink, read_config, movetree
 from payu.scheduler.pbs import get_job_info, pbs_env_init, get_job_id
 from payu.models import index as model_index
 import payu.profilers
@@ -730,11 +730,7 @@ class Experiment(object):
         if os.path.exists(self.output_path):
             sys.exit('payu: error: Output path already exists.')
 
-        cmd = 'mv {work} {output}'.format(
-            work=self.work_path,
-            output=self.output_path
-        )
-        sp.check_call(shlex.split(cmd))
+        movetree(self.work_path, self.output_path)
 
         # Remove old restart files
         # TODO: Move to subroutine

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -54,12 +54,13 @@ def movetree(src, dst, symlinks=False):
             # XXX What about devices, sockets etc.?
         except OSError as why:
             errors.append((srcname, dstname, str(why)))
-        # catch the Error from the recursive copytree so that we can
+        # catch the Error from the recursive movetree so that we can
         # continue with other files
         except Error as err:
             errors.extend(err.args[0])
     if errors:
         raise Error(errors)
+
 
 def read_config(config_fname=None):
     """Parse input configuration file and return a config dict."""

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -43,15 +43,11 @@ def movetree(src, dst, symlinks=False):
     for name in names:
         srcname = os.path.join(src, name)
         dstname = os.path.join(dst, name)
-        try:
-            if symlinks and os.path.islink(srcname):
-                linkto = os.readlink(srcname)
-                os.symlink(linkto, dstname)
-            else:
-                shutil.move(srcname, dstname)
-            # XXX What about devices, sockets etc.?
-        except:
-            raise
+        if symlinks and os.path.islink(srcname):
+            linkto = os.readlink(srcname)
+            os.symlink(linkto, dstname)
+        else:
+            shutil.move(srcname, dstname)
 
     shutil.rmtree(src)
 

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -35,11 +35,11 @@ def mkdir_p(path):
 
 def movetree(src, dst, symlinks=False):
     """
-    Code lifted from from shutil copytree
+    Code based on shutil copytree, but non-recursive
+    as uses move for contents of src directory
     """
     names = os.listdir(src)
     os.makedirs(dst)
-    errors = []
     for name in names:
         srcname = os.path.join(src, name)
         dstname = os.path.join(dst, name)
@@ -50,17 +50,10 @@ def movetree(src, dst, symlinks=False):
             else:
                 shutil.move(srcname, dstname)
             # XXX What about devices, sockets etc.?
-        except OSError as why:
-            errors.append((srcname, dstname, str(why)))
-        # catch the Error from the recursive movetree so that we can
-        # continue with other files
-        except Error as err:
-            errors.extend(err.args[0])
-    if errors:
-        raise Error(errors)
-    else:
-        shutil.rmtree(src)
+        except:
+            raise
 
+    shutil.rmtree(src)
 
 def read_config(config_fname=None):
     """Parse input configuration file and return a config dict."""

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -47,8 +47,6 @@ def movetree(src, dst, symlinks=False):
             if symlinks and os.path.islink(srcname):
                 linkto = os.readlink(srcname)
                 os.symlink(linkto, dstname)
-            elif os.path.isdir(srcname):
-                movetree(srcname, dstname, symlinks)
             else:
                 shutil.move(srcname, dstname)
             # XXX What about devices, sockets etc.?
@@ -60,6 +58,8 @@ def movetree(src, dst, symlinks=False):
             errors.extend(err.args[0])
     if errors:
         raise Error(errors)
+    else:
+        shutil.rmtree(src)
 
 
 def read_config(config_fname=None):

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -10,6 +10,7 @@ import multiprocessing
 import os
 import resource as res
 import shlex
+import shutil
 import subprocess as sp
 import sys
 from itertools import count
@@ -72,18 +73,13 @@ class Fms(Model):
         super(Fms, self).archive()
 
         # Remove the 'INPUT' path
-        cmd = 'rm -rf {work}'.format(work=self.work_input_path)
-        sp.check_call(shlex.split(cmd))
+        shutil.rmtree(self.work_input_path, ignore_errors=True)
 
         # Archive restart files before processing model output
         if os.path.isdir(self.restart_path):
             os.rmdir(self.restart_path)
 
-        cmd = 'mv {work} {restart}'.format(
-            work=self.work_restart_path,
-            restart=self.restart_path
-        )
-        sp.check_call(shlex.split(cmd))
+        shutil.move(self.work_restart_path, self.restart_path)
 
     def collate(self):
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'dateutil',
         'tenacity',
         'scipy',
+        'numpy >= 1.16.0',
     ],
     install_requires=[
         'f90nml >= 0.16',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'dateutil',
         'tenacity',
         'scipy',
-        'numpy >= 1.16.0',
     ],
     install_requires=[
         'f90nml >= 0.16',

--- a/test/common.py
+++ b/test/common.py
@@ -12,7 +12,8 @@ from payu.subcommands.init_cmd import runcmd as payu_init
 from payu.subcommands.setup_cmd import runcmd as payu_setup_orignal
 from payu.subcommands.sweep_cmd import runcmd as payu_sweep
 
-tmpdir = Path().cwd() / Path('test') / 'tmp'
+testdir = Path().cwd() / Path('test')
+tmpdir = testdir / 'tmp'
 ctrldir = tmpdir / 'ctrl'
 labdir = tmpdir / 'lab'
 workdir = ctrldir / 'work'

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -6,3 +6,4 @@ pylint
 mnctools
 scipy
 Sphinx
+numpy >= 1.16.0

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -6,4 +6,4 @@ pylint
 mnctools
 scipy
 Sphinx
-numpy >= 1.16.0
+numpy>=1.16.0

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -1,7 +1,9 @@
 import os
+from pathlib import Path
+import pytest
+import shutil
 import stat
 import sys
-import unittest
 
 try:
     # Python 2.x (str)
@@ -17,105 +19,174 @@ import payu
 import payu.fsops
 import payu.laboratory
 
+from .common import testdir, tmpdir, ctrldir, labdir, workdir
+from .common import make_exe, make_inputs, make_restarts, make_all_files
 
-class Test(unittest.TestCase):
+verbose = False
 
-    def setUp(self):
-        # Data here
+def setup_module(module):
+    """
+    Put any test-wide setup code in here, e.g. creating test files
+    """
+    if verbose:
+        print("setup_module      module:%s" % module.__name__)
+
+    # Should be taken care of by teardown, in case remnants lying around
+    try:
+        shutil.rmtree(tmpdir)
+    except FileNotFoundError:
         pass
 
-    # fsops tests
-    def test_mkdir_p(self):
-        tmp_dir = os.path.join(os.getcwd(), 'tmp_dir')
-        payu.fsops.mkdir_p(tmp_dir)
-
-        # Re-create existing directory
-        payu.fsops.mkdir_p(tmp_dir)
-
-        # Raise a non-EEXIST error (e.g. EACCES)
-        tmp_tmp_dir = os.path.join(tmp_dir, 'more_tmp')
-        os.chmod(tmp_dir, stat.S_IRUSR)
-        self.assertRaises(OSError, payu.fsops.mkdir_p, tmp_tmp_dir)
-
-        # Cleanup
-        os.chmod(tmp_dir, stat.S_IWUSR)
-        os.rmdir(tmp_dir)
-
-    def test_read_config(self):
-        config_path = os.path.join('test', 'config_mom5.yaml')
-        config = payu.fsops.read_config(config_path)
-
-        # Raise a non-ENOENT error (e.g. EACCES)
-        config_tmp = 'config_tmp.yaml'
-        try:
-            config_file = open(config_tmp, 'w')
-            os.chmod(config_tmp, 0)
-            self.assertRaises(IOError, payu.fsops.read_config, config_tmp)
-        finally:
-            os.chmod(config_tmp, stat.S_IWUSR)
-            config_file.close()
-            os.remove(config_tmp)
-
-    def test_make_symlink(self):
-        tmp_path = 'tmp_file'
-        tmp_sym = 'tmp_sym'
-        tmp_alt_path = 'tmp_alt'
-        tmp_dir = 'tmp_dir'
-
-        # Simple symlink test
-        tmp = open(tmp_path, 'w')
-        payu.fsops.make_symlink(tmp_path, tmp_sym)
-
-        # Override an existing symlink
-        tmp_alt = open(tmp_alt_path, 'w')
-        payu.fsops.make_symlink(tmp_alt_path, tmp_sym)
-
-        # Try to create symlink when filename already exists
-        # TODO: validate stdout
-        sys.stdout = StringIO()
-        payu.fsops.make_symlink(tmp_path, tmp_alt_path)
-        sys.stdout = sys.__stdout__
-
-        # Raise a non-EEXIST signal (EACCESS)
-        tmp_dir_sym = os.path.join(tmp_dir, tmp_sym)
-        os.mkdir(tmp_dir)
-        os.chmod(tmp_dir, 0)
-        self.assertRaises(OSError, payu.fsops.make_symlink,
-                          tmp_path, tmp_dir_sym)
-
-        # Cleanup
-        tmp.close()
-        tmp_alt.close()
-
-        os.rmdir(tmp_dir)
-        os.remove(tmp_sym)
-        os.remove(tmp_path)
-        os.remove(tmp_alt_path)
-
-    def test_splitpath(self):
-
-        # Absolute path
-        paths = payu.fsops.splitpath('/a/b/c')
-        self.assertEqual(paths, ('/', 'a', 'b', 'c'))
-
-        # Relative path
-        paths = payu.fsops.splitpath('a/b/c')
-        self.assertEqual(paths, ('a', 'b', 'c'))
-
-        # Single local path
-        paths = payu.fsops.splitpath('a')
-        self.assertEqual(paths, ('a',))
-
-    def test_default_lab_path(self):
-        # TODO
-        pass
-
-    def test_lab_new(self):
-        # TODO: validate stdout
-        sys.stdout = StringIO()
-        lab = payu.laboratory.Laboratory('model')
-        sys.stdout = sys.__stdout__
+    try:
+        tmpdir.mkdir()
+        labdir.mkdir()
+        ctrldir.mkdir()
+    except Exception as e:
+        print(e)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def teardown_module(module):
+    """
+    Put any test-wide teardown code in here, e.g. removing test outputs
+    """
+    if verbose:
+        print("teardown_module   module:%s" % module.__name__)
+
+    try:
+        shutil.rmtree(tmpdir)
+        print('removing tmp')
+    except Exception as e:
+        print(e)
+
+
+def scantree(path):
+    """
+    Recursively yield DirEntry objects for given directory.
+    https://stackoverflow.com/a/33135143/4727812
+    """
+    for entry in os.scandir(path):
+        if entry.is_dir(follow_symlinks=False):
+            yield from scantree(entry.path)
+        else:
+            yield entry
+
+def savetree(path):
+    """
+    Save a directory tree to a dict
+    """
+    result = {}
+    for entry in scantree(path):
+        result[entry.name] = (Path(entry.path).relative_to(path), entry.stat().st_size)
+    return(result)
+
+# fsops tests
+def test_mkdir_p():
+    tmp_dir = os.path.join(os.getcwd(), 'tmp_dir')
+    payu.fsops.mkdir_p(tmp_dir)
+
+    # Re-create existing directory
+    payu.fsops.mkdir_p(tmp_dir)
+
+    # Raise a non-EEXIST error (e.g. EACCES)
+    tmp_tmp_dir = os.path.join(tmp_dir, 'more_tmp')
+    os.chmod(tmp_dir, stat.S_IRUSR)
+    with pytest.raises(OSError):
+        payu.fsops.mkdir_p(tmp_tmp_dir)
+
+    # Cleanup
+    os.chmod(tmp_dir, stat.S_IWUSR)
+    os.rmdir(tmp_dir)
+
+def test_movetree():
+
+    make_all_files()
+
+    treeinfo = savetree(tmpdir)
+
+    tmptwo = testdir / 'tmp2'
+
+    # Ensure top directories are distinct
+    assert( tmpdir.stat().st_ino != tmptwo.stat().st_ino )
+
+    payu.fsops.movetree(tmpdir, tmptwo)
+
+    # Ensure directory tree faithfully moved
+    assert( treeinfo == savetree(tmptwo) )
+
+    shutil.rmtree(tmptwo)
+
+def test_read_config():
+    config_path = os.path.join('test', 'config_mom5.yaml')
+    config = payu.fsops.read_config(config_path)
+
+    # Raise a non-ENOENT error (e.g. EACCES)
+    config_tmp = 'config_tmp.yaml'
+    config_file = open(config_tmp, 'w')
+    os.chmod(config_tmp, 0)
+
+    with pytest.raises(IOError):
+        payu.fsops.read_config(config_tmp)
+
+    os.chmod(config_tmp, stat.S_IWUSR)
+    config_file.close()
+    os.remove(config_tmp)
+
+def test_make_symlink():
+    tmp_path = 'tmp_file'
+    tmp_sym = 'tmp_sym'
+    tmp_alt_path = 'tmp_alt'
+    tmp_dir = 'tmp_dir'
+
+    # Simple symlink test
+    tmp = open(tmp_path, 'w')
+    payu.fsops.make_symlink(tmp_path, tmp_sym)
+
+    # Override an existing symlink
+    tmp_alt = open(tmp_alt_path, 'w')
+    payu.fsops.make_symlink(tmp_alt_path, tmp_sym)
+
+    # Try to create symlink when filename already exists
+    # TODO: validate stdout
+    sys.stdout = StringIO()
+    payu.fsops.make_symlink(tmp_path, tmp_alt_path)
+    sys.stdout = sys.__stdout__
+
+    # Raise a non-EEXIST signal (EACCESS)
+    tmp_dir_sym = os.path.join(tmp_dir, tmp_sym)
+    os.mkdir(tmp_dir)
+    os.chmod(tmp_dir, 0)
+    with pytest.raises(OSError):
+        payu.fsops.make_symlink(tmp_path, tmp_dir_sym)
+
+    # Cleanup
+    tmp.close()
+    tmp_alt.close()
+
+    os.rmdir(tmp_dir)
+    os.remove(tmp_sym)
+    os.remove(tmp_path)
+    os.remove(tmp_alt_path)
+
+def test_splitpath():
+
+    # Absolute path
+    paths = payu.fsops.splitpath('/a/b/c')
+    assert(paths == ('/', 'a', 'b', 'c'))
+
+    # Relative path
+    paths = payu.fsops.splitpath('a/b/c')
+    assert(paths == ('a', 'b', 'c'))
+
+    # Single local path
+    paths = payu.fsops.splitpath('a')
+    assert(paths == ('a',))
+
+def test_default_lab_path():
+    # TODO
+    pass
+
+def test_lab_new():
+    # TODO: validate stdout
+    sys.stdout = StringIO()
+    lab = payu.laboratory.Laboratory('model')
+    sys.stdout = sys.__stdout__

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -18,6 +18,8 @@ from .common import make_exe, make_inputs, make_restarts, make_all_files
 sys.path.insert(1, '../')
 verbose = False
 
+tmptwo = testdir / 'tmp2'
+
 
 def setup_module(module):
     """
@@ -50,6 +52,8 @@ def teardown_module(module):
     try:
         shutil.rmtree(tmpdir)
         print('removing tmp')
+        shutil.rmtree(tmptwo)
+        print('removing tmp2')
     except Exception as e:
         print(e)
 
@@ -102,17 +106,21 @@ def test_movetree():
 
     treeinfo = savetree(tmpdir)
 
-    tmptwo = testdir / 'tmp2'
+    tmp_inode = tmpdir.stat().st_ino 
 
     payu.fsops.movetree(tmpdir, tmptwo)
 
-    # Ensure top directories are distinct
-    assert(tmpdir.stat().st_ino != tmptwo.stat().st_ino)
+    # Ensure src directory removed
+    assert(not tmpdir.exists())
+
+    # Ensure dst directory has new inode number
+    assert(tmp_inode != tmptwo.stat().st_ino)
 
     # Ensure directory tree faithfully moved
     assert(treeinfo == savetree(tmptwo))
 
-    shutil.rmtree(tmptwo)
+    # Move tmp2 back to tmp
+    shutil.move(tmptwo, tmpdir)
 
 
 def test_read_config():

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -1,3 +1,4 @@
+from io import StringIO
 import os
 from pathlib import Path
 import pytest
@@ -5,24 +6,18 @@ import shutil
 import stat
 import sys
 
-try:
-    # Python 2.x (str)
-    from cStringIO import StringIO
-except ImportError:
-    # Python 3.x (unicode)
-    from io import StringIO
-
-sys.path.insert(1, '../')
-import payu
-
 # Submodules
+import payu
 import payu.fsops
 import payu.laboratory
 
 from .common import testdir, tmpdir, ctrldir, labdir, workdir
 from .common import make_exe, make_inputs, make_restarts, make_all_files
 
+
+sys.path.insert(1, '../')
 verbose = False
+
 
 def setup_module(module):
     """
@@ -70,14 +65,17 @@ def scantree(path):
         else:
             yield entry
 
+
 def savetree(path):
     """
     Save a directory tree to a dict
     """
     result = {}
     for entry in scantree(path):
-        result[entry.name] = (Path(entry.path).relative_to(path), entry.stat().st_size)
+        result[entry.name] = (Path(entry.path).relative_to(path),
+                              entry.stat().st_size)
     return(result)
+
 
 # fsops tests
 def test_mkdir_p():
@@ -97,6 +95,7 @@ def test_mkdir_p():
     os.chmod(tmp_dir, stat.S_IWUSR)
     os.rmdir(tmp_dir)
 
+
 def test_movetree():
 
     make_all_files()
@@ -108,12 +107,13 @@ def test_movetree():
     payu.fsops.movetree(tmpdir, tmptwo)
 
     # Ensure top directories are distinct
-    assert( tmpdir.stat().st_ino != tmptwo.stat().st_ino )
+    assert(tmpdir.stat().st_ino != tmptwo.stat().st_ino)
 
     # Ensure directory tree faithfully moved
-    assert( treeinfo == savetree(tmptwo) )
+    assert(treeinfo == savetree(tmptwo))
 
     shutil.rmtree(tmptwo)
+
 
 def test_read_config():
     config_path = os.path.join('test', 'config_mom5.yaml')
@@ -130,6 +130,7 @@ def test_read_config():
     os.chmod(config_tmp, stat.S_IWUSR)
     config_file.close()
     os.remove(config_tmp)
+
 
 def test_make_symlink():
     tmp_path = 'tmp_file'
@@ -167,6 +168,7 @@ def test_make_symlink():
     os.remove(tmp_path)
     os.remove(tmp_alt_path)
 
+
 def test_splitpath():
 
     # Absolute path
@@ -181,9 +183,11 @@ def test_splitpath():
     paths = payu.fsops.splitpath('a')
     assert(paths == ('a',))
 
+
 def test_default_lab_path():
     # TODO
     pass
+
 
 def test_lab_new():
     # TODO: validate stdout

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -105,10 +105,10 @@ def test_movetree():
 
     tmptwo = testdir / 'tmp2'
 
+    payu.fsops.movetree(tmpdir, tmptwo)
+
     # Ensure top directories are distinct
     assert( tmpdir.stat().st_ino != tmptwo.stat().st_ino )
-
-    payu.fsops.movetree(tmpdir, tmptwo)
 
     # Ensure directory tree faithfully moved
     assert( treeinfo == savetree(tmptwo) )

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -106,7 +106,7 @@ def test_movetree():
 
     treeinfo = savetree(tmpdir)
 
-    tmp_inode = tmpdir.stat().st_ino 
+    tmp_inode = tmpdir.stat().st_ino
 
     payu.fsops.movetree(tmpdir, tmptwo)
 


### PR DESCRIPTION
Use new function to move contents of the ephemeral `work` directory to a new `output` directory in `archive`.

Fixes #238 