### PR TITLE
Replace UM um_env.py configuration file with yaml file

### DIFF
--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -110,6 +110,22 @@ class UnifiedModel(Model):
         pass
 
     def setup(self):
+        # Raise a depreciation error if the um_env.yaml file is not found
+        # This could be removed down the line, once older configurations 
+        # have swapped to um_env.yaml files.
+        depreciated_um_env = os.path.join(self.control_path, 'um_env.py')
+        new_um_env = os.path.join(self.control_path, 'um_env.yaml')
+        if (not os.path.isfile(new_um_env)) and os.path.isfile(depreciated_um_env):
+            raise FutureWarning(
+                (
+                    "The `um_env.py` configuration file has been depreciated and "
+                    "should be relplaced with a yaml file. "
+                    "Convert `um_env.py` to `um_env.yaml` using "
+                    "https://github.com/ACCESS-NRI/esm1.5-scripts/blob/main/config-files/UM/um_env_to_yaml.py"
+                )
+            ) 
+
+        # Commence normal setup
         super(UnifiedModel, self).setup()
 
         # Set up environment variables needed to run UM.

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -116,7 +116,7 @@ class UnifiedModel(Model):
         um_env_path = os.path.join(self.control_path, 'um_env.yaml')
         with open(um_env_path, 'r') as um_env_yaml:
             um_env_vars = yaml.safe_load(um_env_yaml)
-        
+
 
         # Stage the UM restart file.
         if self.prior_restart_path and not self.expt.repeat_run:
@@ -131,8 +131,10 @@ class UnifiedModel(Model):
 
         # Set paths in environment variables.
         for k in um_env_vars.keys():
-            um_env_vars[k] = um_env_vars[k].format(input_path=self.input_paths[0],
-                                           work_path=self.work_path)
+            um_env_vars[k] = um_env_vars[k].format(
+                                    input_path=self.input_paths[0],
+                                    work_path=self.work_path
+            )
         os.environ.update(um_env_vars)
 
         # parexe removed from newer configurations - retain the

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -110,15 +110,15 @@ class UnifiedModel(Model):
         pass
 
     def setup(self):
-        # Raise a depreciation error if the um_env.yaml file is not found
+        # Raise a deprecation error if the um_env.yaml file is not found
         # This could be removed down the line, once older configurations 
         # have swapped to um_env.yaml files.
-        depreciated_um_env = os.path.join(self.control_path, 'um_env.py')
+        deprecated_um_env = os.path.join(self.control_path, 'um_env.py')
         new_um_env = os.path.join(self.control_path, 'um_env.yaml')
-        if (not os.path.isfile(new_um_env)) and os.path.isfile(depreciated_um_env):
+        if (not os.path.isfile(new_um_env)) and os.path.isfile(deprecated_um_env):
             raise FutureWarning(
                 (
-                    "The `um_env.py` configuration file has been depreciated and "
+                    "The `um_env.py` configuration file has been deprecated and "
                     "should be relplaced with a yaml file. "
                     "Convert `um_env.py` to `um_env.yaml` using "
                     "https://github.com/ACCESS-NRI/esm1.5-scripts/blob/main/config-files/UM/um_env_to_yaml.py"


### PR DESCRIPTION
Closes #454

[`um.py`](https://github.com/payu-org/payu/blob/master/payu/models/um.py) currently sources a python file [`um_env.py`](https://github.com/ACCESS-NRI/access-esm1.5-configs/blob/pre-industrial/atmosphere/um_env.py) in order to set environment variables by the UM, which might cause security issues. This pull request makes payu read the data from a yaml file instead.

If this ends up being merged, we'll need to also convert the `um_env.py` files in the configurations to yaml.

---
Printing out the environment through a run stage userscript shows that the relevant environment variables are the same with and without the changes:

Printed UM environment variable values without the changes:
<details>

```

AINITIAL=
ASTART=restart_dump.astart
AUSCOM_CPL=true
DATAW=/scratch/tm70/sw6175/access-esm/work/base-run-print-env-pre-industrial-c170a89c/atmosphere
FASTRUN=true
IDEALISE=
PAREXE=parexe
PRINT_STATUS=PrStatus_Diag
RPSEED=
RUNID=PI-01
TYPE=NRUN
UM_ATM_NPROCX=16
UM_ATM_NPROCY=12
UM_NAM_MAX_SECONDS=300
UM_NPES=192
UM_SECTOR_SIZE=2048
UM_STDOUT_FILE=atm.fort6.pe
VN=7.3

UNIT01=
UNIT02=prefix
UNIT04=STASHC
UNIT05=namelists
UNIT07=PI-01.out2
UNIT08=/dev/null
UNIT09=CONTCNTL
UNIT10=xhist
UNIT11=ihist
UNIT12=thist
UNIT14=errflag
UNIT15=
UNIT58=
UNIT22=INPUT/STASHmaster
UNIT57=INPUT/spec3a_sw_hadgem1_6on
UNIT80=INPUT/spec3a_lw_hadgem1_6on
STASETS_DIR=INPUT/stasets
VERT_LEV=INPUT/vertlevs_G3

ARCLBIOG=INPUT/biogenic_351sm.N96L38
BIOMASS=INPUT/Bio_1850_ESM1.anc
CHEMOXID=INPUT/sulpc_oxidants_N96_L38
DMSCONC=INPUT/DMS_conc.N96
NDEPFIL=INPUT/Ndep_1850_ESM1.anc
OCFFEMIS=INPUT/OCFF_1850_ESM1.anc
OZONE=INPUT/ozone_1850_ESM1.anc
SOOTEMIS=INPUT/BC_hi_1850_ESM1.anc
SULPEMIS=INPUT/scycl_1850_ESM1_v4.anc
VEGINIT=INPUT/cable_vegfunc_N96.anc
```
</details>


Printed UM environment variable values with the changes:

<details>

```

AINITIAL=
ASTART=restart_dump.astart
AUSCOM_CPL=true
DATAW=/scratch/tm70/sw6175/access-esm/work/swap-to-yaml-pre-industrial-463fc0f6/atmosphere
FASTRUN=true
IDEALISE=
PAREXE=parexe
PRINT_STATUS=PrStatus_Diag
RPSEED=
RUNID=PI-01
TYPE=NRUN
UM_ATM_NPROCX=16
UM_ATM_NPROCY=12
UM_NAM_MAX_SECONDS=300
UM_NPES=192
UM_SECTOR_SIZE=2048
UM_STDOUT_FILE=atm.fort6.pe
VN=7.3

UNIT01=
UNIT02=prefix
UNIT04=STASHC
UNIT05=namelists
UNIT07=PI-01.out2
UNIT08=/dev/null
UNIT09=CONTCNTL
UNIT10=xhist
UNIT11=ihist
UNIT12=thist
UNIT14=errflag
UNIT15=
UNIT58=
UNIT22=INPUT/STASHmaster
UNIT57=INPUT/spec3a_sw_hadgem1_6on
UNIT80=INPUT/spec3a_lw_hadgem1_6on
STASETS_DIR=INPUT/stasets
VERT_LEV=INPUT/vertlevs_G3

ARCLBIOG=INPUT/biogenic_351sm.N96L38
BIOMASS=INPUT/Bio_1850_ESM1.anc
CHEMOXID=INPUT/sulpc_oxidants_N96_L38
DMSCONC=INPUT/DMS_conc.N96
NDEPFIL=INPUT/Ndep_1850_ESM1.anc
OCFFEMIS=INPUT/OCFF_1850_ESM1.anc
OZONE=INPUT/ozone_1850_ESM1.anc
SOOTEMIS=INPUT/BC_hi_1850_ESM1.anc
SULPEMIS=INPUT/scycl_1850_ESM1_v4.anc
VEGINIT=INPUT/cable_vegfunc_N96.anc
```
</details>

Just to be sure, the simulation is also identical with and without the changes:
![download-6](https://github.com/payu-org/payu/assets/88933912/5e9cb55b-3d9e-4451-aa4d-5d62e9b27fb3)

