### PR TITLE
Update cesm_cmeps.py

### DIFF
--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -39,7 +39,10 @@ component_info = {
     },
     "ww3dev": {
         "config_files": ["wav_in"],
-        "optional_config_files" : ["ww3_shel.nml"]
+        "optional_config_files" : [
+            "ww3_shel.nml",
+            "ww3_points.list",
+        ],
     },
     "datm": {
         "config_files": [


### PR DESCRIPTION
Closes #386 


To generate the point output of WWIII, ww3_points.list file is required in the work directory which contains the wave buoy station locations as point list. This can be added [here](https://github.dev/payu-org/payu/blob/9523ae3e73ab65b681e27a38c2a77e95d4f8e843/payu/models/cesm_cmeps.py#L42-L43) as an optional config file.