### PR TITLE
CI coveralls parallel fix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,7 +94,7 @@ jobs:
           PYTHONPATH=. pytest --cov=payu -s test;
 
       - name: Coveralls
-        uses: AndreMiras/coveralls-python-action@f5fd5c309b39d01599fb92c72d4f7409ea78aec9 # v20201129
+        uses: AndreMiras/coveralls-python-action@65c1672f0b8a201702d86c81b79187df74072505
         with:
           parallel: true
 
@@ -106,6 +106,6 @@ jobs:
     needs: tests
     runs-on: ubuntu-latest
     steps:
-    - uses: AndreMiras/coveralls-python-action@f5fd5c309b39d01599fb92c72d4f7409ea78aec9 # v20201129
+    - uses: AndreMiras/coveralls-python-action@65c1672f0b8a201702d86c81b79187df74072505
       with:
         parallel-finished: true


### PR DESCRIPTION
Closes #453

Update coveralls action to point a commit with a fix for dubious git ownership errors when running parallel coveralls step - e.g. https://github.com/AndreMiras/coveralls-python-action/commit/65c1672f0b8a201702d86c81b79187df74072505

This commit is merged into the `develop` branch on the `coveralls-python-action` repository, but not yet the main branch, and there hasn't been a tag released version update since 2020.

Another option is to use code-cov for this project which is used in other projects? https://github.com/ACCESS-NRI/dev-docs/wiki/Continuous-integration-and-deployment#uploading-code-coverage-reports-to-codecov