### PR TITLE
Allow generic tracers with `cesm_cmeps` driver

### DIFF
--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -121,7 +121,7 @@ class CesmCmeps(Model):
         # for additional restarts (e.g. generic tracer flux restarts)
         self.get_runconfig(self.control_path)
         additional_restart_dir = self.runconfig.get(
-            "ALLCOMP_attributes", "additional_restart_dir", "RESTART/"
+            "ALLCOMP_attributes", "additional_restart_dir", "RESTART"
         )
         self.work_restart_path = os.path.join(self.work_path, additional_restart_dir)
 

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -292,9 +292,11 @@ class Runconfig:
         if m is not None:
             section_start = m.start(1)
             section_end = m.end(1)
-            # Find the variable assignment in the section
+            # This matches everything between the equals sign in
+            # a variable assignment and a # or newline character,
+            # excluding whitespace
             m = re.search(
-                r"{}\s*=\s*(.*)".format(variable),
+                r"{}\s*=\s*(\S+)\s*(?=(#|\n))".format(variable),
                 self.contents[section_start:section_end],
             )
             if m is not None:

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -282,6 +282,8 @@ class Runconfig:
             self.contents = f.read()
 
     def _get_variable_span(self, section, variable):
+        # This matches everything between a section table heading
+        # '{section}::' and a following '::'
         m = re.search(
             r"(?<={}\:\:)(.*?)(?=\:\:)".format(section),
             self.contents,
@@ -290,6 +292,7 @@ class Runconfig:
         if m is not None:
             section_start = m.start(1)
             section_end = m.end(1)
+            # Find the variable assignment in the section
             m = re.search(
                 r"{}\s*=\s*(.*)".format(variable),
                 self.contents[section_start:section_end],

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -115,7 +115,7 @@ class CesmCmeps(Model):
 
         super().set_model_pathnames()
 
-        self.work_input_path = os.path.join(self.work_path, 'input')
+        self.work_input_path = os.path.join(self.work_path, 'INPUT')
         
         # MOM restarts are dealt with via pointer files (see below). Use work_restart_path
         # for additional restarts (e.g. generic tracer flux restarts)

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -1,0 +1,72 @@
+import os
+import pytest
+
+from payu.models.cesm_cmeps import Runconfig
+
+@pytest.mark.parametrize(
+    "section, variable, expected",
+    [
+        ("ALLCOMP_attributes", "OCN_model", "mom"),
+        ("CLOCK_attributes", "restart_n", "1"),
+        ("DOES_NOT_EXIST", "OCN_model", None),
+        ("ALLCOMP_attributes", "DOES_NOT_EXIST", None),
+    ]
+)
+def test_runconfig_get(section, variable, expected):
+    """Test getting values from a nuopc.runconfig file"""
+    runconfig_path = os.path.join('test', 'resources', 'nuopc.runconfig')
+    runconfig = Runconfig(runconfig_path)
+
+    assert runconfig.get(section, variable) == expected
+
+def test_runconfig_get_default():
+    """Test getting default values from a nuopc.runconfig file"""
+    runconfig_path = os.path.join('test', 'resources', 'nuopc.runconfig')
+    runconfig = Runconfig(runconfig_path)
+
+    assert runconfig.get("DOES_NOT_EXIST", "DOES_NOT_EXIST", value="default") == "default"
+
+@pytest.mark.parametrize(
+    "section, variable, new_variable",
+    [
+        ("ALLCOMP_attributes", "OCN_model", "pop"),
+        ("CLOCK_attributes", "restart_n", "2"),
+    ]
+)
+def test_runconfig_set(section, variable, new_variable):
+    """Test setting values in a nuopc.runconfig file"""
+    runconfig_path = os.path.join('test', 'resources', 'nuopc.runconfig')
+    runconfig = Runconfig(runconfig_path)
+
+    runconfig.set(section, variable, new_variable)
+
+    assert runconfig.get(section, variable) == new_variable
+
+def test_runconfig_set_error():
+    """Test error setting values in a nuopc.runconfig file that don't exist"""
+    runconfig_path = os.path.join('test', 'resources', 'nuopc.runconfig')
+    runconfig = Runconfig(runconfig_path)
+
+    with pytest.raises(
+        NotImplementedError,
+        match='Cannot set value of variable that does not already exist'
+        ):
+        runconfig.set("DOES_NOT_EXIST", "OCN_model", "value")
+        runconfig.set("ALLCOMP_attributes", "DOES_NOT_EXIST", "value")
+
+def test_runconfig_set_write_get():
+    """Test updating the values in a nuopc.runconfig file"""
+    runconfig_path = os.path.join('test', 'resources', 'nuopc.runconfig')
+    runconfig = Runconfig(runconfig_path)
+
+    assert runconfig.get("CLOCK_attributes", "restart_n") == "1"
+
+    runconfig.set("CLOCK_attributes", "restart_n", "2")
+
+    runconfig_path_tmp = "nuopc.runconfig.tmp"
+    runconfig.write(runconfig_tmp)
+
+    runconfig_updated = Runconfig(runconfig_tmp)
+    assert runconfig.get("CLOCK_attributes", "restart_n") == "2"
+
+    os.remove(runconfig_path_tmp)

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -10,6 +10,11 @@ from payu.models.cesm_cmeps import Runconfig
         ("CLOCK_attributes", "restart_n", "1"),
         ("DOES_NOT_EXIST", "OCN_model", None),
         ("ALLCOMP_attributes", "DOES_NOT_EXIST", None),
+        ("allcomp_attributes", "OCN_model", None),                  # verify case sensitivity in section
+        ("ALLCOMP_attributes", "ocn_model", None),                # verify case sensitivity in variable
+        ("ATM_attributes", "perpetual", ".false."),                        # correctly read booleans
+        ("ICE_attributes", "eps_imeshT", "1e-13"),                     # correctly read commented value
+        ("MED_attributes", "histaux_atm2med_file1_flds", "Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf"), # correctly read long colon separated value
     ]
 )
 def test_runconfig_get(section, variable, expected):

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -10,10 +10,10 @@ from payu.models.cesm_cmeps import Runconfig
         ("CLOCK_attributes", "restart_n", "1"),
         ("DOES_NOT_EXIST", "OCN_model", None),
         ("ALLCOMP_attributes", "DOES_NOT_EXIST", None),
-        ("allcomp_attributes", "OCN_model", None),                  # verify case sensitivity in section
-        ("ALLCOMP_attributes", "ocn_model", None),                # verify case sensitivity in variable
-        ("ATM_attributes", "perpetual", ".false."),                        # correctly read booleans
-        ("ICE_attributes", "eps_imeshT", "1e-13"),                     # correctly read commented value
+        ("allcomp_attributes", "OCN_model", None), # verify case sensitivity in section
+        ("ALLCOMP_attributes", "ocn_model", None), # verify case sensitivity in variable
+        ("ATM_attributes", "perpetual", ".false."), # correctly read booleans
+        ("ICE_attributes", "eps_imesh", "1e-13"), # correctly read commented value
         ("MED_attributes", "histaux_atm2med_file1_flds", "Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf"), # correctly read long colon separated value
     ]
 )

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -64,9 +64,9 @@ def test_runconfig_set_write_get():
     runconfig.set("CLOCK_attributes", "restart_n", "2")
 
     runconfig_path_tmp = "nuopc.runconfig.tmp"
-    runconfig.write(runconfig_tmp)
+    runconfig.write(runconfig_path_tmp)
 
-    runconfig_updated = Runconfig(runconfig_tmp)
+    runconfig_updated = Runconfig(runconfig_path_tmp)
     assert runconfig.get("CLOCK_attributes", "restart_n") == "2"
 
     os.remove(runconfig_path_tmp)

--- a/test/resources/nuopc.runconfig
+++ b/test/resources/nuopc.runconfig
@@ -1,0 +1,453 @@
+DRIVER_attributes::
+     Verbosity = off
+     cime_model = cesm
+     drv_restart_pointer = rpointer.cpl
+     logFilePostFix = .log
+     outPathRoot = ./
+     pio_blocksize = -1
+     pio_buffer_size_limit = -1
+     pio_debug_level = 0
+     pio_rearr_comm_enable_hs_comp2io = .true.
+     pio_rearr_comm_enable_hs_io2comp = .false.
+     pio_rearr_comm_enable_isend_comp2io = .false.
+     pio_rearr_comm_enable_isend_io2comp = .true.
+     pio_rearr_comm_fcd = 2denable
+     pio_rearr_comm_max_pend_req_comp2io = -2
+     pio_rearr_comm_max_pend_req_io2comp = 64
+     pio_rearr_comm_type = p2p
+     reprosum_diffmax = -1.0e-8
+     reprosum_recompute = .false.
+     reprosum_use_ddpdd = .false.
+     tchkpt_dir = ./timing/checkpoints
+     timing_dir = ./timing
+     wv_sat_scheme = GoffGratch
+     wv_sat_table_spacing = 1.0D0
+     wv_sat_transition_start = 20.0D0
+     wv_sat_use_tables = .false.
+::
+
+PELAYOUT_attributes::
+     atm_ntasks = 48
+     atm_nthreads = 1
+     atm_pestride = 1
+     atm_rootpe = 0
+     cpl_ntasks = 48
+     cpl_nthreads = 1
+     cpl_pestride = 1
+     cpl_rootpe = 0
+     esmf_logging = ESMF_LOGKIND_NONE
+     esp_ntasks = 1
+     esp_nthreads = 1
+     esp_pestride = 1
+     esp_rootpe = 0
+     glc_ntasks = 48
+     glc_nthreads = 1
+     glc_pestride = 1
+     glc_rootpe = 0
+     ice_ntasks = 48
+     ice_nthreads = 1
+     ice_pestride = 1
+     ice_rootpe = 0
+     lnd_ntasks = 48
+     lnd_nthreads = 1
+     lnd_pestride = 1
+     lnd_rootpe = 0
+     ninst = 1
+     ocn_ntasks = 48
+     ocn_nthreads = 1
+     ocn_pestride = 1
+     ocn_rootpe = 0
+     pio_asyncio_ntasks = 0
+     pio_asyncio_rootpe = 1
+     pio_asyncio_stride = 0
+     rof_ntasks = 48
+     rof_nthreads = 1
+     rof_pestride = 1
+     rof_rootpe = 0
+     wav_ntasks = 48
+     wav_nthreads = 1
+     wav_pestride = 1
+     wav_rootpe = 0
+::
+
+component_list: MED ATM ICE OCN ROF
+ALLCOMP_attributes::
+     ATM_model = datm
+     GLC_model = sglc
+     ICE_model = cice
+     LND_model = slnd
+     MED_model = cesm
+     OCN_model = mom
+     Profiling = 0
+     ROF_model = drof
+     ScalarFieldCount = 4
+     ScalarFieldIdxGridNX = 1
+     ScalarFieldIdxGridNY = 2
+     ScalarFieldIdxNextSwCday = 3
+     ScalarFieldIdxPrecipFactor = 0
+     ScalarFieldName = cpl_scalars
+     WAV_model = swav
+     brnch_retain_casename = .false.
+     case_desc = UNSET
+     case_name = access-om3
+     cism_evolve = .false.
+     coldair_outbreak_mod = .false.
+     data_assimilation_atm = .false.
+     data_assimilation_cpl = .false.
+     data_assimilation_glc = .false.
+     data_assimilation_ice = .false.
+     data_assimilation_lnd = .false.
+     data_assimilation_ocn = .false.
+     data_assimilation_rof = .false.
+     data_assimilation_wav = .false.
+     flds_bgc_oi = .false.
+     flds_co2a = .false.
+     flds_co2b = .false.
+     flds_co2c = .false.
+     flds_i2o_per_cat = .false.
+     flds_r2l_stream_channel_depths = .false.
+     flds_wiso = .false.
+     flux_convergence = 0.01
+     flux_max_iteration = 5
+     glc_nec = 10
+     histaux_l2x1yrg = .false.
+     history_n = -999
+     history_option = never
+     hostname = gadi
+     ice_ncat = 5
+     mediator_present = true
+     mesh_atm = ./INPUT/access-om2-1deg-nomask-ESMFmesh.nc
+     mesh_glc = UNSET
+     mesh_ice = ./INPUT/access-om2-1deg-ESMFmesh.nc
+     mesh_lnd = UNSET
+     mesh_mask = ./INPUT/access-om2-1deg-ESMFmesh.nc
+     mesh_ocn = ./INPUT/access-om2-1deg-ESMFmesh.nc
+     model_version = unknown
+     ocn2glc_coupling = .false.
+     ocn2glc_levels = 1:10:19:26:30:33:35
+     orb_eccen = 1.e36
+     orb_iyear = 2000
+     orb_iyear_align = 2000
+     orb_mode = fixed_year
+     orb_mvelp = 1.e36
+     orb_obliq = 1.e36
+     scol_lat = -999.99
+     scol_lon = -999.99
+     single_column_lnd_domainfile = UNSET
+     start_type = startup
+     tfreeze_option = linear_salt
+     wav_coupling_to_cice = .false.
+     write_restart_at_endofrun = .false.
+     additional_restart_dir = RESTART
+::
+
+MED_attributes::
+     Verbosity = off
+     aoflux_grid = ogrid
+     atm2ice_map = unset
+     atm2lnd_map = unset
+     atm2ocn_map = unset
+     atm2wav_map = unset
+     atm_nx = 360
+     atm_ny = 300
+     budget_ann = 1
+     budget_daily = 0
+     budget_inst = 0
+     budget_ltann = 1
+     budget_ltend = 0
+     budget_month = 1
+     budget_table_version = v1
+     check_for_nans = .true.
+     coupling_mode = cesm
+     do_budgets = .true.
+     flux_albav = .true.
+     glc2ice_rmapname = idmap
+     glc2ocn_ice_rmapname = idmap
+     glc2ocn_liq_rmapname = idmap
+     glc_renormalize_smb = on_if_glc_coupled_fluxes
+     gust_fac = 0.0D0
+     histaux_atm2med_file1_auxname = atm.1h.inst
+     histaux_atm2med_file1_doavg = .false.
+     histaux_atm2med_file1_enabled = .false.
+     histaux_atm2med_file1_flds = Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf
+     histaux_atm2med_file1_history_n = 1
+     histaux_atm2med_file1_history_option = nhours
+     histaux_atm2med_file1_ntperfile = 24
+     histaux_atm2med_file2_auxname = atm.1h.avrg
+     histaux_atm2med_file2_doavg = .true.
+     histaux_atm2med_file2_enabled = .false.
+     histaux_atm2med_file2_flds = Sa_u:Sa_v
+     histaux_atm2med_file2_history_n = 1
+     histaux_atm2med_file2_history_option = nhours
+     histaux_atm2med_file2_ntperfile = 24
+     histaux_atm2med_file3_auxname = atm.3hprec.avrg
+     histaux_atm2med_file3_doavg = .true.
+     histaux_atm2med_file3_enabled = .false.
+     histaux_atm2med_file3_flds = Faxa_rainc:Faxa_rainl:Faxa_snowc:Faxa_snowl
+     histaux_atm2med_file3_history_n = 3
+     histaux_atm2med_file3_history_option = nhours
+     histaux_atm2med_file3_ntperfile = 8
+     histaux_atm2med_file4_auxname = atm.3h.avrg
+     histaux_atm2med_file4_doavg = .true.
+     histaux_atm2med_file4_enabled = .false.
+     histaux_atm2med_file4_flds = Sa_z:Sa_topo:Sa_u:Sa_v:Sa_tbot:Sa_ptem:Sa_shum:Sa_dens:Sa_pbot:Sa_pslv:Faxa_lwdn:Faxa_rainc:Faxa_rainl:Faxa_snowc:Faxa_snowl:Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf:Sa_co2diag:Sa_co2prog
+     histaux_atm2med_file4_history_n = 3
+     histaux_atm2med_file4_history_option = nhours
+     histaux_atm2med_file4_ntperfile = 8
+     histaux_atm2med_file5_auxname = atm.24h.avrg
+     histaux_atm2med_file5_doavg = .true.
+     histaux_atm2med_file5_enabled = .false.
+     histaux_atm2med_file5_flds = Faxa_bcph:Faxa_ocph:Faxa_dstwet:Faxa_dstdry:Sa_co2prog:Sa_co2diag
+     histaux_atm2med_file5_history_n = 3
+     histaux_atm2med_file5_history_option = nhours
+     histaux_atm2med_file5_ntperfile = 2
+     histaux_lnd2med_file1_auxname = lnd.ncpl.inst
+     histaux_lnd2med_file1_doavg = .false.
+     histaux_lnd2med_file1_enabled = .false.
+     histaux_lnd2med_file1_flds = all
+     histaux_lnd2med_file1_history_n = 1
+     histaux_lnd2med_file1_history_option = nsteps
+     histaux_lnd2med_file1_ntperfile = 1
+     histaux_ocn2med_file1_auxname = ocn.24h.avg
+     histaux_ocn2med_file1_doavg = .true.
+     histaux_ocn2med_file1_enabled = .false.
+     histaux_ocn2med_file1_flds = So_bldepth:So_t:So_u:So_v
+     histaux_ocn2med_file1_history_n = 1
+     histaux_ocn2med_file1_history_option = ndays
+     histaux_ocn2med_file1_ntperfile = 30
+     histaux_rof2med_file1_auxname = rof.24h.avrg
+     histaux_rof2med_file1_doavg = .true.
+     histaux_rof2med_file1_enabled = .false.
+     histaux_rof2med_file1_flds = all
+     histaux_rof2med_file1_history_n = 3
+     histaux_rof2med_file1_history_option = nhours
+     histaux_rof2med_file1_ntperfile = 2
+     history_n_atm_avg = -999
+     history_n_atm_inst = -999
+     history_n_glc_avg = -999
+     history_n_glc_inst = -999
+     history_n_ice_avg = -999
+     history_n_ice_inst = -999
+     history_n_lnd_avg = -999
+     history_n_lnd_inst = -999
+     history_n_med_inst = -999
+     history_n_ocn_avg = -999
+     history_n_ocn_inst = -999
+     history_n_rof_avg = -999
+     history_n_rof_inst = -999
+     history_n_wav_avg = -999
+     history_n_wav_inst = -999
+     history_option_atm_avg = never
+     history_option_atm_inst = never
+     history_option_glc_avg = never
+     history_option_glc_inst = never
+     history_option_ice_avg = never
+     history_option_ice_inst = never
+     history_option_lnd_avg = never
+     history_option_lnd_inst = never
+     history_option_med_inst = never
+     history_option_ocn_avg = never
+     history_option_ocn_inst = never
+     history_option_rof_avg = never
+     history_option_rof_inst = never
+     history_option_wav_avg = never
+     history_option_wav_inst = never
+     ice2atm_map = unset
+     ice2wav_smapname = unset
+     ice_nx = 360
+     ice_ny = 300
+     info_debug = 1
+     lnd2atm_map = unset
+     lnd2rof_map = unset
+     lnd_nx = 0
+     lnd_ny = 0
+     mapuv_with_cart3d = .true.
+     ocn2atm_map = unset
+     ocn2wav_smapname = unset
+     ocn_nx = 360
+     ocn_ny = 300
+     ocn_surface_flux_scheme = 0
+     rof2lnd_map = unset
+     rof2ocn_fmapname = unset
+     rof2ocn_ice_rmapname = unset
+     rof2ocn_liq_rmapname = unset
+     rof_nx = 360
+     rof_ny = 300
+     wav2ocn_smapname = unset
+     wav_nx = 0
+     wav_ny = 0
+::
+
+CLOCK_attributes::
+     atm_cpl_dt = 3600
+     calendar = NO_LEAP
+     end_restart = .false.
+     glc_avg_period = yearly
+     glc_cpl_dt = 86400
+     history_ymd = -999
+     ice_cpl_dt = 3600
+     lnd_cpl_dt = 3600
+     ocn_cpl_dt = 3600
+     restart_n = 1
+     restart_option = nmonths
+     restart_ymd = -999
+     rof_cpl_dt = 3600
+     start_tod = 0
+     start_ymd = 19000101
+     stop_n = 1
+     stop_option = nmonths
+     stop_tod = 0
+     stop_ymd = -999
+     tprof_n = -999
+     tprof_option = never
+     tprof_ymd = -999
+     wav_cpl_dt = 3600
+::
+
+ATM_attributes::
+     Verbosity = off
+     aqua_planet = .false.
+     perpetual = .false.
+     perpetual_ymd = -999
+::
+
+ICE_attributes::
+     eps_imesh = 1e-13 # allowed error between angles in mesh file and cice grid
+     Verbosity = off
+::
+
+GLC_attributes::
+     Verbosity = off
+::
+
+LND_attributes::
+     Verbosity = off
+::
+
+OCN_attributes::
+     Verbosity = off
+::
+
+ROF_attributes::
+     Verbosity = off
+     mesh_rof = ./INPUT/access-om2-1deg-nomask-ESMFmesh.nc
+::
+
+WAV_attributes::
+     Verbosity = off
+     mesh_wav = UNSET
+::
+
+MED_modelio::
+     diro = ./log
+     logfile = med.log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = 2
+     pio_root = 1
+     pio_stride = 48
+     pio_typename = netcdf
+::
+
+ATM_modelio::
+     diro = ./log
+     logfile = atm.log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = 1
+     pio_root = 1
+     pio_stride = 48
+     pio_typename = netcdf
+::
+
+LND_modelio::
+     diro = ./log
+     logfile = lnd.log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = 2
+     pio_root = 1
+     pio_stride = 48
+     pio_typename = netcdf
+::
+
+ICE_modelio::
+     diro = ./log
+     logfile = ice.log
+     pio_async_interface = .false.
+     pio_netcdf_format = nothing
+     pio_numiotasks = 1
+     pio_rearranger = 1
+     pio_root = 0
+     pio_stride = 48
+     pio_typename = netcdf4p
+::
+
+OCN_modelio::
+     diro = ./log
+     logfile = ocn.log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = 2
+     pio_root = 1
+     pio_stride = 48
+     pio_typename = netcdf
+::
+
+ROF_modelio::
+     diro = ./log
+     logfile = rof.log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = 2
+     pio_root = 1
+     pio_stride = 48
+     pio_typename = netcdf
+::
+
+GLC_modelio::
+     diro = ./log
+     logfile = glc/log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = 2
+     pio_root = 1
+     pio_stride = 48
+     pio_typename = netcdf
+::
+
+WAV_modelio::
+     diro = ./log
+     logfile = wav.log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = 2
+     pio_root = 1
+     pio_stride = 48
+     pio_typename = netcdf
+::
+
+ESP_modelio::
+     diro = ./log
+     logfile = esp.log
+     pio_async_interface = .false.
+     pio_netcdf_format = 64bit_offset
+     pio_numiotasks = -99
+     pio_rearranger = -99
+     pio_root = -99
+     pio_stride = -99
+     pio_typename = nothing
+::
+
+DRV_modelio::
+     diro = ./log
+     logfile = drv.log
+::
+


### PR DESCRIPTION
This is a ~work-in-progress~ PR with changes required to allow running generic_tracers in MOM with the `cesm_cmeps` driver. ~This PR is still under development and is likely to change. I'm only opening now for visibility and to help me keep track of the various changes I'm having to make across multiple repos to allow this functionality.~

Changes made:

- **BREAKING CHANGE**: input directory in work directory renamed to `INPUT` (from `input`). This is because unfortunately `INPUT` is hardcoded in some parts of FMS that are used by generic tracers.
- This model uses "pointer files" to keep track of most restarts. However, when generic tracers are used, there are additional restarts that do not have pointer files. These are written to an `additional_restart_dir` that is specified in the `nuopc.runconfig`.
- Small refactor of the `Runconfig` class to return a default value when `get`ing values that aren't set in the `nuopc.runconfig` file.