### PR TITLE
Add pypi build and publish to CD

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -37,9 +37,9 @@ jobs:
     if: github.repository == 'payu-org/payu' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.11
 

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -31,3 +31,37 @@ jobs:
           user: accessnri
           label: main
           token: ${{ secrets.anaconda_token }}
+
+  pypi-build:
+    name: Build package for PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.11
+
+      - run: |
+          python3 -m pip install --upgrade build && python3 -m build
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./dist
+
+  pypi-publish:
+    # Split build and publish to restrict trusted publishing to just this workflow
+    needs: ['pypi-build']
+    name: Publish to PyPI.org
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+
+      - name: Publish package distributions to PyPI
+        # This is version v1.8.10
+        uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e
+        with:
+          packages_dir: artifact/

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -61,6 +61,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/download-artifact@v3
+        with:
+          path: artifact/
 
       - name: Publish package distributions to PyPI
         # This is version v1.8.10

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -11,7 +11,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup conda environment
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -34,6 +34,7 @@ jobs:
 
   pypi-build:
     name: Build package for PyPI
+    if: github.repository == 'payu-org/payu' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -53,6 +54,7 @@ jobs:
     # Split build and publish to restrict trusted publishing to just this workflow
     needs: ['pypi-build']
     name: Publish to PyPI.org
+    if: github.repository == 'payu-org/payu' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing


### PR DESCRIPTION
Add automated PyPI publishing to CD Workflow.

Closes #361 