### PR TITLE
Docs update

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,7 +12,7 @@ of this document.
 NCI Users
 =========
 
-Payu is available for all users on Raijin.
+Payu is available for all users on Gadi.
 
 To load payu, load the environment module::
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -13,10 +13,10 @@ NCI Users
 =========
 
 Payu is available for all users on Gadi.
-
-To load payu, load the environment module::
-
-   module load payu
+But it needs to access the 'hh5' data in NCI at first, we could use that conda module to work payu functions.
+load the environment module::
+   cd /g/data/hh5/public/modules/
+   module load conda
 
 Local installation
 ------------------


### PR DESCRIPTION
Issue #332
The Payu module could not be located using the Gadi directly, while we could use the 'conda' module from 'hh5' data storage to have the payu functions work.