### PR TITLE
Tell SIS2 about restart runs for MOM6

### DIFF
--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -73,4 +73,7 @@ class Mom6(Fms):
             input_type = 'r'
         input_nml['MOM_input_nml']['input_filename'] = input_type
 
+        if 'SIS_input_nml' in input_nml:
+            input_nml['SIS_input_nml']['input_filename'] = input_type
+
         f90nml.write(input_nml, input_fpath, force=True)


### PR DESCRIPTION
At some point last year, SIS2 stopped ignoring its namelist for input filenames. I think this effectively meant that every run segment was starting with no ice. If the `SIS_input_nml` is present, it should get the same input type (i.e. restart or new run) as MOM6 itself.