### PR TITLE
Add check for UUIDs when checking for existence of archives

### DIFF
--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -155,7 +155,7 @@ class Metadata:
                   self.experiment_name)
             return
 
-        # Legacy experiment name and archive path
+        # Legacy experiment name
         legacy_name = self.control_path.name
 
         if not self.enabled:
@@ -167,7 +167,6 @@ class Metadata:
             return
 
         branch_uuid_experiment_name = self.new_experiment_name()
-
         if is_new_experiment or self.has_archive(branch_uuid_experiment_name):
             # Use branch-UUID aware experiment name
             self.experiment_name = branch_uuid_experiment_name
@@ -191,13 +190,13 @@ class Metadata:
         archive_path = self.lab_archive_path / experiment_name
 
         if archive_path.exists():
-            # If a new UUID has not been generated, check if the
-            # UUID in the archive metadata matches UUID in metadata
+            # Check if the UUID in the archive metadata matches the
+            # UUID in metadata
             archive_metadata_path = archive_path / METADATA_FILENAME
-            if not self.uuid_updated and archive_metadata_path.exists():
+            if archive_metadata_path.exists():
                 archive_metadata = YAML().load(archive_metadata_path)
-                if (UUID_FIELD not in archive_metadata
-                        or archive_metadata[UUID_FIELD] != self.uuid):
+                if (UUID_FIELD in archive_metadata and
+                        archive_metadata[UUID_FIELD] != self.uuid):
                     print("Mismatch of UUIDs between metadata and an archive "
                           f"metadata found at: {archive_metadata_path}")
                     return False

--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -157,7 +157,6 @@ class Metadata:
 
         # Legacy experiment name and archive path
         legacy_name = self.control_path.name
-        legacy_archive_path = self.lab_archive_path / legacy_name
 
         if not self.enabled:
             # Metadata/UUID generation is disabled, so leave UUID out of
@@ -167,18 +166,14 @@ class Metadata:
                   f"Experiment name used for archival: {self.experiment_name}")
             return
 
-        # Branch-UUID experiment name and archive path
         branch_uuid_experiment_name = self.new_experiment_name()
-        archive_path = self.lab_archive_path / branch_uuid_experiment_name
 
-        if is_new_experiment or archive_path.exists():
+        if is_new_experiment or self.has_archive(branch_uuid_experiment_name):
             # Use branch-UUID aware experiment name
             self.experiment_name = branch_uuid_experiment_name
-        elif legacy_archive_path.exists():
+        elif self.has_archive(legacy_name):
             # Use legacy CONTROL-DIR experiment name
             self.experiment_name = legacy_name
-            print(f"Pre-existing archive found at: {legacy_archive_path}. "
-                  f"Experiment name will remain: {legacy_name}")
         elif keep_uuid:
             # Use same experiment UUID and use branch-UUID name for archive
             self.experiment_name = branch_uuid_experiment_name
@@ -189,6 +184,25 @@ class Metadata:
                 MetadataWarning
             )
             self.set_new_uuid(is_new_experiment=True)
+
+    def has_archive(self, experiment_name: str) -> bool:
+        """Return True if archive under the experiment name exists and
+        if it exists, check for a non-matching UUID in archive metadata."""
+        archive_path = self.lab_archive_path / experiment_name
+
+        if archive_path.exists():
+            # If a new UUID has not been generated, check if the
+            # UUID in the archive metadata matches UUID in metadata
+            archive_metadata_path = archive_path / METADATA_FILENAME
+            if not self.uuid_updated and archive_metadata_path.exists():
+                archive_metadata = YAML().load(archive_metadata_path)
+                if (UUID_FIELD not in archive_metadata
+                        or archive_metadata[UUID_FIELD] != self.uuid):
+                    print("Mismatch of UUIDs between metadata and an archive "
+                          f"metadata found at: {archive_metadata_path}")
+                    return False
+            print(f"Found experiment archive: {archive_path}")
+        return archive_path.exists()
 
     def set_new_uuid(self, is_new_experiment: bool = False) -> None:
         """Generate a new uuid and set experiment name"""

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -261,6 +261,60 @@ def test_set_experiment_and_uuid(uuid_exists, keep_uuid, is_new_experiment,
     assert metadata.uuid == expected_uuid
 
 
+@pytest.mark.parametrize(
+    "new_uuid, archive_metadata_exists, archive_uuid, expected_result",
+    [
+        # A legacy archive exists, but there's no corresponding metadata
+        (
+            True, False, None, True
+        ),
+        # A legacy archive exists, there's a metadata with a UUID in
+        # control directory, but no metadata in archive
+        (
+            False, False, None, True
+        ),
+        # Archive metadata exists but has no UUID
+        (
+            False, True, None, False
+        ),
+        # Archive metadata exists with same UUID
+        (
+            False, True, "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", True
+        ),
+        # Archive metadata exists with different UUID
+        (
+            False, True, "cb793e91-6168-4ed2-a70c-f6f9ccf1659b", False
+        ),
+    ]
+)
+def test_has_archive(new_uuid, archive_metadata_exists, archive_uuid,
+                     expected_result):
+    # Setup config and metadata
+    write_config(config)
+    with cd(ctrldir):
+        metadata = Metadata(archive_dir)
+    metadata.uuid = "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136"
+
+    if new_uuid:
+        metadata.uuid_updated = True
+
+    # Setup archive and it's metadata file
+    archive_path = archive_dir / "ctrl"
+    archive_path.mkdir(parents=True)
+
+    if archive_metadata_exists:
+        archive_metadata = {}
+
+        if archive_uuid is not None:
+            archive_metadata["experiment_uuid"] = archive_uuid
+
+        with open(archive_path / 'metadata.yaml', 'w') as file:
+            YAML().dump(archive_metadata, file)
+
+    result = metadata.has_archive("ctrl")
+    assert result == expected_result
+
+
 def test_set_configured_experiment_name():
     # Set experiment in config file
     test_config = copy.deepcopy(config)
@@ -287,6 +341,7 @@ def test_set_configured_experiment_name():
 )
 def test_new_experiment_name(branch, expected_name):
     # Test configured experiment name is the set experiment name
+    write_config(config)
     with cd(ctrldir):
         metadata = Metadata(archive_dir)
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -262,41 +262,33 @@ def test_set_experiment_and_uuid(uuid_exists, keep_uuid, is_new_experiment,
 
 
 @pytest.mark.parametrize(
-    "new_uuid, archive_metadata_exists, archive_uuid, expected_result",
+    "archive_metadata_exists, archive_uuid, expected_result",
     [
         # A legacy archive exists, but there's no corresponding metadata
+        # in archive
         (
-            True, False, None, True
-        ),
-        # A legacy archive exists, there's a metadata with a UUID in
-        # control directory, but no metadata in archive
-        (
-            False, False, None, True
+            False, None, True
         ),
         # Archive metadata exists but has no UUID
         (
-            False, True, None, False
+            True, None, True
         ),
         # Archive metadata exists with same UUID
         (
-            False, True, "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", True
+            True, "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", True
         ),
         # Archive metadata exists with different UUID
         (
-            False, True, "cb793e91-6168-4ed2-a70c-f6f9ccf1659b", False
+            True, "cb793e91-6168-4ed2-a70c-f6f9ccf1659b", False
         ),
     ]
 )
-def test_has_archive(new_uuid, archive_metadata_exists, archive_uuid,
-                     expected_result):
+def test_has_archive(archive_metadata_exists, archive_uuid, expected_result):
     # Setup config and metadata
     write_config(config)
     with cd(ctrldir):
         metadata = Metadata(archive_dir)
     metadata.uuid = "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136"
-
-    if new_uuid:
-        metadata.uuid_updated = True
 
     # Setup archive and it's metadata file
     archive_path = archive_dir / "ctrl"


### PR DESCRIPTION
In #420, there’s a bug with using branching logic, where an existing experiment is not detected if its archive does not exist. So if an experiment was created then deleted on a branch in a control directory that has a corresponding legacy archive,  subsequent `payu setup/run` calls, it’ll use the legacy archive. 

This PR so far adds an additional check when checking for the existence of archives, also check for metadata with a matching UUID. 

This isn’t a perfect check as it requires `payu setup/payu run/ payu checkout` to be run on the legacy experiment which will then subsequently create a UUID and metadata in the legacy archive if it doesn’t already exist. Otherwise, if there is no metadata associated with the legacy archive and a new UUID has not been generated, it’s difficult to know whether to use a legacy archive or not.

Closes #420

TODO:
    - Write up a short explainer for "recommendations for use with legacy experiments"