### PR TITLE
PEP8 whitespace changes

### DIFF
--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -51,6 +51,7 @@ def movetree(src, dst, symlinks=False):
 
     shutil.rmtree(src)
 
+
 def read_config(config_fname=None):
     """Parse input configuration file and return a config dict."""
 

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -246,6 +246,7 @@ class PayuManifest(YaManifest):
             hashes.append(self.get(filepath, hashfn))
         return hashes
 
+
 class Manifest(object):
     """
     A Manifest class which stores all manifests for file tracking and
@@ -412,11 +413,11 @@ class Manifest(object):
         code from directly calling anything in PayuManifest.
         """
         filepath = os.path.normpath(filepath)
-        if self.manifests[manifest].add_filepath(filepath=filepath,
-                                                 fullpath=fullpath,
-                                                 hashes=self.fast_hashes +
-                                                        self.full_hashes,
-                                                 copy=copy):
+        if self.manifests[manifest].add_filepath(
+                filepath=filepath,
+                fullpath=fullpath,
+                hashes=self.fast_hashes + self.full_hashes,
+                copy=copy):
             # Only link if filepath was added
             self.manifests[manifest].make_link(filepath)
 


### PR DESCRIPTION
Minor PEP8 whitespace changes:
- two spaces between code blocks outside of classes
- Extended argument indentation