### PR TITLE
Add environment variables and shell checks for postscripts

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -841,7 +841,6 @@ class Experiment(object):
             else:
                 sp.check_call(shlex.split(cmd))
 
-           
         # Submit a sync script if remote syncing is enabled
         sync_config = self.config.get('sync', {})
         syncing = sync_config.get('enable', False)


### PR DESCRIPTION
This pull request covers initial work for #463.  

Allowing both syncing and NetCDF conversion for ESM simulations will be easier if the NetCDF conversion is run as a payu postscript, rather than as a userscript. This pull request adds in shell requirement checks and environment variable exports to the postscript submission, which are needed for the NetCDF conversion script.