### PR TITLE
Empty YAML config handled as empty dict

### DIFF
--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -73,8 +73,6 @@ def read_config(config_fname=None):
         else:
             raise
 
-
-
     collate_config = config.pop('collate', {})
 
     # Transform legacy collate config options

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -61,6 +61,10 @@ def read_config(config_fname=None):
     try:
         with open(config_fname, 'r') as config_file:
             config = yaml.safe_load(config_file)
+
+        # NOTE: A YAML file with no content returns `None`
+        if config is None:
+            config = {}
     except IOError as exc:
         if exc.errno == errno.ENOENT:
             print('payu: warning: Configuration file {0} not found!'
@@ -68,6 +72,8 @@ def read_config(config_fname=None):
             config = {}
         else:
             raise
+
+
 
     collate_config = config.pop('collate', {})
 

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -143,7 +143,11 @@ def test_read_config():
     os.chmod(config_tmp, stat.S_IWUSR | stat.S_IREAD)
     config_file.close()
 
-    assert( payu.fsops.read_config(config_tmp) == { 'collate': {} } )
+    config = payu.fsops.read_config(config_tmp)
+
+    assert(config.pop('collate') == {})
+    assert(config.pop('control_path') == os.getcwd())
+    assert(config == {})
 
     os.remove(config_tmp)
 

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -140,8 +140,11 @@ def test_read_config():
     with pytest.raises(IOError):
         payu.fsops.read_config(config_tmp)
 
-    os.chmod(config_tmp, stat.S_IWUSR)
+    os.chmod(config_tmp, stat.S_IWUSR | stat.S_IREAD)
     config_file.close()
+
+    assert( payu.fsops.read_config(config_tmp) == { 'collate': {} } )
+
     os.remove(config_tmp)
 
 


### PR DESCRIPTION
If one passes an empty YAML file, e.g. all lines commented out, then
PyYAML returns `None`, which breaks subsequent assumptions in the
handling of config.

We now parse an empty file as an empty dict, {}.