### PR TITLE
Removed scipy from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'yamanifest',
         'dateutil',
         'tenacity',
-        'scipy',
     ],
     install_requires=[
         'f90nml >= 0.16',


### PR DESCRIPTION
Scipy is listed as a dependency but does not appear to be used in payu.

Scipy depends on NumPy, which is a very large package, so we probably do
not want this to be installed.