### PR TITLE
Replace deprecated `distutils` dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
     # Run the job for different versions of python
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -8,7 +8,7 @@
 """
 
 import argparse
-from distutils import sysconfig
+import sysconfig
 import importlib
 import os
 import pkgutil


### PR DESCRIPTION
A `distutils.sysconfig` import was used in `payu/cli.py`. `distutils` is now deprecated and has been removed in Python 3.12. The PR replaces `distutils` with the `sysconfig` standard library (as recommended here: https://peps.python.org/pep-0632/#migration-advice).

I've also added Python 3.12 to CI tests. Keeping the Python 3.9 tests at this stage as Python 3.9 is still currently used in the `vk83`'s payu environments on NCI. 

Closes #476 

