### PR TITLE
Add support for legacy mount points on gadi

### DIFF
--- a/payu/scheduler/pbs.py
+++ b/payu/scheduler/pbs.py
@@ -141,10 +141,12 @@ def find_mounts(paths, mounts):
     for p in paths:
         for m in mounts:
             if p.startswith(m):
+                # Find the number of path elements in the mount string
+                offset = len(m.split(os.path.sep))
                 # Relevant project code is the next element of the path
                 # after the mount point. DO NOT USE os.path.split as it
                 # is not consistent with trailing slash
-                proj = os.path.relpath(p, m).split(os.path.sep)[0]
+                proj = p.split(os.path.sep)[offset]
                 storages.add(make_mount_string(encode_mount(m), proj))
                 break
 

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -125,6 +125,13 @@ def test_find_mounts():
 
     assert(pbs.find_mounts(paths, mounts) == set(['fdata/x00', ]))
 
+    # Test legacy naming that allows for extra characters at the
+    # end of mount path
+    paths = ['/f/data1a/x00', ]
+    mounts = ['/f/data', ]
+
+    assert(pbs.find_mounts(paths, mounts) == set(['fdata/x00', ]))
+
 
 def test_run():
 


### PR DESCRIPTION
Fixes #245 

Uses the mount point being scanned for to find the next path element that is the project code required.