### PR TITLE
Get module executables from path loaded by environment modules

### DIFF
--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -33,6 +33,7 @@ commands, e.g.:
     $ module unuse dir # Remove dir from $MODULEPATH
 """
 
+
 def setup(basepath=DEFAULT_BASEPATH):
     """Set the environment modules used by the Environment Module system."""
 
@@ -153,7 +154,7 @@ def setup_user_modules(user_modules, user_modulepaths):
 
         # Extract out the modulefiles available
         modules = [line for line in output.strip().splitlines()
-                    if not (line.startswith('/') and line.endswith(':'))]
+                   if not (line.startswith('/') and line.endswith(':'))]
 
         if len(modules) > 1:
             # Modules are used for finding model executable paths - so check
@@ -176,7 +177,7 @@ def env_var_set_by_modules(user_modules, env_var):
     if 'MODULESHOME' not in os.environ:
         print('payu: warning: No Environment Modules found; skipping '
               f'inspecting user module changes to ${env_var}')
-        return []
+        return
 
     # Note: Using subprocess shell to isolate changes to environment
     load_commands = [f'load {module}' for module in user_modules]

--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -113,7 +113,7 @@ def lib_update(required_libs, lib_name):
 
 
 def paths_set_by_user_modules(user_modules, user_modulepaths):
-    # Orginal environment 
+    # Orginal environment
     previous_env = dict(os.environ)
     previous_modulepath = os.environ['MODULEPATH']
 
@@ -127,12 +127,11 @@ def paths_set_by_user_modules(user_modules, user_modulepaths):
         init_paths = paths_post_module_commands(["purge"])
         for module in user_modules:
             # Check if module is available
-            cmd = f'{os.environ['MODULESHOME']}/bin/modulecmd bash is-avail {module}'
+            module_cmd = "{os.environ['MODULESHOME']}/bin/modulecmd bash"
+            cmd = f"{module_cmd} is-avail {module}"
             if run_cmd(cmd).returncode != 0:
                 continue
-
-            #TODO: Check if multiple modules are available..
-
+            # TODO: Check if multiple modules are available..
             try:
                 # Get $PATH paths post running module purge && module load
                 paths.extend(paths_post_module_commands(['purge',
@@ -147,16 +146,16 @@ def paths_set_by_user_modules(user_modules, user_modulepaths):
             "Warning: Env vars changed when inspecting paths set by modules"
         )
 
-    # Remove inital paths and convert into a set 
+    # Remove inital paths and convert into a set
     return set(paths).difference(set(init_paths))
 
 
 def paths_post_module_commands(commands):
-    """Runs subprocess module command and parse out the resulting 
+    """Runs subprocess module command and parse out the resulting
     PATH environment variable"""
     # Use modulecmd as module command is not available on compute nodes
     module_cmds = [
-        f'eval `{os.environ['MODULESHOME']}/bin/modulecmd bash {c}`'
+        f"eval `{os.environ['MODULESHOME']}/bin/modulecmd bash {c}`"
         for c in commands
     ]
     command = ' && '.join(module_cmds) + ' && echo $PATH'
@@ -165,7 +164,7 @@ def paths_post_module_commands(commands):
     output = run_cmd(command)
     output.check_returncode()
 
-    # Extact out the PATH value, and split the paths 
+    # Extact out the PATH value, and split the paths
     path = output.stdout.strip().split('\n')[-1]
     return path.split(':')
 

--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -135,7 +135,7 @@ def paths_set_by_user_modules(user_modules, user_modulepaths):
         init_paths = paths_post_module_commands(["purge"])
         for module in user_modules:
             # Check if module is available
-            module_cmd = "{os.environ['MODULESHOME']}/bin/modulecmd bash"
+            module_cmd = f"{os.environ['MODULESHOME']}/bin/modulecmd bash"
             cmd = f"{module_cmd} is-avail {module}"
             if run_cmd(cmd).returncode != 0:
                 continue

--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -113,6 +113,14 @@ def lib_update(required_libs, lib_name):
 
 
 def paths_set_by_user_modules(user_modules, user_modulepaths):
+    """Search along changes PATH added by user defined modules
+    and return a set of paths added - this is used for
+    searching for the model executable"""
+    if 'MODULESHOME' not in os.environ:
+        print('payu: warning: No Environment Modules found; skipping '
+              'inspecting user module changes to PATH')
+        return set()
+
     # Orginal environment
     previous_env = dict(os.environ)
     previous_modulepath = os.environ['MODULEPATH']

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -132,7 +132,7 @@ class Experiment(object):
 
         self.run_id = None
 
-        self.user_modules_path = None
+        self.user_modules_paths = None
 
     def init_models(self):
 
@@ -227,23 +227,15 @@ class Experiment(object):
         envmod.setup()
 
         # Get user modules info from config
-        self.user_modulepaths = self.config.get('modules', {}).get('use', [])
-        self.user_modules = self.config.get('modules', {}).get('load', [])
+        user_modulepaths = self.config.get('modules', {}).get('use', [])
+        user_modules = self.config.get('modules', {}).get('load', [])
 
-        # Run module use + load commands for user-defined modules
-        envmod.setup_user_modules(self.user_modules, self.user_modulepaths)
-
-        # Get paths and loaded modules post loading only the user modules
-        self.user_modules_path = envmod.env_var_set_by_modules(
-            self.user_modules, 'PATH'
-        )
-
-        # Store list of all modules loaded by user-modules
-        self.loaded_user_modules = envmod.env_var_set_by_modules(
-            self.user_modules, 'LOADEDMODULES'
-        )
-        if self.loaded_user_modules is not None:
-            self.loaded_user_modules = self.loaded_user_modules.split(':')
+        # Run module use + load commands for user-defined modules, and
+        # get a set of paths and loaded modules added by loading the modules
+        loaded_mods, paths = envmod.setup_user_modules(user_modules,
+                                                       user_modulepaths)
+        self.user_modules_paths = paths
+        self.loaded_user_modules = [] if loaded_mods is None else loaded_mods
 
     def load_modules(self):
         # Scheduler

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -132,6 +132,8 @@ class Experiment(object):
 
         self.run_id = None
 
+        self.user_modules_path = None
+
     def init_models(self):
 
         self.model_name = self.config.get('model')
@@ -232,13 +234,16 @@ class Experiment(object):
         envmod.setup_user_modules(self.user_modules, self.user_modulepaths)
 
         # Get paths and loaded modules post loading only the user modules
-        self.user_modules_paths = envmod.env_var_set_by_modules(
+        self.user_modules_path = envmod.env_var_set_by_modules(
             self.user_modules, 'PATH'
-        ).split(':')
+        )
 
+        # Store list of all modules loaded by user-modules
         self.loaded_user_modules = envmod.env_var_set_by_modules(
             self.user_modules, 'LOADEDMODULES'
-        ).split(':')
+        )
+        if self.loaded_user_modules is not None:
+            self.loaded_user_modules = self.loaded_user_modules.split(':')
 
     def load_modules(self):
         # Scheduler
@@ -264,7 +269,7 @@ class Experiment(object):
                 print('mod '+mod)
                 mod_base = mod.split('/')[0]
                 if (mod_base not in core_modules and
-                     mod not in self.loaded_user_modules):
+                        mod not in self.loaded_user_modules):
                     envmod.module('unload', mod)
 
         # Now load model-dependent modules

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -76,9 +76,16 @@ def fms_collate(model):
     mpi = collate_config.get('mpi', False)
 
     if mpi:
-        # Must use envmod to be able to load mpi modules for collation
-        envmod.setup()
-        model.expt.load_modules()
+        # TODO: I've added module setup and load functions to
+        # Experiment.collate - as user modules needed to be use & loaded
+        # to expand executable paths. However, is loading mpi module
+        # for non-mpi collate jobs going to cause errors?
+        # If so, need to only use/load user modules in Experiment.collate
+        # and only load additional modules for mpi here
+
+        # # Must use envmod to be able to load mpi modules for collation
+        # envmod.setup()
+        # model.expt.load_modules()
         default_exe = 'mppnccombine-fast'
     else:
         default_exe = 'mppnccombine'
@@ -92,8 +99,7 @@ def fms_collate(model):
                 mppnc_path = os.path.join(model.expt.lab.bin_path, f)
                 break
     else:
-        if not os.path.isabs(mppnc_path):
-            mppnc_path = os.path.join(model.expt.lab.bin_path, mppnc_path)
+        mppnc_path = model.expand_executable_path(mppnc_path)
 
     assert mppnc_path, 'No mppnccombine program found'
 

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -76,16 +76,8 @@ def fms_collate(model):
     mpi = collate_config.get('mpi', False)
 
     if mpi:
-        # TODO: I've added module setup and load functions to
-        # Experiment.collate - as user modules needed to be use & loaded
-        # to expand executable paths. However, is loading mpi module
-        # for non-mpi collate jobs going to cause errors?
-        # If so, need to only use/load user modules in Experiment.collate
-        # and only load additional modules for mpi here
-
-        # # Must use envmod to be able to load mpi modules for collation
-        # envmod.setup()
-        # model.expt.load_modules()
+        # Load mpi modules for collation
+        model.expt.load_modules()
         default_exe = 'mppnccombine-fast'
     else:
         default_exe = 'mppnccombine'

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -205,7 +205,7 @@ class Model(object):
                     print(
                         f"Expanded model exectuable path to: {self.exec_path}")
                 else:
-                    # Prepend the lab bin path 
+                    # Prepend the lab bin path
                     self.exec_path = os.path.join(self.expt.lab.bin_path,
                                                   self.exec_name)
 

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -82,21 +82,6 @@ class Model(object):
         self.work_output_path = self.work_path
         self.work_init_path = self.work_path
 
-        self.exec_prefix = self.config.get('exe_prefix', '')
-        self.exec_name = self.config.get('exe', self.default_exec)
-        if self.exec_name:
-            # By default os.path.join will not prepend the lab bin_path
-            # to an absolute path
-            self.exec_path = os.path.join(self.expt.lab.bin_path,
-                                          self.exec_name)
-        else:
-            self.exec_path = None
-        if self.exec_path:
-            # Make exec_name consistent for models with fully qualified path.
-            # In all cases it will just be the name of the executable without a
-            # path
-            self.exec_name = os.path.basename(self.exec_path)
-
     def set_local_pathnames(self):
 
         # This is the path relative to the control directory, required for
@@ -129,12 +114,6 @@ class Model(object):
                 os.path.relpath(self.work_init_path, self.expt.work_path)
             )
         )
-        if self.exec_path:
-            # Local path in work directory
-            self.exec_path_local = os.path.join(
-                self.work_path_local,
-                os.path.basename(self.exec_path)
-            )
 
     def set_input_paths(self):
         if len(self.expt.models) == 1:
@@ -197,6 +176,49 @@ class Model(object):
         except Exception as e:
             print("No prior restart files found: {error}".format(error=str(e)))
             return []
+
+    def setup_executable_paths(self, module_added_paths):
+        """Set model executable paths"""
+        self.exec_prefix = self.config.get('exe_prefix', '')
+        self.exec_name = self.config.get('exe', self.default_exec)
+        self.exec_path = None
+        if self.exec_name:
+            if os.path.isabs(self.exec_name):
+                # Use absolute path
+                self.exec_path = self.exec_name
+            else:
+                # Check for executable inside paths added by user-modules
+                exec_paths = []
+                for path in module_added_paths:
+                    exec_path = os.path.join(path, self.exec_name)
+                    if os.path.exists(exec_path):
+                        exec_paths.append(exec_path)
+
+                if len(exec_paths) > 1:
+                    # Will this ever happen?
+                    raise ValueError(
+                        f"Executable: {self.exec_name} found in multiple " +
+                        f"module paths: {exec_paths}"
+                    )
+                elif len(exec_paths) == 1:
+                    self.exec_path = exec_paths[0]
+                    print(
+                        f"Expanded model exectuable path to: {self.exec_path}")
+                else:
+                    # Prepend the lab bin path 
+                    self.exec_path = os.path.join(self.expt.lab.bin_path,
+                                                  self.exec_name)
+
+            # Make exec_name consistent for models with fully qualified path.
+            # In all cases it will just be the name of the executable without a
+            # path
+            self.exec_name = os.path.basename(self.exec_path)
+
+            # Local path in work directory
+            self.exec_path_local = os.path.join(
+                self.work_path_local,
+                os.path.basename(self.exec_path)
+            )
 
     def setup_configuration_files(self):
         """Copy configuration and optional configuration files from control

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -184,9 +184,9 @@ class Model(object):
             return exec
 
         if not search_module_path:
-            module_added_paths = set()
+            module_added_paths = []
         else:
-            module_added_paths = self.expt.user_modules_set_paths
+            module_added_paths = self.expt.user_modules_paths
 
         # Search for exe inside paths added to $PATH by user-defined modules
         exec_paths = []

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -184,15 +184,11 @@ class Model(object):
             return exec
 
         # Check if path set by loading user modules has been defined
-        module_added_path = self.expt.user_modules_path
-        if module_added_path is None:
+        module_added_paths = self.expt.user_modules_paths
+        if module_added_paths is None:
             print("payu: warning: Skipping searching for model executable " +
                   "in $PATH set by user modules")
             module_added_paths = []
-        elif module_added_path == '':
-            module_added_paths = []
-        else:
-            module_added_paths = module_added_path.split(':')
 
         # Search for exe inside paths added to $PATH by user-defined modules
         exec_paths = []


### PR DESCRIPTION
- Move setting executable paths in Model class to Experiment.setup()
- Inspect user modules (specified in config.yaml) to changes to PATH - The modules are restricted to user module directories defined in config.yaml
- If exe is not an absolute path, search along above paths

Modules are still loaded the same way in experiment.run so to not change users env vars when running `payu setup` 

Closes #379 
