### PR TITLE
Fix FMS collate for >9999 files

### DIFF
--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 
 from collections import defaultdict
+from pathlib import Path
 import multiprocessing
 import os
 import resource as res
@@ -62,12 +63,12 @@ class Fms(Model):
             return []
 
         # Generate collated file list and identify the first tile
-        tile_fnames = [f for f in os.listdir(dir)
-                       if f[-4:].isdigit() and f[-8:-4] == '.nc.']
+        tile_fnames = [f for f in Path(dir).iterdir()
+                       if f.suffixes[0] == '.nc' and f.suffixes[1][1:].isdigit()]
 
-        # print("dir: ",tile_fnames)
-        tile_fnames.sort()
-        return tile_fnames
+        # Sort numerically according to the number in the suffix and strip off
+        # path information
+        return [f.name for f in sorted(tile_fnames, key=lambda e: int(e.suffixes[1][1:]))]
 
     def archive(self, **kwargs):
         super(Fms, self).archive()

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -64,12 +64,12 @@ class Fms(Model):
 
         # Generate collated file list and identify the first tile
         tile_fnames = [f for f in Path(dir).iterdir()
-                       if f.suffixes[0] == '.nc' and 
+                       if f.suffixes[0] == '.nc' and
                        f.suffixes[1][1:].isdigit()]
 
         # Sort numerically according to the number in the suffix and strip off
         # path information
-        return [f.name for f 
+        return [f.name for f
                 in sorted(tile_fnames, key=lambda e: int(e.suffixes[1][1:]))]
 
     def archive(self, **kwargs):

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -64,11 +64,13 @@ class Fms(Model):
 
         # Generate collated file list and identify the first tile
         tile_fnames = [f for f in Path(dir).iterdir()
-                       if f.suffixes[0] == '.nc' and f.suffixes[1][1:].isdigit()]
+                       if f.suffixes[0] == '.nc' and 
+                       f.suffixes[1][1:].isdigit()]
 
         # Sort numerically according to the number in the suffix and strip off
         # path information
-        return [f.name for f in sorted(tile_fnames, key=lambda e: int(e.suffixes[1][1:]))]
+        return [f.name for f 
+                in sorted(tile_fnames, key=lambda e: int(e.suffixes[1][1:]))]
 
     def archive(self, **kwargs):
         super(Fms, self).archive()

--- a/test/models/test_fms.py
+++ b/test/models/test_fms.py
@@ -1,0 +1,95 @@
+import copy
+import os
+from pathlib import Path
+import pdb
+import shutil
+
+import f90nml
+import pytest
+import yaml
+
+import payu
+
+from payu.models.fms import Fms
+
+from test.common import tmpdir
+
+verbose = False
+
+def rmtmp():
+    try:
+        shutil.rmtree(tmpdir)
+    except FileNotFoundError:
+        pass
+
+def mktmp():
+    tmpdir.mkdir()
+
+def setup_module(module):
+    """
+    Put any test-wide setup code in here, e.g. creating test files
+    """
+    if verbose:
+        print("setup_module      module:%s" % module.__name__)
+
+    rmtmp()
+    mktmp()
+
+def teardown_module(module):
+    """
+    Put any test-wide teardown code in here, e.g. removing test outputs
+    """
+    if verbose:
+        print("teardown_module   module:%s" % module.__name__)
+
+    rmtmp()
+
+def make_tiles(begin, end):
+
+    files = []
+    for n in range(begin, end): 
+        p = tmpdir / "tile.nc.{0:06d}".format(n)
+        p.touch()
+        files.append(str(p.name))
+
+    return files
+
+def rm_tiles():
+
+    for f in tmpdir.iterdir():
+        f.unlink()
+
+def test_get_uncollated_files():
+
+    files = make_tiles(9900,9999)
+
+    mncfiles = Fms.get_uncollated_files(tmpdir)
+
+    assert len(mncfiles) == len(files)
+    assert all(a == b for a,b in zip(mncfiles, files))
+
+    files = make_tiles(9900,10100)
+
+    mncfiles = Fms.get_uncollated_files(tmpdir)
+
+    assert len(mncfiles) == len(files)
+    assert all(a == b for a,b in zip(mncfiles, files))
+
+    rm_tiles()
+
+    files = make_tiles(0,99)
+
+    mncfiles = Fms.get_uncollated_files(tmpdir)
+
+    assert len(mncfiles) == len(files)
+    assert all(a == b for a,b in zip(mncfiles, files))
+
+    rm_tiles()
+
+    # Make sure still sorts once over the six-figure zero-padding
+    files = make_tiles(999997,1000010)
+
+    mncfiles = Fms.get_uncollated_files(tmpdir)
+
+    assert len(mncfiles) == len(files)
+    assert all(a == b for a,b in zip(mncfiles, files))


### PR DESCRIPTION
Closes #309 

Modified payu.models.fms.get_uncollated_files to support > 9999 files.

Added tests.