### PR TITLE
Fix collating restarts

### DIFF
--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -64,13 +64,13 @@ class Fms(Model):
 
         # Generate collated file list and identify the first tile
         tile_fnames = [f for f in Path(dir).glob('*.nc.*')
-                       if f.suffixes[0] == '.nc' and
-                       f.suffixes[1][1:].isdigit()]
+                       if f.suffixes[-2] == '.nc' and
+                       f.suffixes[-1][1:].isdigit()]
 
         # Sort numerically according to the number in the suffix and strip off
         # path information
         return [f.name for f
-                in sorted(tile_fnames, key=lambda e: int(e.suffixes[1][1:]))]
+                in sorted(tile_fnames, key=lambda e: int(e.suffixes[-1][1:]))]
 
     def archive(self, **kwargs):
         super(Fms, self).archive()

--- a/test/models/test_fms.py
+++ b/test/models/test_fms.py
@@ -44,14 +44,14 @@ def teardown_module(module):
 
     rmtmp()
 
-def make_tiles(begin, end):
-
-    files = []
-    for n in range(begin, end): 
-        p = tmpdir / "tile.nc.{0:06d}".format(n)
-        p.touch()
+def make_tiles(begin, end, prefix='tile'):
+                                                       
+    files = []            
+    for n in range(begin, end):                     
+        p = tmpdir / "{}.nc.{:06d}".format(prefix, n)
+        p.touch()                                      
         files.append(str(p.name))
-    
+
     # Make a random non-conforming filename
     (tmpdir / "log.out").touch()
 
@@ -99,3 +99,42 @@ def test_get_uncollated_files():
 
     assert len(mncfiles) == len(files)
     assert all(a == b for a,b in zip(mncfiles, files))
+
+def test_get_uncollated_restart_files():
+
+    rm_tiles()
+
+    prefix = "tile.res"
+
+    files = make_tiles(9900, 9999, prefix)
+
+    mncfiles = Fms.get_uncollated_files(tmpdir)
+
+    assert len(mncfiles) == len(files)
+    assert all(a == b for a, b in zip(mncfiles, files))
+
+    files = make_tiles(9900, 10100, prefix)
+
+    mncfiles = Fms.get_uncollated_files(tmpdir)
+
+    assert len(mncfiles) == len(files)
+    assert all(a == b for a, b in zip(mncfiles, files))
+
+    rm_tiles()
+
+    files = make_tiles(0, 99, prefix)
+
+    mncfiles = Fms.get_uncollated_files(tmpdir)
+
+    assert len(mncfiles) == len(files)
+    assert all(a == b for a, b in zip(mncfiles, files))
+
+    rm_tiles()
+
+    # Make sure still sorts once over the six-figure zero-padding
+    files = make_tiles(999997, 1000010, prefix)
+
+    mncfiles = Fms.get_uncollated_files(tmpdir)
+
+    assert len(mncfiles) == len(files)
+    assert all(a == b for a, b in zip(mncfiles, files))

--- a/test/models/test_fms.py
+++ b/test/models/test_fms.py
@@ -16,14 +16,17 @@ from test.common import tmpdir
 
 verbose = False
 
+
 def rmtmp():
     try:
         shutil.rmtree(tmpdir)
     except FileNotFoundError:
         pass
 
+
 def mktmp():
     tmpdir.mkdir()
+
 
 def setup_module(module):
     """
@@ -35,6 +38,7 @@ def setup_module(module):
     rmtmp()
     mktmp()
 
+
 def teardown_module(module):
     """
     Put any test-wide teardown code in here, e.g. removing test outputs
@@ -44,12 +48,13 @@ def teardown_module(module):
 
     rmtmp()
 
+
 def make_tiles(begin, end, prefix='tile'):
-                                                       
-    files = []            
-    for n in range(begin, end):                     
+
+    files = []
+    for n in range(begin, end):
         p = tmpdir / "{}.nc.{:06d}".format(prefix, n)
-        p.touch()                                      
+        p.touch()
         files.append(str(p.name))
 
     # Make a random non-conforming filename
@@ -60,45 +65,48 @@ def make_tiles(begin, end, prefix='tile'):
 
     return files
 
+
 def rm_tiles():
 
     for f in tmpdir.iterdir():
         f.unlink()
 
+
 def test_get_uncollated_files():
 
-    files = make_tiles(9900,9999)
+    files = make_tiles(9900, 9999)
 
     mncfiles = Fms.get_uncollated_files(tmpdir)
 
     assert len(mncfiles) == len(files)
-    assert all(a == b for a,b in zip(mncfiles, files))
+    assert all(a == b for a, b in zip(mncfiles, files))
 
-    files = make_tiles(9900,10100)
+    files = make_tiles(9900, 10100)
 
     mncfiles = Fms.get_uncollated_files(tmpdir)
 
     assert len(mncfiles) == len(files)
-    assert all(a == b for a,b in zip(mncfiles, files))
+    assert all(a == b for a, b in zip(mncfiles, files))
 
     rm_tiles()
 
-    files = make_tiles(0,99)
+    files = make_tiles(0, 99)
 
     mncfiles = Fms.get_uncollated_files(tmpdir)
 
     assert len(mncfiles) == len(files)
-    assert all(a == b for a,b in zip(mncfiles, files))
+    assert all(a == b for a, b in zip(mncfiles, files))
 
     rm_tiles()
 
     # Make sure still sorts once over the six-figure zero-padding
-    files = make_tiles(999997,1000010)
+    files = make_tiles(999997, 1000010)
 
     mncfiles = Fms.get_uncollated_files(tmpdir)
 
     assert len(mncfiles) == len(files)
-    assert all(a == b for a,b in zip(mncfiles, files))
+    assert all(a == b for a, b in zip(mncfiles, files))
+
 
 def test_get_uncollated_restart_files():
 


### PR DESCRIPTION
Fixes #316 

PR #310 broke collating restart directories because of the extra ``.res.`` "suffix" when using suffixes in the new method.

Indexing backwards seems to work. Added tests which are passing.