### PR TITLE
Fix PyPI upload

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -23,9 +23,10 @@ jobs:
       - run: |
           python3 -m pip install --upgrade build && python3 -m build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          path: ./dist
+          name: release
+          path: dist
 
   pypi-publish:
     # Split build and publish to restrict trusted publishing to just this workflow
@@ -36,9 +37,10 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          path: artifact/
+          name: release
+          path: dist
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -44,8 +44,6 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11
-        with:
-          packages-dir: artifact/
 
   conda:
     name: Build with conda and upload


### PR DESCRIPTION
The PyPI upload stopped working after #403 was merged. I can't say I understand why as #403 didn't touch the workflow steps that are causing the problem... Regardless, this PR should fix things.

The update to `actions/upload-artifact@v4` (from `v3`) is not necessary to fix the issue, but good to do anyway.

Closes #398 (again)