### PR TITLE
Fix bug copying mom6 config files introduced in #373

### DIFF
--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -10,7 +10,6 @@
 
 # Standard library
 import os
-import shutil
 
 # Extensions
 import f90nml
@@ -67,11 +66,13 @@ class Mom6(Fms):
         # FMS initialisation
         super(Mom6, self).setup()
 
-        self.init_config()
-
-        # Add parameter files to config files and copy files over to work path
+        # Add parameter files to config files
         mom6_add_parameter_files(self)
+
+        # Copy configuration files over to work path
         self.setup_configuration_files()
+
+        self.init_config()
 
     def init_config(self):
         """Patch input.nml as a new or restart run."""


### PR DESCRIPTION
Closes #380.

Small fix in mom6 driver. Ensuring config files are copied to work path before any patches to `input.nml` are written.

Added another test 