### PR TITLE
Prevent UM restart files being archived to output

### DIFF
--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -101,6 +101,11 @@ class UnifiedModel(Model):
                   '{} does not exist.\n'
                   'Check DUMPFREQim in namelists'.format(restart_dump))
 
+        # Now remove restart files from work directory so they're not
+        # unnecessarily archived to output
+        for f_path in glob.glob(os.path.join(self.work_path, 'aiihca.da*')):
+            os.remove(f_path)
+
     def collate(self):
         pass
 


### PR DESCRIPTION
Fix is to remove the restart files from the work directory after the last one is copied.

Previously in `archive/pre-industrial/output000/atmosphere` there were 12 monthly restart files `aiihca.daa*`
```
% ls ai*
aiihca.daa1210  aiihca.daa1c10  aiihca.paa1may  aiihca.pea1jun  aiihca.pga1jan
aiihca.daa1310  aiihca.daa2110  aiihca.paa1nov  aiihca.pea1mar  aiihca.pga1jul
aiihca.daa1410  aiihca.paa1apr  aiihca.paa1oct  aiihca.pea1may  aiihca.pga1jun
aiihca.daa1510  aiihca.paa1aug  aiihca.paa1sep  aiihca.pea1nov  aiihca.pga1mar
aiihca.daa1610  aiihca.paa1dec  aiihca.pea1apr  aiihca.pea1oct  aiihca.pga1may
aiihca.daa1710  aiihca.paa1feb  aiihca.pea1aug  aiihca.pea1sep  aiihca.pga1nov
aiihca.daa1810  aiihca.paa1jan  aiihca.pea1dec  aiihca.pga1apr  aiihca.pga1oct
aiihca.daa1910  aiihca.paa1jul  aiihca.pea1feb  aiihca.pga1aug  aiihca.pga1sep
aiihca.daa1a10  aiihca.paa1jun  aiihca.pea1jan  aiihca.pga1dec
aiihca.daa1b10  aiihca.paa1mar  aiihca.pea1jul  aiihca.pga1feb
```

Now
```
aiihca.paa1apr  aiihca.paa1may  aiihca.pea1jan  aiihca.pga1apr  aiihca.pga1may
aiihca.paa1aug  aiihca.paa1nov  aiihca.pea1jul  aiihca.pga1aug  aiihca.pga1nov
aiihca.paa1dec  aiihca.paa1oct  aiihca.pea1jun  aiihca.pga1dec  aiihca.pga1oct
aiihca.paa1feb  aiihca.paa1sep  aiihca.pea1mar  aiihca.pga1feb  aiihca.pga1sep
aiihca.paa1jan  aiihca.pea1apr  aiihca.pea1may  aiihca.pga1jan
aiihca.paa1jul  aiihca.pea1aug  aiihca.pea1nov  aiihca.pga1jul
aiihca.paa1jun  aiihca.pea1dec  aiihca.pea1oct  aiihca.pga1jun
aiihca.paa1mar  aiihca.pea1feb  aiihca.pea1sep  aiihca.pga1mar
```
