### PR TITLE
Update tag_prefix in _version.py

### DIFF
--- a/payu/_version.py
+++ b/payu/_version.py
@@ -51,7 +51,7 @@ def get_config() -> VersioneerConfig:
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = "v"
+    cfg.tag_prefix = ""
     cfg.parentdir_prefix = "payu-"
     cfg.versionfile_source = "payu/_version.py"
     cfg.verbose = False


### PR DESCRIPTION
Removes the "v" `tag_prefix` from `_version.py` (by reinstalling `versioneer`: `versioneer install --no-vendor`). This was preventing the version from being determined correctly in readthedocs builds.

Closes #398 (again again)