### PR TITLE
Remove unnecessary UM config files

### DIFF
--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -140,15 +140,15 @@ class UnifiedModel(Model):
                                            work_path=self.work_path)
         os.environ.update(um_vars)
 
-        # parexe removed from newer configurations - retain the old processing if 
-        # it exists for backwards compatibility 
+        # parexe removed from newer configurations - retain the
+        # old processing if file exists for backwards compatibility
         try:
             # The above needs to be done in parexe also.
-            # FIXME: a better way to do this or remove.  
+            # FIXME: a better way to do this or remove.
             parexe = os.path.join(self.work_path, 'parexe')
             for line in fileinput.input(parexe, inplace=True):
                 line = line.format(input_path=self.input_paths[0],
-                                work_path=self.work_path)
+                                   work_path=self.work_path)
                 print(line, end='')
         except FileNotFoundError:
             pass

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -38,14 +38,13 @@ class UnifiedModel(Model):
         self.restart_calendar_file = self.model_type + '.res.yaml'
 
         # TODO: many of these can probably be ignored.
-        self.config_files = ['CNTLALL', 'prefix.CNTLATM', 'prefix.CNTLGEN',
-                             'CONTCNTL', 'errflag', 'exstat',
-                             'ftxx', 'ftxx.new', 'ftxx.vars',
-                             'hnlist', 'ihist', 'INITHIS',
-                             'namelists', 'PPCNTL', 'prefix.PRESM_A',
-                             'SIZES', 'STASHC', 'UAFILES_A', 'UAFLDS_A',
-                             'parexe', 'cable.nml', 'um_env.py']
-        self.optional_config_files = ['input_atm.nml']
+        self.config_files = [
+            'errflag',
+            'hnlist', 'ihist',
+            'namelists', 'prefix.PRESM_A',
+            'STASHC', 'UAFILES_A', 'UAFLDS_A',
+            'cable.nml', 'um_env.py']
+        self.optional_config_files = ['input_atm.nml', 'parexe']
 
         self.restart = 'restart_dump.astart'
 
@@ -141,13 +140,18 @@ class UnifiedModel(Model):
                                            work_path=self.work_path)
         os.environ.update(um_vars)
 
-        # The above needs to be done in parexe also.
-        # FIXME: a better way to do this or remove.
-        parexe = os.path.join(self.work_path, 'parexe')
-        for line in fileinput.input(parexe, inplace=True):
-            line = line.format(input_path=self.input_paths[0],
-                               work_path=self.work_path)
-            print(line, end='')
+        # parexe removed from newer configurations - retain the old processing if 
+        # it exists for backwards compatibility 
+        try:
+            # The above needs to be done in parexe also.
+            # FIXME: a better way to do this or remove.  
+            parexe = os.path.join(self.work_path, 'parexe')
+            for line in fileinput.input(parexe, inplace=True):
+                line = line.format(input_path=self.input_paths[0],
+                                work_path=self.work_path)
+                print(line, end='')
+        except FileNotFoundError:
+            pass
 
         work_nml_path = os.path.join(self.work_path, 'namelists')
         work_nml = f90nml.read(work_nml_path)

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -141,17 +141,16 @@ class UnifiedModel(Model):
         os.environ.update(um_vars)
 
         # parexe removed from newer configurations - retain the
-        # old processing if file exists for backwards compatibility
-        try:
+        # old processing if parexe file exists for backwards compatibility
+        parexe = os.path.join(self.work_path, 'parexe')
+        if os.path.isfile(parexe):
             # The above needs to be done in parexe also.
             # FIXME: a better way to do this or remove.
-            parexe = os.path.join(self.work_path, 'parexe')
             for line in fileinput.input(parexe, inplace=True):
                 line = line.format(input_path=self.input_paths[0],
                                    work_path=self.work_path)
                 print(line, end='')
-        except FileNotFoundError:
-            pass
+
 
         work_nml_path = os.path.join(self.work_path, 'namelists')
         work_nml = f90nml.read(work_nml_path)


### PR DESCRIPTION
Changes related to #419.

Payu currently requires several UM configuration files which aren't required and duplicate settings in the required ones, making it confusing to modify the correct namelists. 

I've removed the unneeded files from the `config_files` in `um.py`, though kept `parexe` as an `optional_configuration_file` in case it is needed by older configurations.