### PR TITLE
Symlink instead of copy the `mod_def.ww3` input in the cesm_cmeps driver

### DIFF
--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -168,7 +168,8 @@ class CesmCmeps(Model):
 
         self.runconfig.write()
 
-        # Horrible hack to make a link to the mod_def.ww3 input in the work directory
+        # Horrible hack to make a link to the mod_def.ww3 input in the work
+        # directory
         # The ww3 mod_def input needs to be in work_path and called mod_def.ww3
         if "ww3dev" in self.components.values():
             f_name = "mod_def.ww3"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -17,7 +17,7 @@ import glob
 import shutil
 import multiprocessing
 
-from payu.fsops import mkdir_p
+from payu.fsops import mkdir_p, make_symlink
 from payu.models.model import Model
 from payu.models.fms import fms_collate
 

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -168,17 +168,15 @@ class CesmCmeps(Model):
 
         self.runconfig.write()
 
-        # TODO: Should have a better way to do this
+        # Horrible hack to make a link to the mod_def.ww3 input in the work directory
         # The ww3 mod_def input needs to be in work_path and called mod_def.ww3
         if "ww3dev" in self.components.values():
-            files =  glob.glob(
-                os.path.join(self.work_input_path, "*mod_def.ww3*"),
-                recursive=False
-            )
-            if files:
-                assert len(files) == 1, "Multiple mod_def.ww3 files found in input directory"
-                f_dst = os.path.join(self.work_path, "mod_def.ww3")
-                shutil.copy(files[0], f_dst)
+            f_name = "mod_def.ww3"
+            f_src = os.path.join(self.work_input_path, f_name)
+            f_dst = os.path.join(self.work_path, f_name)
+
+            if os.path.isfile(f_src):
+                make_symlink(f_src, f_dst)
             else:
                 # TODO: copied this from other models. Surely we want to exit here or something
                 print('payu: error: Unable to find mod_def.ww3 file in input directory')


### PR DESCRIPTION
The WW3 model definition file input needs to be in the work directory and called `mod_def.ww3`. Previously this driver looked for a file in the inputs with "mod_def.ww3" in the filename and then copied that file to the work directory. This is bad practice. Now, the name of the file is assumed to be "mod_def.ww3" and this file is symlinked instead. Those setting up the configuration will need to ensure that a file with the right name is included in the inputs (e.g. using a symlink if the original input has a different name).

Closes #365 