### PR TITLE
Adding date based pruning for ESM

### DIFF
--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -235,7 +235,7 @@ class Access(Model):
                 return model.get_restart_datetime(mom_restart_path)
 
         raise NotImplementedError(
-            'Cannot find mom sub-model: access-om2 date-based restart pruning '
+            'Cannot find mom sub-model: access-ESM1.5 date-based restart pruning '
             'requires the mom sub-model to determine restart dates')
 
     def set_model_pathnames(self):

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -226,6 +226,18 @@ class Access(Model):
             o2i_dst = os.path.join(cice5.restart_path, 'o2i.nc')
             shutil.copy2(o2i_src, o2i_dst)
 
+    def get_restart_datetime(self, restart_path):
+        """Given a restart path, parse the restart files and
+        return a cftime datetime (for date-based restart pruning)"""
+        for model in self.expt.models:
+            if model.model_type == 'mom':
+                mom_restart_path = os.path.join(restart_path, model.name)
+                return model.get_restart_datetime(mom_restart_path)
+
+        raise NotImplementedError(
+            'Cannot find mom sub-model: access-om2 date-based restart pruning '
+            'requires the mom sub-model to determine restart dates')
+
     def set_model_pathnames(self):
         pass
 

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -23,6 +23,7 @@ import f90nml
 # Local
 from payu.fsops import make_symlink
 from payu.models.model import Model
+from payu.models.mom import get_restart_datetime_using_mom_submodel
 import payu.calendar as cal
 
 
@@ -229,16 +230,10 @@ class Access(Model):
     def get_restart_datetime(self, restart_path):
         """Given a restart path, parse the restart files and
         return a cftime datetime (for date-based restart pruning)"""
-        for model in self.expt.models:
-            if model.model_type == 'mom':
-                mom_restart_path = os.path.join(restart_path, model.name)
-                return model.get_restart_datetime(mom_restart_path)
-
-        raise NotImplementedError(
-            'Cannot find mom sub-model: access-esm1.5 date-based '
-            'restart pruning requires the mom sub-model to '
-            'determine restart dates'
-            )
+        return get_restart_datetime_using_mom_submodel(
+            model=self, 
+            restart_path=restart_path
+        )
 
     def set_model_pathnames(self):
         pass

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -235,8 +235,10 @@ class Access(Model):
                 return model.get_restart_datetime(mom_restart_path)
 
         raise NotImplementedError(
-            'Cannot find mom sub-model: access-esm1.5 date-based restart pruning '
-            'requires the mom sub-model to determine restart dates')
+            'Cannot find mom sub-model: access-esm1.5 date-based '
+            'restart pruning requires the mom sub-model to '
+            'determine restart dates'
+            )
 
     def set_model_pathnames(self):
         pass

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -235,7 +235,7 @@ class Access(Model):
                 return model.get_restart_datetime(mom_restart_path)
 
         raise NotImplementedError(
-            'Cannot find mom sub-model: access-ESM1.5 date-based restart pruning '
+            'Cannot find mom sub-model: access-esm1.5 date-based restart pruning '
             'requires the mom sub-model to determine restart dates')
 
     def set_model_pathnames(self):

--- a/payu/models/accessom2.py
+++ b/payu/models/accessom2.py
@@ -14,6 +14,7 @@ import os
 import shutil
 
 from payu.models.model import Model
+from payu.models.mom import get_restart_datetime_using_mom_submodel
 
 
 class AccessOm2(Model):
@@ -90,11 +91,8 @@ class AccessOm2(Model):
     def get_restart_datetime(self, restart_path):
         """Given a restart path, parse the restart files and
         return a cftime datetime (for date-based restart pruning)"""
-        for model in self.expt.models:
-            if model.model_type == 'mom':
-                mom_restart_path = os.path.join(restart_path, model.name)
-                return model.get_restart_datetime(mom_restart_path)
-
-        raise NotImplementedError(
-            'Cannot find mom sub-model: access-om2 date-based restart pruning '
-            'requires the mom sub-model to determine restart dates')
+       # Use mom submodel to determine restart datetimes
+        return get_restart_datetime_using_mom_submodel(
+            model=self, 
+            restart_path=restart_path
+        )

--- a/payu/models/mom.py
+++ b/payu/models/mom.py
@@ -225,3 +225,19 @@ class Mom(MomMixin, Fms):
             land_cells = int(fmask.readline())
 
         return land_cells
+
+
+def get_restart_datetime_using_mom_submodel(model, restart_path):
+    """Given a model object and a restart path, check for
+    a MOM sub-model and use it's restart files to find a cftime datetime 
+   (for date-based restart pruning)"""
+    for sub_model in model.expt.models:
+        if sub_model.model_type == 'mom' :
+            mom_restart_path = os.path.join(restart_path, sub_model.name)
+            return sub_model.get_restart_datetime(mom_restart_path)
+
+    raise NotImplementedError(
+        f'Cannot find mom sub-model: {model.model_type} date-based '
+        'restart pruning requires the mom sub-model to '
+        'determine restart dates'
+    )


### PR DESCRIPTION
Closes #464 

This pull requests adds support for date based restart pruning for ESM1.5, which was previously implemented for the MOM models. As ESM1.5 uses MOM as a submodel, and produces the same ocean date files `ocean_solo.res` in the restart directories, I've just copied the `get_restart_datetime` method from `mom_mixin.py` into `access.py`. 

I've manually tested it with with different monthly and yearly restart frequencies. E.g. running in month long sections, with `restart_freq: 3MS` for a total of 10 month results in the following archive:

```
metadata.yaml  output000  output001  output002  output003  output004  output005  output006  output007  output008  output009  pbs_logs  restart000  restart003  restart006  restart009
```

Likewise running for 6 months with `restart_freq: 2MS` results in 
```
metadata.yaml  output000  output001  output002  output003  output004  output005  restart000  restart002  restart004  restart005
```

Creating a fake group of restart directories with yearly gaps in their `ocean_solo.res` dates, and running the pruning with `restart_freq: 7YS` also looks like it works (note that restart010 was the first of the fake directories):
```
metadata.yaml  pbs_logs    restart017  restart031  restart045  restart059  restart073  restart087  restart101 
output102      restart010  restart024  restart038  restart052  restart066  restart080  restart094  restart102
``` 

The implementation and manual tests are both a bit ad-hoc, and so it would be great to get another opinion on whether what's here is sufficient or if its better to try and do it differently. 
