### PR TITLE
441 inconsistency between yaml libs bugfix

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -15,6 +15,7 @@ import pkgutil
 import shlex
 import subprocess
 import sys
+import warnings
 
 import payu
 import payu.envmod as envmod
@@ -23,9 +24,16 @@ from payu.models import index as supported_models
 from payu.schedulers import index as scheduler_index
 import payu.subcommands
 
-
 # Default configuration
 DEFAULT_CONFIG = 'config.yaml'
+
+# Force warnings.warn() to omit the source code line in the message
+formatwarning_orig = warnings.formatwarning
+warnings.formatwarning = (
+    lambda message, category, filename, lineno, line=None: (
+        formatwarning_orig(message, category, filename, lineno, line='')
+    )
+)
 
 
 def parse():

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -76,8 +76,8 @@ class DuplicateKeyWarnLoader(yaml.SafeLoader):
             if key in mapping:
                 warnings.warn(
                     "Duplicate key found in config.yaml: "
-                    f"key '{key}' with value '{value}' "
-                    f"(original value: '{mapping[key]}')"
+                    f"key '{key}' with value '{value}'. "
+                    f"This overwrites the original value: '{mapping[key]}'"
                 )
             mapping[key] = value
 

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -1,6 +1,7 @@
 from io import StringIO
 import os
 from pathlib import Path
+import payu.branch
 import pytest
 import shutil
 import stat
@@ -432,3 +433,34 @@ def test_run_userscript_command(tmp_path):
 ])
 def test_needs_shell(command, expected):
     assert payu.fsops.needs_subprocess_shell(command) == expected
+
+
+def test_read_config_yaml_duplicate_key():
+    """The PyYAML library is used for reading config.yaml, but use ruamel yaml
+    is used in when modifying config.yaml as part of payu checkout
+    (ruamel is used to preserve comments and multi-line strings).
+    This led to bug #441, where pyyaml allowed duplicate keys but
+    ruamel.library raises an error
+    """
+    # Create a yaml file with a duplicate key
+    config_content = """
+pbs_flags: value1
+pbs_flags: value2
+"""
+    config_path = tmpdir / "config.yaml"
+    with config_path.open("w") as file:
+        file.write(config_content)
+
+    # Test read config passes without an error but a warning is raised
+    warn_msg = r"Duplicate key found in config.yaml: key 'pbs_flags' with "
+    warn_msg += r"value 'value2' \(original value: 'value1'\)"
+    with pytest.warns(UserWarning, match=warn_msg):
+        payu.fsops.read_config(config_path)
+
+    restart_path = tmpdir / "restarts"
+
+    # Test add restart to config.yaml does not fail with an error, but
+    # still raises another warning that duplicates keys will be deleted
+    warn_msg = "Removing any subsequent duplicate keys from config.yaml"
+    with pytest.warns(UserWarning, match=warn_msg):
+        payu.branch.add_restart_to_config(restart_path, config_path)

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -452,8 +452,8 @@ pbs_flags: value2
         file.write(config_content)
 
     # Test read config passes without an error but a warning is raised
-    warn_msg = r"Duplicate key found in config.yaml: key 'pbs_flags' with "
-    warn_msg += r"value 'value2' \(original value: 'value1'\)"
+    warn_msg = "Duplicate key found in config.yaml: key 'pbs_flags' with "
+    warn_msg += "value 'value2'. This overwrites the original value: 'value1'"
     with pytest.warns(UserWarning, match=warn_msg):
         payu.fsops.read_config(config_path)
 


### PR DESCRIPTION
As suggested in this issue #441,
- Add warnings when reading config.yaml files with duplicate keys (as PyYAML library silently over-writes the value with the subsequent value) 
- When adding restarts to config.yaml when creating a new git branch, allow duplicate keys but still warn that they will get deleted when the config.yaml file gets modified (note the subsequent key will get deleted). Ruamel yaml library is used for modifying the config files as it can preserve multi-line strings and comments.
- Added a test for testing the warnings above

Closes #441

By default warnings are formatted with a line of the source code, e.g. the line `warnings.warn(` in
```
/home/189/jb4202/payu_fork/payu/fsops.py:83: UserWarning: Duplicate key found in config.yaml: key 'model' with value 'mom6' (original value: '')
  warnings.warn(
```
In fb45911983e399befc52e03feb9394a74c796f93, I have just patched the warnings used globally it doesn't include the line of source code. This is to avoid logs with like `warnings.warn(` with unclosed brackets. 

