### PR TITLE
Proto-scheduler class, pre-support for slurm

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -69,6 +69,7 @@ def generate_parser():
 
     return parser
 
+
 def get_model_type(model_type, config):
     """Determine and validate the active model type."""
 

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -20,8 +20,9 @@ import payu
 import payu.envmod as envmod
 from payu.fsops import is_conda
 from payu.models import index as supported_models
+from payu.schedulers import index as scheduler_index
 import payu.subcommands
-from payu.scheduler.pbs import generate_command
+
 
 # Default configuration
 DEFAULT_CONFIG = 'config.yaml'
@@ -144,8 +145,11 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
 def submit_job(script, config, vars=None):
     """Submit a userscript the scheduler."""
 
-    cmd = generate_command(script, config, vars)
-
+    # TODO: Temporary stub to replicate the old approach
+    sched_name = config.get('scheduler', 'pbs')
+    sched_type = scheduler_index[sched_name]
+    sched = sched_type()
+    cmd = sched.submit(script, config, vars)
     print(cmd)
 
     subprocess.check_call(shlex.split(cmd))

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -536,8 +536,11 @@ class Experiment(object):
 
             model_ncpus = model.config.get('ncpus')
             if model_ncpus:
-                #model_prog.append('-np {0}'.format(model_ncpus))
-                model_prog.append('-n {0}'.format(model_ncpus))
+                if self.config.get('scheduler') == 'slurm':
+                    model_prog.append('-n {0}'.format(model_ncpus))
+                else:
+                    # Default to preferred mpirun syntax
+                    model_prog.append('-np {0}'.format(model_ncpus))
 
             model_npernode = model.config.get('npernode')
             # TODO: New Open MPI format?

--- a/payu/schedulers/__init__.py
+++ b/payu/schedulers/__init__.py
@@ -1,0 +1,9 @@
+from payu.schedulers.pbs import PBS
+from payu.schedulers.slurm import Slurm
+
+from payu.schedulers.scheduler import Scheduler
+
+index = {
+    'pbs': PBS,
+    'slurm': Slurm,
+}

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -1,11 +1,7 @@
-# coding: utf-8
-"""payu.scheduler.pbs
-   ===============
+""" Functions to support PBS based schedulers
 
-   Functions to support PBS based schedulers
-
-   :copyright: Copyright 2011 Marshall Ward, see AUTHORS for details.
-   :license: Apache License, Version 2.0, see LICENSE for details.
+:copyright: Copyright 2011 Marshall Ward, see AUTHORS for details.
+:license: Apache License, Version 2.0, see LICENSE for details.
 """
 
 # Standard library
@@ -18,9 +14,123 @@ import subprocess
 import payu.envmod as envmod
 from payu.fsops import check_exe_path
 from payu.manifest import Manifest
+from payu.schedulers.scheduler import Scheduler
 
 from tenacity import retry, stop_after_delay
 
+
+# TODO: This is a stub acting as a minimal port to a Scheduler class.
+class PBS(Scheduler):
+    # TODO: __init__
+
+    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None):
+        """Prepare a correct PBS command string"""
+
+        pbs_env_init()
+
+        # Initialisation
+        if pbs_vars is None:
+            pbs_vars = {}
+
+        # Necessary for testing
+        if python_exe is None:
+            python_exe = sys.executable
+
+        pbs_flags = []
+
+        pbs_queue = pbs_config.get('queue', 'normal')
+        pbs_flags.append('-q {queue}'.format(queue=pbs_queue))
+
+        pbs_project = pbs_config.get('project', os.environ['PROJECT'])
+        pbs_flags.append('-P {project}'.format(project=pbs_project))
+
+        pbs_resources = ['walltime', 'ncpus', 'mem', 'jobfs']
+
+        for res_key in pbs_resources:
+            res_flags = []
+            res_val = pbs_config.get(res_key)
+            if res_val:
+                res_flags.append('{key}={val}'.format(key=res_key, val=res_val))
+
+            if res_flags:
+                pbs_flags.append('-l {res}'.format(res=','.join(res_flags)))
+
+        # TODO: Need to pass lab.config_path somehow...
+        pbs_jobname = pbs_config.get('jobname', os.path.basename(os.getcwd()))
+        if pbs_jobname:
+            # PBSPro has a 15-character jobname limit
+            pbs_flags.append('-N {name}'.format(name=pbs_jobname[:15]))
+
+        pbs_priority = pbs_config.get('priority')
+        if pbs_priority:
+            pbs_flags.append('-p {priority}'.format(priority=pbs_priority))
+
+        pbs_flags.append('-l wd')
+
+        pbs_join = pbs_config.get('join', 'n')
+        if pbs_join not in ('oe', 'eo', 'n'):
+            print('payu: error: unknown qsub IO stream join setting.')
+            sys.exit(-1)
+        else:
+            pbs_flags.append('-j {join}'.format(join=pbs_join))
+
+        # Append environment variables to qsub command
+        # TODO: Support full export of environment variables: `qsub -V`
+        pbs_vstring = ','.join('{0}={1}'.format(k, v)
+                               for k, v in pbs_vars.items())
+        pbs_flags.append('-v ' + pbs_vstring)
+
+        storages = set()
+        storage_config = pbs_config.get('storage', {})
+        mounts = set(['/scratch', '/g/data'])
+        for mount in storage_config:
+            mounts.add(mount)
+            for project in storage_config[mount]:
+                storages.add(make_mount_string(encode_mount(mount), project))
+
+        # Append any additional qsub flags here
+        pbs_flags_extend = pbs_config.get('qsub_flags')
+        if pbs_flags_extend:
+            pbs_flags.append(pbs_flags_extend)
+
+        payu_path = pbs_vars.get('PAYU_PATH', os.path.dirname(sys.argv[0]))
+        pbs_script = check_exe_path(payu_path, pbs_script)
+
+        # Check for storage paths that might need to be mounted in the
+        # python and script paths
+        extra_search_paths = [python_exe, payu_path, pbs_script]
+
+        laboratory_path = pbs_config.get('laboratory', None)
+        if laboratory_path is not None:
+            extra_search_paths.append(laboratory_path)
+        short_path = pbs_config.get('shortpath', None)
+        if short_path is not None:
+            extra_search_paths.append(short_path)
+
+        storages.update(find_mounts(extra_search_paths, mounts))
+        storages.update(find_mounts(get_manifest_paths(), mounts))
+
+        # Add storage flags. Note that these are sorted to get predictable
+        # behaviour for testing
+        pbs_flags_extend = '+'.join(sorted(storages))
+        if pbs_flags_extend:
+            pbs_flags.append("-l storage={}".format(pbs_flags_extend))
+
+        # Set up environment modules here for PBS.
+        envmod.setup()
+        envmod.module('load', 'pbs')
+
+        # Construct job submission command
+        cmd = 'qsub {flags} -- {python} {script}'.format(
+            flags=' '.join(pbs_flags),
+            python=python_exe,
+            script=pbs_script
+        )
+
+        return cmd
+
+
+# TODO: These support functions can probably be integrated into the class
 
 def get_job_id(short=True):
     """

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -50,8 +50,9 @@ class PBS(Scheduler):
             res_flags = []
             res_val = pbs_config.get(res_key)
             if res_val:
-                res_flags.append('{key}={val}'.format(key=res_key, val=res_val))
-
+                res_flags.append(
+                    '{key}={val}'.format(key=res_key, val=res_val)
+                )
             if res_flags:
                 pbs_flags.append('-l {res}'.format(res=','.join(res_flags)))
 

--- a/payu/schedulers/scheduler.py
+++ b/payu/schedulers/scheduler.py
@@ -1,0 +1,18 @@
+"""Generic interface for job scheduler control.
+
+:copyright: Copyright 2020 Marshall Ward, see AUTHORS for details
+:license: Apache License, Version 2.0, see LICENSE for details
+"""
+
+# TODO: This class is currently just a stub.  I would hope that it will be
+# expanded to provide greater functionality in the future.
+
+class Scheduler(object):
+    """Abstract scheduler class."""
+
+    def __init__(self):
+        # TODO
+        pass
+
+    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None):
+        raise NotImplementedError

--- a/payu/schedulers/scheduler.py
+++ b/payu/schedulers/scheduler.py
@@ -7,6 +7,7 @@
 # TODO: This class is currently just a stub.  I would hope that it will be
 # expanded to provide greater functionality in the future.
 
+
 class Scheduler(object):
     """Abstract scheduler class."""
 

--- a/payu/schedulers/slurm.py
+++ b/payu/schedulers/slurm.py
@@ -1,0 +1,47 @@
+"""Functions to support Slurm scheduling.
+
+:copyright: Copyright 2011 Marshall Ward, see AUTHORS for details.
+:license: Apache License, Version 2.0, see LICENSE for details.
+"""
+
+# Standard library
+import os
+import re
+import sys
+import shlex
+import subprocess
+
+from payu.fsops import check_exe_path
+from payu.schedulers.scheduler import Scheduler
+
+class Slurm(Scheduler):
+    # TODO: __init__
+
+    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None):
+        """Prepare a correct PBS command string"""
+
+        if python_exe is None:
+            python_exe = sys.executable
+
+        if pbs_vars is None:
+            pbs_vars = {}
+
+        payu_path = pbs_vars.get('PAYU_PATH', os.path.dirname(sys.argv[0]))
+        pbs_script = check_exe_path(payu_path, pbs_script)
+
+        pbs_flags = []
+        pbs_flags.append('--time={}'.format(pbs_config.get('walltime')))
+        pbs_flags.append('--ntasks={}'.format(pbs_config.get('ncpus')))
+
+        # Flags which need to be addressed
+        pbs_flags.append('--qos=debug')
+        pbs_flags.append('--cluster=c4')
+
+        # Construct job submission command
+        cmd = 'sbatch {flags} --wrap="{python} {script}"'.format(
+            flags=' '.join(pbs_flags),
+            python=python_exe,
+            script=pbs_script
+        )
+
+        return cmd

--- a/payu/schedulers/slurm.py
+++ b/payu/schedulers/slurm.py
@@ -14,6 +14,7 @@ import subprocess
 from payu.fsops import check_exe_path
 from payu.schedulers.scheduler import Scheduler
 
+
 class Slurm(Scheduler):
     # TODO: __init__
 

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -1,6 +1,6 @@
 coverage
 coveralls
-pytest
+pytest>=4.6; python_version>"2.7"
 pylint
 mnctools
 Sphinx

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -9,7 +9,7 @@ import yaml
 import payu
 
 from payu.laboratory import Laboratory
-from payu.scheduler.pbs import find_mounts
+from payu.schedulers.pbs import find_mounts
 
 
 from .common import cd, make_random_file, get_manifests

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -13,7 +13,7 @@ import payu
 
 from payu.fsops import read_config
 from payu.laboratory import Laboratory
-from payu.scheduler import pbs
+from payu.schedulers import pbs
 
 
 from .common import cd, make_random_file, get_manifests
@@ -137,9 +137,9 @@ def test_run():
 
     # Monkey patch pbs_env_init as we don't have a
     # functioning PBS install in travis
-    payu.scheduler.pbs.pbs_env_init = lambda: True
+    payu.schedulers.pbs.pbs_env_init = lambda: True
 
-    payu.scheduler.pbs.check_exe_path = lambda x, y: y
+    payu.schedulers.pbs.check_exe_path = lambda x, y: y
 
     # payu_path = os.path.join(os.environ['PWD'], 'bin')
     payu_path = payudir / 'bin'


### PR DESCRIPTION
This is a very minimal implementation of a Scheduler class, in order to
handle scheduler-specific operations.

It includes a basic Factory for controlling the Scheduler instantiation,
and a single method for returning the submission command line.

I do not expect things to keep working like this, it is only meant to be
the most minimal implementation to support both PBS and Slurm.

Hopefully more changes to come.