### PR TITLE
Update check for load user modulefiles to allow  exact match

### DIFF
--- a/payu/envmod.py
+++ b/payu/envmod.py
@@ -185,6 +185,9 @@ def check_modulefile(modulefile: str) -> None:
     modules_avail = [line for line in output.strip().splitlines()
                      if not (line.startswith('/') and line.endswith(':'))]
 
+    # Remove () from end of modulefiles if they exist, e.g. (default)
+    modules_avail = [mod.rsplit('(', 1)[0] for mod in modules_avail]
+
     # Modules are used for finding model executable paths - so check
     # for unique module, or an exact match for the modulefile name
     if len(modules_avail) > 1 and modules_avail.count(modulefile) != 1:

--- a/test/test_envmod.py
+++ b/test/test_envmod.py
@@ -20,6 +20,20 @@ def test_check_modulefile_without_version(mock_module_cmd):
     mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
 test-module/1.0.0
 test-module/2.0.0
+test-module/3.0.1
+"""
+
+    # Expect an error raised
+    with pytest.raises(ValueError) as exc_info:
+        check_modulefile('test-module')
+        exc_info.value.startswith(
+            "There are multiple modules available for test-module"
+        )
+
+    # Mock module avail command use debug in name
+    mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
+test-module/1.0.0
+test-module/1.0.0-debug
 """
 
     # Expect an error raised
@@ -35,6 +49,27 @@ def test_check_modulefile_exact_match(mock_module_cmd):
     # Mock module avail command
     mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
 test-module/1.0.0
+test-module/1.0.0-debug
+"""
+
+    # Test runs without an error
+    check_modulefile('test-module/1.0.0')
+
+
+@patch('payu.envmod.run_module_cmd')
+def test_check_modulefile_exact_match_with_symbolic_version(mock_module_cmd):
+    # Mock module avail command
+    mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
+test-module/1.0.0(default)
+test-module/1.0.0-debug
+"""
+
+    # Test runs without an error
+    check_modulefile('test-module/1.0.0')
+
+    # Rerun test with another symbolic version/alias other than default
+    mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
+test-module/1.0.0(some_symbolic_name_or_alias)
 test-module/1.0.0-debug
 """
 

--- a/test/test_envmod.py
+++ b/test/test_envmod.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import patch
+
+from payu.envmod import check_modulefile
+
+
+@patch('payu.envmod.run_module_cmd')
+def test_check_modulefile_unique(mock_module_cmd):
+    # Mock module avail command
+    mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
+test-module/1.0.0
+"""
+    # Test runs without an error
+    check_modulefile('test-module/1.0.0')
+
+
+@patch('payu.envmod.run_module_cmd')
+def test_check_modulefile_without_version(mock_module_cmd):
+    # Mock module avail command
+    mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
+test-module/1.0.0
+test-module/2.0.0
+"""
+
+    # Expect an error raised
+    with pytest.raises(ValueError) as exc_info:
+        check_modulefile('test-module')
+        exc_info.value.startswith(
+            "There are multiple modules available for test-module"
+        )
+
+
+@patch('payu.envmod.run_module_cmd')
+def test_check_modulefile_exact_match(mock_module_cmd):
+    # Mock module avail command
+    mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
+test-module/1.0.0
+test-module/1.0.0-debug
+"""
+
+    # Test runs without an error
+    check_modulefile('test-module/1.0.0')
+
+
+@patch('payu.envmod.run_module_cmd')
+def test_check_modulefile_multiple_modules(mock_module_cmd):
+    # Mock module avail command
+    mock_module_cmd.return_value.stderr = """/path/to/modulefiles:
+test-module/1.0.0
+/another/module/path:
+test-module/1.0.0
+"""
+
+    # Expect an error raised
+    with pytest.raises(ValueError) as exc_info:
+        check_modulefile('test-module/1.0.0')
+        exc_info.value.startswith(
+            "There are multiple modules available for test-module"
+        )
+
+
+@patch('payu.envmod.run_module_cmd')
+def test_check_modulefile_no_modules_found(mock_module_cmd):
+    # Mock module avail command
+    mock_module_cmd.return_value.stderr = ""
+
+    # Expect an error raised
+    with pytest.raises(ValueError) as exc_info:
+        check_modulefile('test-module/1.0.0')
+        exc_info.value.startswith("Module is not found: test-module")


### PR DESCRIPTION
Allow checks for "modules: load:" modulefiles to allow when there's an exact match in available modules. This is to fix bug #481 where module avail for `openmpi/4.1.5` includes `openmpi/4.1.5` and `openmpi/4.1.5-debug`.

I've also added tests for parsing module avail output.

Closes #481.

@aidanheerdegen last week there was an issue with multiple modules found in `/g/data/vk83/modules` and `/g/data/vk83/modules/access-models`, even though they were the same modulefile. I noticed in the modules docs there's a `module paths` command that lists paths of available modulefiles matching a pattern so for the above, it would still evaluate to the same path. There's a couple of differences to `module avail`:
-  Running the command `module paths` using `modulecmd` (`$MODULESHOME//bin/modulecmd`) generates a bunch of code. So for `bash`, it generates a bunch of echo statements, rather than output going to `stderr` which is the case for `module avail`. So to get what values are printed, have to run the generated code, and then capture the output.
- Specifying `openmpi/` with a `/` just matches the default module version (I think), so only one path is returned.

If it's unlikely to have a case where `module/version` can be accessed from two different modulepaths and are different, e.g. 

```
/path/to/modulefiles:
test-module/1.0.0
/another/module/path:
test-module/1.0.0
```

The check could be changed from `modules_avail.count(modulefile) != 1` to `modulefile not in modules_avail` in this PR. Maybe this be moved to separate to avoid blocking this PR? 

