### PR TITLE
Use keyword arguments for calls to cli.set_env_vars

### DIFF
--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -21,7 +21,9 @@ arguments = [args.model, args.config, args.initial, args.laboratory,
 def runcmd(model_type, config_path, init_run, lab_path, dir_path):
 
     pbs_config = fsops.read_config(config_path)
-    pbs_vars = cli.set_env_vars(init_run, lab_path, dir_path)
+    pbs_vars = cli.set_env_vars(init_run=init_run,
+                                lab_path=lab_path,
+                                dir_path=dir_path)
 
     collate_config = pbs_config.get('collate', {})
 
@@ -95,9 +97,9 @@ def runscript():
 
     run_args = parser.parse_args()
 
-    pbs_vars = cli.set_env_vars(run_args.init_run,
-                                run_args.lab_path,
-                                run_args.dir_path)
+    pbs_vars = cli.set_env_vars(init_run=run_args.init_run,
+                                lab_path=run_args.lab_path,
+                                dir_path=run_args.dir_path)
 
     for var in pbs_vars:
         os.environ[var] = str(pbs_vars[var])

--- a/payu/subcommands/profile_cmd.py
+++ b/payu/subcommands/profile_cmd.py
@@ -21,7 +21,9 @@ arguments = [args.model, args.config, args.initial, args.nruns,
 def runcmd(model_type, config_path, init_run, n_runs, lab_path):
 
     pbs_config = fsops.read_config(config_path)
-    pbs_vars = cli.set_env_vars(init_run, n_runs, lab_path)
+    pbs_vars = cli.set_env_vars(init_run=init_run,
+                                n_runs=n_runs,
+                                lab_path=lab_path)
 
     pbs_config['queue'] = pbs_config.get('profile_queue', 'normal')
 
@@ -71,7 +73,8 @@ def runscript():
 
     run_args = parser.parse_args()
 
-    pbs_vars = cli.set_env_vars(run_args.init_run, run_args.n_runs)
+    pbs_vars = cli.set_env_vars(init_run=run_args.init_run,
+                                n_runs=run_args.n_runs)
     for var in pbs_vars:
         os.environ[var] = str(pbs_vars[var])
 

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -20,8 +20,11 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
 
     # Get job submission configuration
     pbs_config = fsops.read_config(config_path)
-    pbs_vars = cli.set_env_vars(init_run, n_runs, lab_path,
-                                reproduce=reproduce, force=force)
+    pbs_vars = cli.set_env_vars(init_run=init_run,
+                                n_runs=n_runs,
+                                lab_path=lab_path,
+                                reproduce=reproduce,
+                                force=force)
 
     # Set the queue
     # NOTE: Maybe force all jobs on the normal queue


### PR DESCRIPTION
Fixes #268 

Options were not being properly propagated due to not specifying arguments correctly when calling cli.set_env_vars