### PR TITLE
Enable seperate ice_history.nml & cice_in.nml settings

### DIFF
--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -51,10 +51,6 @@ class Access(Model):
 
             if model.model_type == 'cice5':
                 model.access_restarts.append(['u_star.nc', 'sicemass.nc'])
-            
-            if model.model_type == 'cice':
-                model.history_nml_fname = 'ice_history.nml'
-                model.optional_config_files.append(model.history_nml_fname)
 
 
     def setup(self):
@@ -90,26 +86,6 @@ class Access(Model):
 
                         if os.path.isfile(f_src):
                             make_symlink(f_src, f_dst)
-
-            if model.model_type == 'cice':
-                # Patch the cice namelist with the history requests 
-                # if a separate history namelist exists.
-                history_nml_fpath = os.path.join(model.control_path,
-                                         model.history_nml_fname)
-                if os.path.isfile(history_nml_fpath):
-                    history_nml = f90nml.read(history_nml_fpath)
-                    work_ice_nml_path = os.path.join(
-                        model.work_path,
-                        model.ice_nml_fname
-                    )
-                    #TODO: This requires that cice.py's setup has already been 
-                    # called so that the ice_nml exists in the control directory.
-                    # Is this always the case??
-                    work_ice_nml = f90nml.read(work_ice_nml_path)
-                    print("SPENCER: patching ice namelist")
-                    print(work_ice_nml_path)
-                    work_ice_nml.patch(history_nml)
-                    work_ice_nml.write(work_ice_nml_path, force = True)
             
             if model.model_type in ('cice', 'matm'):
 

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -51,6 +51,11 @@ class Access(Model):
 
             if model.model_type == 'cice5':
                 model.access_restarts.append(['u_star.nc', 'sicemass.nc'])
+            
+            if model.model_type == 'cice':
+                model.history_nml_fname = 'ice_history.nml'
+                model.optional_config_files.append(model.history_nml_fname)
+
 
     def setup(self):
         if not self.top_level_model:
@@ -86,6 +91,26 @@ class Access(Model):
                         if os.path.isfile(f_src):
                             make_symlink(f_src, f_dst)
 
+            if model.model_type == 'cice':
+                # Patch the cice namelist with the history requests 
+                # if a separate history namelist exists.
+                history_nml_fpath = os.path.join(model.control_path,
+                                         model.history_nml_fname)
+                if os.path.isfile(history_nml_fpath):
+                    history_nml = f90nml.read(history_nml_fpath)
+                    work_ice_nml_path = os.path.join(
+                        model.work_path,
+                        model.ice_nml_fname
+                    )
+                    #TODO: This requires that cice.py's setup has already been 
+                    # called so that the ice_nml exists in the control directory.
+                    # Is this always the case??
+                    work_ice_nml = f90nml.read(work_ice_nml_path)
+                    print("SPENCER: patching ice namelist")
+                    print(work_ice_nml_path)
+                    work_ice_nml.patch(history_nml)
+                    work_ice_nml.write(work_ice_nml_path, force = True)
+            
             if model.model_type in ('cice', 'matm'):
 
                 # Update the supplemental OASIS namelists

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -52,7 +52,6 @@ class Access(Model):
             if model.model_type == 'cice5':
                 model.access_restarts.append(['u_star.nc', 'sicemass.nc'])
 
-
     def setup(self):
         if not self.top_level_model:
             return
@@ -86,7 +85,7 @@ class Access(Model):
 
                         if os.path.isfile(f_src):
                             make_symlink(f_src, f_dst)
-            
+
             if model.model_type in ('cice', 'matm'):
 
                 # Update the supplemental OASIS namelists

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -158,7 +158,7 @@ class Cice(Model):
     def setup(self):
         super(Cice, self).setup()
 
-        # If there is a seperate ice_history.nml, 
+        # If there is a seperate ice_history.nml,
         # update the cice namelist with its contents
         history_nml_fpath = os.path.join(self.control_path,
                                          self.history_nml_fname)

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -254,10 +254,6 @@ class Cice(Model):
         assert(total_runtime % setup_nml['dt'] == 0)
         setup_nml['istep0'] = int(total_runtime / setup_nml['dt'])
 
-        if self.model_type != 'cice':  # model_type==cice5
-            # Force creation of a dump (restart) file at end of run
-            setup_nml['dump_last'] = True
-
         nml_path = os.path.join(self.work_path, self.ice_nml_fname)
         self.ice_in.write(nml_path, force=True)
 

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -247,6 +247,7 @@ class Cice(Model):
         # Force creation of a dump (restart) file at end of run
         setup_nml['dump_last'] = True
 
+        # Write the prepared cice namelist into the work directory
         nml_path = os.path.join(self.work_path, self.ice_nml_fname)
         self.ice_in.write(nml_path, force=True)
 

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -45,7 +45,7 @@ class Cice(Model):
 
         self.ice_nml_fname = 'cice_in.nml'
 
-        self.history_nml_fname = 'ice_history.nml' #only used by payu
+        self.history_nml_fname = 'ice_history.nml'  # only used by payu
 
         self.set_timestep = self.set_local_timestep
 
@@ -158,7 +158,8 @@ class Cice(Model):
     def setup(self):
         super(Cice, self).setup()
 
-        #  If there is a seperate ice_history.nml, update the cice namelist with its contents
+        # If there is a seperate ice_history.nml, 
+        # update the cice namelist with its contents
         history_nml_fpath = os.path.join(self.control_path,
                                          self.history_nml_fname)
         if os.path.isfile(history_nml_fpath):
@@ -253,11 +254,10 @@ class Cice(Model):
         assert(total_runtime % setup_nml['dt'] == 0)
         setup_nml['istep0'] = int(total_runtime / setup_nml['dt'])
 
-        if self.model_type != 'cice' : #model_type==cice5
+        if self.model_type != 'cice':  # model_type==cice5
             # Force creation of a dump (restart) file at end of run
             setup_nml['dump_last'] = True
 
-        # Write the prepared cice namelist into the work directory
         nml_path = os.path.join(self.work_path, self.ice_nml_fname)
         self.ice_in.write(nml_path, force=True)
 

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -53,6 +53,9 @@ class Cice5(Cice):
         self.ice_in.write(ice_in_path, force=True)
 
     def setup(self):
+       # Force creation of a dump (restart) file at end of run
+        self.ice_in['setup_nml']['dump_last'] = True
+
         super(Cice5, self).setup()
 
         # Make log dir

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -1,0 +1,144 @@
+import os
+import shutil
+
+import pytest
+import f90nml
+
+import payu
+
+from test.common import cd
+from test.common import tmpdir, ctrldir, labdir, expt_workdir, ctrldir_basename
+from test.common import write_config, write_metadata
+from test.common import make_inputs, make_exe
+
+verbose = True
+
+DEFAULT_CICE_NML = {
+    "setup_nml": {
+        "history_dir": "./HISTORY/",
+        "restart_dir": "./RESTART/",
+        "year_init": 9999,
+        "days_per_year": 360,
+        "ice_ic": "default",
+        "restart": ".false.",
+        "pointer_file": "./RESTART/ice.restart_file",
+        "runtype": "initial",
+        "npt": 99999,
+        "dt": 1,
+    },
+    "grid_nml": {"grid_file": "./INPUT/grid.nc", "kmt_file": "./INPUT/kmt.nc"},
+    "icefields_nml": {"f_icy": "x"},
+}
+CICE_NML_NAME = "cice_in.nml"
+HIST_NML_NAME = "ice_history.nml"
+
+
+def setup_module(module):
+    """
+    Put any test-wide setup code in here, e.g. creating test files
+    """
+    if verbose:
+        print("setup_module      module:%s" % module.__name__)
+
+    # Should be taken care of by teardown, in case remnants lying around
+    try:
+        shutil.rmtree(tmpdir)
+    except FileNotFoundError:
+        pass
+
+    try:
+        tmpdir.mkdir()
+        labdir.mkdir()
+        ctrldir.mkdir()
+        expt_workdir.mkdir(parents=True)
+        make_inputs()
+        make_exe()
+        write_metadata()
+    except Exception as e:
+        print(e)
+
+    config = {
+        "laboratory": "lab",
+        "jobname": "testrun",
+        "model": "cice",
+        "exe": "test.exe",
+        "experiment": ctrldir_basename,
+        "metadata": {"enable": False},
+    }
+    write_config(config)
+
+
+def teardown_module(module):
+    """
+    Put any test-wide teardown code in here, e.g. removing test outputs
+    """
+    if verbose:
+        print("teardown_module   module:%s" % module.__name__)
+
+    try:
+        shutil.rmtree(tmpdir)
+        print("removing tmp")
+    except Exception as e:
+        print(e)
+
+
+# Confirm that 1: payu overwrites cice_in with ice_history
+# 2: payu works without ice_history.nml
+# 3: payu overwrites cice_in and allows additional fields
+# In all cases confirm dump_last is not added to model_type='cice'
+@pytest.mark.parametrize(
+    "ice_history",
+    [
+        {"icefields_nml": { "f_icy": "m" }},
+        False,
+        {"icefields_nml": {"f_icy": "m", "f_new": "y"}},
+    ],
+)
+def test_setup(ice_history):
+    cice_nml = DEFAULT_CICE_NML
+
+    # create the files parsed by setup:
+    # 1. a restart pointer file
+    with cd(expt_workdir):
+        os.mkdir(cice_nml["setup_nml"]["restart_dir"])
+        with open(cice_nml["setup_nml"]["pointer_file"], "w") as f:
+            f.write("./RESTART/ice.r")
+            f.close()
+
+    with cd(ctrldir):
+        # 2. Create config.nml
+        f90nml.write(cice_nml, CICE_NML_NAME)
+        if ice_history:
+            f90nml.write(ice_history, HIST_NML_NAME)
+
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        model.setup()
+
+    # Check config files are moved to model's work path
+    work_path_files = os.listdir(model.work_path)
+    assert CICE_NML_NAME in work_path_files
+
+    # Check cice_in was patched with ice_history
+    work_input_fpath = os.path.join(model.work_path, CICE_NML_NAME)
+    input_nml = f90nml.read(work_input_fpath)
+    if ice_history:
+        assert input_nml["icefields_nml"] == ice_history["icefields_nml"]
+    else:
+        assert input_nml["icefields_nml"] == DEFAULT_CICE_NML["icefields_nml"]
+
+    # Check dump_last doesn't exist
+    with pytest.raises(KeyError, match="dump_last"):
+        input_nml["setup_nml"]["dump_last"]
+
+    # cleanup
+    with cd(expt_workdir):
+        os.remove(cice_nml["setup_nml"]["pointer_file"])
+        os.rmdir(cice_nml["setup_nml"]["restart_dir"])
+    with cd(ctrldir):
+        os.remove(CICE_NML_NAME)
+        if ice_history:
+            os.remove(HIST_NML_NAME)


### PR DESCRIPTION
To enable simpler changes to the icefields namelist in cice, this change adds support for an `ice_history.nml` file which is spliced into the normal cice runtime settings (`cice_in.nml`) by payu before the model is run.

This follow the discussion in https://forum.access-hive.org.au/t/access-esm1-5-release-work-plan/1721/24

The contents of ice_history.nml can be anything which also would fit in cice_in.nml , but the intention is to move &icefields_nml to the ice_history file

Do we need to update docs ? Or tests ? There doesn't appear to be any of either at this point 