### PR TITLE
User-scripts error-handling, commands and tests

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -28,6 +28,7 @@ import yaml
 from payu import envmod
 from payu.fsops import mkdir_p, make_symlink, read_config, movetree
 from payu.fsops import list_archive_dirs
+from payu.fsops import run_script_command
 from payu.schedulers.pbs import get_job_info, pbs_env_init, get_job_id
 from payu.models import index as model_index
 import payu.profilers
@@ -887,44 +888,12 @@ class Experiment(object):
             }
         )
 
-    def run_userscript(self, script_cmd):
-        # Setup environment variables with current run information
+    def run_userscript(self, script_cmd : str):
+        """Run a user defined script or subcommand at various stages of the
+        payu submissions"""
         self.set_userscript_env_vars()
-
-        # First try to interpret the argument as a full command:
-        try:
-            sp.check_call(shlex.split(script_cmd))
-        except EnvironmentError as exc:
-            # Now try to run the script explicitly
-            if exc.errno == errno.ENOENT:
-                cmd = os.path.join(self.control_path, script_cmd)
-                # Simplistic recursion check
-                assert os.path.isfile(cmd)
-                self.run_userscript(cmd)
-
-            # If we get a "non-executable" error, then guess the type
-            elif exc.errno == errno.EACCES:
-                # TODO: Move outside
-                ext_cmd = {'.py': sys.executable,
-                           '.sh': '/bin/bash',
-                           '.csh': '/bin/tcsh'}
-
-                _, f_ext = os.path.splitext(script_cmd)
-                shell_name = ext_cmd.get(f_ext)
-                if shell_name:
-                    print('payu: warning: Assuming that {0} is a {1} script '
-                          'based on the filename extension.'
-                          ''.format(os.path.basename(script_cmd),
-                                    os.path.basename(shell_name)))
-                    cmd = ' '.join([shell_name, script_cmd])
-                    self.run_userscript(cmd)
-                else:
-                    # If we can't guess the shell, then abort
-                    raise
-        except sp.CalledProcessError as exc:
-            # If the script runs but the output is bad, then warn the user
-            print('payu: warning: user script \'{0}\' failed (error {1}).'
-                  ''.format(script_cmd, exc.returncode))
+        run_script_command(script_cmd,
+                           control_path=Path(self.control_path))
 
     def sweep(self, hard_sweep=False):
         # TODO: Fix the IO race conditions!

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -888,7 +888,7 @@ class Experiment(object):
             }
         )
 
-    def run_userscript(self, script_cmd : str):
+    def run_userscript(self, script_cmd: str):
         """Run a user defined script or subcommand at various stages of the
         payu submissions"""
         self.set_userscript_env_vars()

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -257,6 +257,7 @@ def run_script_command(script_cmd: str, control_path: Path) -> None:
         error_msg = f"User defined script/command failed to run: {script_cmd}"
         raise RuntimeError(error_msg) from e
 
+
 def needs_subprocess_shell(command: str) -> bool:
     """Check if command contains shell specific values. For example, file
     redirections, pipes or logical operators.
@@ -276,6 +277,7 @@ def needs_subprocess_shell(command: str) -> bool:
         if value in command:
             return True
     return False
+
 
 def _run_script(script_cmd: str, control_path: Path) -> None:
     """Helper recursive function to attempt running a script command.

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -296,7 +296,7 @@ def _run_script(script_cmd: str, control_path: Path) -> None:
             subprocess.check_call(script_cmd, shell=True)
         else:
             subprocess.check_call(shlex.split(script_cmd))
-            print(script_cmd)
+        print(script_cmd)
 
     except FileNotFoundError:
         # Check if script is a file in the control directory
@@ -311,10 +311,11 @@ def _run_script(script_cmd: str, control_path: Path) -> None:
         _, file_ext = os.path.splitext(script_cmd)
         shell_name = EXTENSION_TO_INTERPRETER.get(file_ext, None)
         if shell_name:
-            print('payu: warning: Assuming that {0} is a {1} '
-                  'script based on the filename extension.'
-                  ''.format(os.path.basename(script_cmd),
-                            os.path.basename(shell_name)))
+            print(
+                f'payu: warning: Assuming that {os.path.basename(script_cmd)} '
+                f'is a {os.path.basename(shell_name)} script based on the '
+                'filename extension.'
+            )
 
             cmd = f'{shell_name} {script_cmd}'
             _run_script(cmd, control_path)

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -320,6 +320,28 @@ def test_run_userscript_python_script(tmp_path):
         assert f.read() == "Test Python user script"
 
 
+def test_run_userscript_python_script_with_shebang_header(tmp_path):
+    # Create a simple python script
+    python_script = tmp_path / 'test_script_with_python_shebang.py'
+    with open(python_script, 'w') as f:
+        f.writelines([
+            '#!/usr/bin/env python\n'
+            f"with open('{tmp_path}/output.txt', 'w') as f:\n",
+            "   f.write('Test Python user script with python shebang header')"
+        ])
+
+    # Make file executable
+    os.chmod(python_script, 0o775)
+
+    # Test run userscript
+    payu.fsops.run_script_command('test_script_with_python_shebang.py',
+                                  tmp_path)
+
+    # Check script output
+    with open((tmp_path / 'output.txt'), 'r') as f:
+        assert f.read() == "Test Python user script with python shebang header"
+
+
 def test_run_userscript_bash_script(tmp_path):
     # Create a simple bash script
     bash_script = tmp_path / 'test_script.sh'

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -377,7 +377,7 @@ def test_userscript_non_existent_file(tmp_path):
                                       tmp_path)
 
 
-def test_run_userscript_python_script_eror(tmp_path):
+def test_run_userscript_python_script_error(tmp_path):
     # Create a python script that'll exit with an error
     python_script = tmp_path / 'test_script_error.py'
     with open(python_script, 'w') as f:
@@ -389,7 +389,7 @@ def test_run_userscript_python_script_eror(tmp_path):
                                       tmp_path)
 
 
-def test_run_userscript_bash_script_eror(tmp_path):
+def test_run_userscript_bash_script_error(tmp_path):
     # Create a bash script that'll exit with an error
     bash_script = tmp_path / 'test_script_error.sh'
     with open(bash_script, 'w') as f:


### PR DESCRIPTION
- Raise RuntimeErrors when user-scripts exit with an error (previously it was just a warning)
- Move run user-script code to payu.fsops out of Experiment class so it's easier to test
- Use shell=True for subprocess commands needing a shell, e.g. file redirections, pipes
- Add tests for running userscripts

To be able to run commands such as `echo "some_data" > input.txt` that are in payu documentation, it requires use of `shell=True`. So there's some security issues with using `shell=True` (https://docs.python.org/3/library/subprocess.html#security-considerations). However as the user scripts have typically been user defined `.sh` files run with `/bin/bash`, it could contain malicious code anyway..

I added a `needs_subprocess_shell` function that checks for any shell specific values. The list I've added might not be exhaustive. The question I am not sure on is that function even needed, and should all the user script commands just be run with `shell=True`?

Closes #448, closes #444 

