### PR TITLE
Add postscript action to non-collate jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
         run: payu list
 
       - name: Lint
-        run: pylint --extension-pkg-whitelist=netCDF4,backports -E payu
+        run: pylint --extension-pkg-whitelist=netCDF4 --ignored-modules=backports -E payu
 
       - name: Run tests
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
         run: payu list
 
       - name: Lint
-        run: pylint --extension-pkg-whitelist=netCDF4 -E payu
+        run: pylint --extension-pkg-whitelist=netCDF4,backports -E payu
 
       - name: Run tests
         run: |

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -784,7 +784,8 @@ class Experiment(object):
             os.environ['LD_LIBRARY_PATH'] = ':'.join([py_libpath, ld_libpaths])
 
         collate_config = self.config.get('collate', {})
-        if collate_config.get('enable', True):
+        collating = collate_config.get('enable', True)
+        if collating:
             cmd = '{python} {payu} collate -i {expt}'.format(
                 python=sys.executable,
                 payu=self.payu_path,
@@ -803,6 +804,10 @@ class Experiment(object):
         archive_script = self.userscripts.get('archive')
         if archive_script:
             self.run_userscript(archive_script)
+
+        # Ensure postprocess runs if model not collating
+        if not collating and self.postscript:
+            self.postprocess()
 
     def collate(self):
         for model in self.models:


### PR DESCRIPTION
Closes #289 

Add logic to run the `postscript` action for jobs which do not collate, which ensures `postscript` will *always* run once an output directory is guaranteed not to change as a result of an action by `payu`.

Tested and works fine. Not sure if there is a simple `pytest` I could add for this unfortunately.