### PR TITLE
Default to add '-wdir' arguments 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ MANIFEST
 /docs/_build
 .coverage
 .ipynb_checkpoints
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ MANIFEST
 .coverage
 .ipynb_checkpoints
 .vscode
+/test/tmp/

--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -104,7 +104,8 @@ def lib_update(bin_path, lib_name):
     slibs = ldd_output.split('\n')
 
     for lib_entry in slibs:
-        if lib_name in lib_entry:
+        if lib_name in lib_entry and 'spack' not in lib_entry:
+            # Only load enviroment modules available - assuming spack built libs includes 'spack' in full path of library
             lib_path = lib_entry.split()[2]
 
             # pylint: disable=unbalanced-tuple-unpacking
@@ -112,7 +113,3 @@ def lib_update(bin_path, lib_name):
 
             module('unload', mod_name)
             module('load', os.path.join(mod_name, mod_version))
-            return '{0}/{1}'.format(mod_name, mod_version)
-
-    # If there are no libraries, return an empty string
-    return ''

--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -92,24 +92,21 @@ def module(command, *args):
     exec(envs)
 
 
-def lib_update(bin_path, lib_name):
+def lib_update(required_libs, lib_name):
     # Local import to avoid reversion interference
     # TODO: Bad design, fixme!
     # NOTE: We may be able to move this now that reversion is going away
     from payu import fsops
 
-    # TODO: Use objdump instead of ldd
-    cmd = 'ldd {0}'.format(bin_path)
-    ldd_output = subprocess.check_output(shlex.split(cmd)).decode('ascii')
-    slibs = ldd_output.split('\n')
-
-    for lib_entry in slibs:
-        if lib_name in lib_entry and 'spack' not in lib_entry:
-            # Only load enviroment modules available - assuming spack built libs includes 'spack' in full path of library
-            lib_path = lib_entry.split()[2]
-
+    for lib_filename, lib_path in required_libs.items():
+        if lib_filename.startswith(lib_name) and lib_path.startswith('/apps/'): 
+            # Load nci's /apps/ version of module if required 
             # pylint: disable=unbalanced-tuple-unpacking
             mod_name, mod_version = fsops.splitpath(lib_path)[2:4]
 
             module('unload', mod_name)
             module('load', os.path.join(mod_name, mod_version))
+            return '{0}/{1}'.format(mod_name, mod_version)
+
+    # If there are no libraries, return an empty string
+    return ''

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -527,7 +527,7 @@ class Experiment(object):
 
             wdir_arg = '-wdir'
             if self.config.get('scheduler') == 'slurm':
-                # Slurm's launcher controls the working directory
+                # Option to set the working directory differs in slurm
                 wdir_arg = '--chdir'
             model_prog.append(f'{wdir_arg} {model.work_path}')
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -25,7 +25,7 @@ import yaml
 
 # Local
 from payu import envmod
-from payu.fsops import mkdir_p, make_symlink, read_config, movetree
+from payu.fsops import mkdir_p, make_symlink, read_config, movetree, required_libs
 from payu.schedulers.pbs import get_job_info, pbs_env_init, get_job_id
 from payu.models import index as model_index
 import payu.profilers
@@ -137,6 +137,10 @@ class Experiment(object):
         self.models = []
 
         submodels = self.config.get('submodels', [])
+
+        # Inject information about required dynamically loaded libraries into submodel configuration
+        for sm in submodels:
+            sm['required_libs'] = required_libs(sm['exe'])
 
         solo_model = self.config.get('model')
         if not solo_model:
@@ -515,7 +519,7 @@ class Experiment(object):
             # TODO: Check for MPI library mismatch across multiple binaries
             if mpi_module is None:
                 envmod.lib_update(
-                    model.exec_path_local,
+                    model.config.get('required_libs'),
                     'libmpi.so'
                 )
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -521,12 +521,17 @@ class Experiment(object):
 
             model_prog = []
 
-            if mpi_module.startswith('openmpi'):
-                # Our MPICH wrapper does not support a working directory flag
-                model_prog.append('-wdir {0}'.format(model.work_path))
-            elif self.config.get('scheduler') == 'slurm':
-                # Slurm's launcher controls the working directory
-                model_prog.append('--chdir {0}'.format(model.work_path))
+            # Our MVAPICH wrapper does not support working directories
+            if mpi_module is not None and mpi_module.startswith('mvapich'):
+                curdir = os.getcwd()
+                os.chdir(self.work_path)
+            else:
+                curdir = None
+                wdir_arg = '-wdir'
+                if self.config.get('scheduler') == 'slurm':
+                    # Slurm's launcher controls the working directory
+                    wdir_arg = '--chdir'
+                model_prog.append(f'{wdir_arg} {model.work_path}')
 
             # Append any model-specific MPI flags
             model_flags = model.config.get('mpiflags', [])

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -19,6 +19,7 @@ import fnmatch
 
 from payu.models.model import Model
 from payu import envmod
+from payu.fsops import required_libs
 
 # There is a limit on the number of command line arguments in a forked
 # MPI process. This applies only to mppnccombine-fast. The limit is higher
@@ -109,7 +110,7 @@ def fms_collate(model):
         # and mppnccombine-fast uses an explicit -o flag to specify
         # the output
         collate_flags = " ".join([collate_flags, '-o'])
-        envmod.lib_update(mppnc_path, 'libmpi.so')
+        envmod.lib_update(required_libs(mppnc_path), 'libmpi.so')
 
     # Import list of collated files to ignore
     collate_ignore = collate_config.get('ignore')

--- a/test/resources/sample_ldd_output.txt
+++ b/test/resources/sample_ldd_output.txt
@@ -1,0 +1,5 @@
+	linux-vdso.so.1 (0x00007ffd60799000)
+    libmpi_usempif08_Intel.so.40 => /apps/openmpi/4.0.2/lib/libmpi_usempif08_Intel.so.40 (0x00007fa492a7c000)
+    libmpi_usempi_ignore_tkr_Intel.so.40 => /apps/openmpi/4.0.2/lib/libmpi_usempi_ignore_tkr_Intel.so.40 (0x00007fa492863000)
+    libmpi.so.40 => /apps/openmpi/4.0.2/lib/libmpi.so.40 (0x00007fa493665000)
+    libmpi_mpifh_Intel.so.40 => /apps/openmpi/4.0.2/lib/libmpi_mpifh_Intel.so.40 (0x00007fa4925cb000)

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -10,6 +10,7 @@ import sys
 import payu
 import payu.fsops
 import payu.laboratory
+import payu.envmod
 
 from .common import testdir, tmpdir, ctrldir, labdir, workdir
 from .common import make_exe, make_inputs, make_restarts, make_all_files
@@ -214,3 +215,30 @@ def test_lab_new():
     sys.stdout = StringIO()
     lab = payu.laboratory.Laboratory('model')
     sys.stdout = sys.__stdout__
+
+
+def test_parse_ldd_output():
+    ldd_output_path = os.path.join('test', 'resources', 'sample_ldd_output.txt')
+    with open(ldd_output_path, 'r') as f:
+        ldd_output = f.read()
+    required_libs = payu.fsops.parse_ldd_output(ldd_output)
+    assert(len(required_libs), 4) 
+    assert(required_libs['libmpi.so.40'], '/apps/openmpi/4.0.2/lib/libmpi.so.40')
+
+
+def test_lib_update_lib_if_required():
+    required_libs_dict = {
+        'libmpi.so.40': '/apps/openmpi/4.0.2/lib/libmpi.so.40',
+        'libmpi_usempif08_Intel.so.40': '/apps/openmpi/4.0.2/lib/libmpi_usempif08_Intel.so.40'
+    }
+    result = payu.envmod.lib_update(required_libs_dict, 'libmpi.so')
+    assert(result == 'openmpi/4.0.2')
+
+
+def test_lib_update_if_nci_module_not_required():
+    required_libs_dict = {
+         'libmpi.so.40': '/$HOME/spack-microarchitectures.git/opt/spack/linux-rocky8-cascadelake/intel-2019.5.281/openmpi-4.1.5-ooyg5wc7sa3tvmcpazqqb44pzip3wbyo/lib/libmpi.so.40', 
+         'libmpi_usempif08.so.40': '/$HOME/exe/spack-microarchitectures.git/opt/spack/linux-rocky8-cascadelake/intel-2019.5.281/openmpi-4.1.5-ooyg5wc7sa3tvmcpazqqb44pzip3wbyo/lib/libmpi_usempif08.so.40',
+    }
+    result = payu.envmod.lib_update(required_libs_dict, 'libmpi.so')
+    assert(result == '')


### PR DESCRIPTION
Change logic in experiments  to default to adding `-wdir` to the arguments given to mpirun. 
Should close #341 and close #350 