### PR TITLE
add cftime dependency to conda meta.yaml

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,6 +29,7 @@ requirements:
         - python-dateutil
         - tenacity
         - requests
+        - cftime
         # The following two requirements are from the security
         # extra for the pypi package
         - pyOpenSSL >=0.14

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -151,8 +151,8 @@ def test_setup():
         expt = payu.experiment.Experiment(lab, reproduce=False)
         model = expt.models[0]
 
-    # Function to test
-    model.setup()
+        # Function to test
+        model.setup()
 
     # Check config files are moved to model's work path
     work_path_files = os.listdir(model.work_path)


### PR DESCRIPTION
Small change here adding cftime run dependency to `conda/meta.yaml`. This in used in date based restart pruning.

There's also a fix for a small bug in testing which creates a `work` directory in payu. Moved setup call so it runs inside the temporary test control directory. 