### PR TITLE
Flag a MOM6 run as a restart if using prior restart path

### DIFF
--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -67,7 +67,8 @@ class Mom6(Fms):
 
         input_nml = f90nml.read(input_fpath)
 
-        if self.expt.counter == 0 or self.expt.repeat_run:
+        if ((self.expt.counter == 0 or self.expt.repeat_run) and
+                self.prior_restart_path is None):
             input_type = 'n'
         else:
             input_type = 'r'


### PR DESCRIPTION
Using the mechanism to point to an external restart directory:

```yaml
restart: /path/to/restart
```

doesn't modify the experiment counter, because as far as payu is concerned, this is the first run. This breaks the logic the MOM6 module was using to determine whether to flag a run as a restart or not. In the case that the prior restart path has been set, we want to explicitly perform a restart run.

Thanks to @julia-neme for (unfortunately) finding this!