### PR TITLE
Update metadata schema url

### DIFF
--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -36,8 +36,7 @@ MODEL_FIELD = "model"
 METADATA_FILENAME = "metadata.yaml"
 
 # Metadata Schema
-SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/experiment_asset.json"
-
+SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/80a3ce720af14b2b5e718630e1b52e7b3d22ea95/au.org.access-nri/model/output/experiment-metadata/1-0-3.json"
 
 class MetadataWarning(Warning):
     pass


### PR DESCRIPTION
This PR updates the metadata schema used by `metadata.py` to [experiment-metadata/1-0-3.json](https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/output/experiment-metadata/1-0-3.json)

Closes #424. Related #429

