### PR TITLE
add checks of io layout to cmeps driver

### DIFF
--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -198,10 +198,10 @@ class CesmCmeps(Model):
             if nthreads < 1:
                 raise ValueError(f"The number of {realm}_nthreads ({nthreads}) in "
                                  f"{NUOPC_CONFIG} must be at least 1.")
-                                 
+                           
             if nthreads > 1:
                 npes = nthreads*ntasks*pestride
-                # this is taken from 
+                # this is taken from
                 # https://github.com/ESCOMP/CMEPS/blob/5b7d76978e2fdc661ec2de4ba9834b985decadc6/cesm/driver/esm.F90#L1007
                 # the correct calculation might be (ntasks-1)*pestride*nthreads + nthreads
             else:
@@ -242,7 +242,17 @@ class CesmCmeps(Model):
                         case "netcdf4p" | "pnetcdf":
                             niotasks = int(self.runconfig.get(io_section, "pio_numiotasks"))
                             iostride = int(self.runconfig.get(io_section, "pio_stride"))
-                            if (ioroot + (niotasks-1)*iostride) >= npes:
+                            if (niotasks<=0) : 
+                                warn(f"The pio_numiotasks for {io_section} in {NUOPC_CONFIG} is "
+                                    "not set, using model default")
+                            if (iostride<=0) : 
+                                warn(f"The pio_stride for {io_section} in {NUOPC_CONFIG} is "
+                                    "not set, using model default")
+                            if (all(
+                                    niotasks>0, 
+                                    iostride>0,
+                                    ioroot + (niotasks-1)*iostride) >= npes
+                                ):
                                 raise ValueError(
                                     f"The iolayout for {io_section} in {NUOPC_CONFIG} is "
                                     "requesting out of range cpus"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -163,7 +163,7 @@ class CesmCmeps(Model):
             ntasks = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_ntasks"))
             rootpe = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_rootpe"))
             pestride = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_pestride"))
-            #rootpe is zero-based
+            # rootpe is zero-based
             if cpucount < (rootpe + ntasks*pestride):
                 raise ValueError(
                     f"Insufficient cpus for the {realm} pelayout in nuopc.runconfig"
@@ -172,26 +172,30 @@ class CesmCmeps(Model):
         # check iolayout
         for realm in self.realms:
             # med and cpl names are both used in runconfig
-            if realm == "cpl": realm="MED"
+            if realm == "cpl": 
+                realm = "MED"
             io_section = f"{realm.upper()}_modelio"
             nc_type = self.runconfig.get(io_section, "pio_typename")
             if nc_type == "netcdf4c":
                 raise ValueError(
-                    f"netcdf4c in {io_section} of nuopc.runconfig is deprecated, use netcdf4p"
+                    f"netcdf4c in {io_section} of nuopc.runconfig is deprecated, "
+                      "use netcdf4p"
                 )
             else:
                 # if nc_type is netcdf, only one pe is needed
-                ioroot=int(self.runconfig.get(io_section, "pio_root"))
+                ioroot = int(self.runconfig.get(io_section, "pio_root"))
                 if cpucount < int(ioroot):
                     raise ValueError(
-                        f"Insufficient cpus for the {io_section} ioroot pe in nuopc.runconfig"
+                        f"Insufficient cpus for the {io_section} ioroot pe in "
+                        "nuopc.runconfig"
                     )
                 if nc_type == "netcdf4p":
-                    niotasks=int(self.runconfig.get(io_section, "pio_numiotasks"))
-                    iostride=int(self.runconfig.get(io_section, "pio_stride"))
+                    niotasks = int(self.runconfig.get(io_section, "pio_numiotasks"))
+                    iostride = int(self.runconfig.get(io_section, "pio_stride"))
                     if cpucount <= (ioroot + niotasks*iostride):
                         raise ValueError(
-                            f"The iolayout for {io_section} in nuopc.runconfig is requesting out of range cpus"
+                            f"The iolayout for {io_section} in nuopc.runconfig is "
+                            "requesting out of range cpus"
                         )
 
         # Ensure that restarts will be written at the end of each run

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -198,7 +198,8 @@ class CesmCmeps(Model):
 
             if nthreads > 1:
                 npes = nthreads*ntasks*pestride
-                # this is taken from https://github.com/ESCOMP/CMEPS/blob/5b7d76978e2fdc661ec2de4ba9834b985decadc6/cesm/driver/esm.F90#L1007
+                # this is taken from 
+                # https://github.com/ESCOMP/CMEPS/blob/5b7d76978e2fdc661ec2de4ba9834b985decadc6/cesm/driver/esm.F90#L1007
                 # this correct calculation might be (ntasks-1)*pestride*nthreads + nthreads
             else:
                 npes = (ntasks-1)*pestride + 1

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -21,6 +21,7 @@ from payu.models.fms import fms_collate
 from payu.models.mom6 import mom6_add_parameter_files
 
 NUOPC_CONFIG = "nuopc.runconfig"
+NUOPC_RUNSEQ = "nuopc.runseq"
 
 # Add as needed
 component_info = {
@@ -76,7 +77,7 @@ class CesmCmeps(Model):
             "drv_in",
             "fd.yaml",
             NUOPC_CONFIG,
-            "nuopc.runseq"
+            NUOPC_RUNSEQ
         ]
 
         self.realms = ["ocn", "ice", "wav", "atm", "rof", "cpl"]

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -198,7 +198,6 @@ class CesmCmeps(Model):
             if nthreads < 1:
                 raise ValueError(f"The number of {realm}_nthreads ({nthreads}) in "
                                  f"{NUOPC_CONFIG} must be at least 1.")
-            
             if nthreads > 1:
                 npes = nthreads*ntasks*pestride
                 # this is taken from
@@ -244,10 +243,10 @@ class CesmCmeps(Model):
                             iostride = int(self.runconfig.get(io_section, "pio_stride"))
                             if (niotasks <= 0):
                                 warn(f"The pio_numiotasks for {io_section} in {NUOPC_CONFIG} is "
-                                    "not set, using model default")
+                                     "not set, using model default")
                             if (iostride <= 0):
                                 warn(f"The pio_stride for {io_section} in {NUOPC_CONFIG} is "
-                                    "not set, using model default")
+                                     "not set, using model default")
                             if (all([
                                     niotasks > 0, 
                                     iostride > 0,

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -195,7 +195,7 @@ class CesmCmeps(Model):
             nthreads = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_nthreads"))
             rootpe = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_rootpe"))
             pestride = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_pestride"))
-            npes = (ntasks-1)*nthreads*pestride  # count to the last process, starting at 0
+            npes = ntasks*nthreads*pestride  # count to the last process, starting at 0
             if (rootpe + npes) > cpucount:
                 raise ValueError(
                     f"Insufficient cpus for the {realm} pelayout in {NUOPC_CONFIG}"
@@ -224,7 +224,7 @@ class CesmCmeps(Model):
                         if self.runconfig.get(io_section, "pio_async_interface") == ".false.":
                             niotasks = int(self.runconfig.get(io_section, "pio_numiotasks"))
                             iostride = int(self.runconfig.get(io_section, "pio_stride"))
-                            if (int(ioroot) + (niotasks-1)*iostride) > npes:
+                            if (ioroot + niotasks*iostride) > npes:
                                 raise ValueError(
                                     f"The iolayout for {io_section} in {NUOPC_CONFIG} is "
                                     "requesting out of range cpus"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -195,7 +195,7 @@ class CesmCmeps(Model):
             nthreads = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_nthreads"))
             rootpe = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_rootpe"))
             pestride = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_pestride"))
-            npes = (ntasks-1)*nthreads*pestride  #count to the last process, starting at 0
+            npes = (ntasks-1)*nthreads*pestride  # count to the last process, starting at 0
             if (rootpe + npes) > cpucount:
                 raise ValueError(
                     f"Insufficient cpus for the {realm} pelayout in {NUOPC_CONFIG}"
@@ -204,7 +204,7 @@ class CesmCmeps(Model):
             # check iolayout
             if realm == "cpl":
                 comp = "MED"  # med and cpl names are both used in runconfig
-            else :
+            else:
                 comp = realm.upper()
             if comp in self.runconfig.get_component_list():
                 io_section = f"{comp}_modelio"
@@ -218,9 +218,9 @@ class CesmCmeps(Model):
                     )
 
                 match nc_type:
-                    case "netcdf" :
+                    case "netcdf":
                         break
-                    case "netcdf4p" | "pnetcdf" :
+                    case "netcdf4p" | "pnetcdf":
                         if self.runconfig.get(io_section, "pio_async_interface") == ".false." :
                             niotasks = int(self.runconfig.get(io_section, "pio_numiotasks"))
                             iostride = int(self.runconfig.get(io_section, "pio_stride"))
@@ -235,7 +235,7 @@ class CesmCmeps(Model):
                             f"netcdf4c in {io_section} of {NUOPC_CONFIG} is deprecated, "
                             "use netcdf4p"
                         )
-                    case _ : 
+                    case _:
                         raise ValueError(
                             f"The iotype for {io_section} in {NUOPC_CONFIG} is "
                             'invalid, valid options are "netcdf", "pnetcdf" and "netcdf4p"'
@@ -364,7 +364,7 @@ class Runconfig:
             return self.contents[span[0]:span[1]]
         else:
             return value
-        
+
     def get_component_list(self, value=None):
         """
         Get the `component_list`

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -205,7 +205,7 @@ class CesmCmeps(Model):
                 npes = nthreads*ntasks*pestride
                 # this is taken from 
                 # https://github.com/ESCOMP/CMEPS/blob/5b7d76978e2fdc661ec2de4ba9834b985decadc6/cesm/driver/esm.F90#L1007
-                # this correct calculation might be (ntasks-1)*pestride*nthreads + nthreads
+                # the correct calculation might be (ntasks-1)*pestride*nthreads + nthreads
             else:
                 npes = (ntasks-1)*pestride + 1
 

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -197,6 +197,10 @@ class CesmCmeps(Model):
             rootpe = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_rootpe"))
             pestride = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_pestride"))
 
+            if nthreads < 1:
+                raise ValueError(f"The number of {realm}_nthreads ({nthreads}) in "
+                                 f"{NUOPC_CONFIG} must be at least 1.")
+                                 
             if nthreads > 1:
                 npes = nthreads*ntasks*pestride
                 # this is taken from 

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -196,15 +196,13 @@ class CesmCmeps(Model):
             rootpe = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_rootpe"))
             pestride = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_pestride"))
 
-            if (pestride<nthreads):
-                raise ValueError(
-                    f"{realm}_pestride needs to be equal or greater than {realm}_nthreads"
-                )
-
-            npes = (ntasks-1)*pestride + nthreads  # count to the last process, starting at 0
-
-            # can pestride be less than nthreads ??
-
+            if nthreads > 1 :
+                npes = nthreads*ntasks*pestride 
+                # this is taken from https://github.com/ESCOMP/CMEPS/blob/5b7d76978e2fdc661ec2de4ba9834b985decadc6/cesm/driver/esm.F90#L1007
+                # this correct calculation might be (ntasks-1)*pestride*nthreads + nthreads
+            else: 
+                npes = (ntasks-1)*pestride + 1  
+            
             if (rootpe + npes) > cpucount:
                 raise ValueError(
                     f"Insufficient cpus for the {realm} pelayout in {NUOPC_CONFIG}"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -164,7 +164,7 @@ class CesmCmeps(Model):
             rootpe = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_rootpe"))
             pestride = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_pestride"))
             #rootpe is zero-based
-            if cpucount <= (rootpe + ntasks*pestride):
+            if cpucount < (rootpe + ntasks*pestride):
                 raise ValueError(
                     f"Insufficient cpus for the {realm} pelayout in nuopc.runconfig"
                 )
@@ -182,7 +182,7 @@ class CesmCmeps(Model):
             else:
                 # if nc_type is netcdf, only one pe is needed
                 ioroot=int(self.runconfig.get(io_section, "pio_root"))
-                if cpucount <= int(ioroot):
+                if cpucount < int(ioroot):
                     raise ValueError(
                         f"Insufficient cpus for the {io_section} ioroot pe in nuopc.runconfig"
                     )

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -164,7 +164,7 @@ class CesmCmeps(Model):
             rootpe = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_rootpe"))
             pestride = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_pestride"))
             #rootpe is zero-based
-            if cpucount >= (rootpe + ntasks*pestride):
+            if cpucount <= (rootpe + ntasks*pestride):
                 raise ValueError(
                     f"Insufficient cpus for the {realm} pelayout in nuopc.runconfig"
                 )
@@ -182,14 +182,14 @@ class CesmCmeps(Model):
             else:
                 # if nc_type is netcdf, only one pe is needed
                 ioroot=int(self.runconfig.get(io_section, "pio_root"))
-                if cpucount > int(ioroot):
+                if cpucount <= int(ioroot):
                     raise ValueError(
                         f"Insufficient cpus for the {io_section} ioroot pe in nuopc.runconfig"
                     )
                 if nc_type == "netcdf4p":
                     niotasks=int(self.runconfig.get(io_section, "pio_numiotasks"))
                     iostride=int(self.runconfig.get(io_section, "pio_stride"))
-                    if cpucount >= (ioroot + niotasks*iostride):
+                    if cpucount <= (ioroot + niotasks*iostride):
                         raise ValueError(
                             f"The iolayout for {io_section} in nuopc.runconfig is requesting out of range cpus"
                         )

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -198,7 +198,7 @@ class CesmCmeps(Model):
             if nthreads < 1:
                 raise ValueError(f"The number of {realm}_nthreads ({nthreads}) in "
                                  f"{NUOPC_CONFIG} must be at least 1.")
-                           
+            
             if nthreads > 1:
                 npes = nthreads*ntasks*pestride
                 # this is taken from
@@ -217,7 +217,7 @@ class CesmCmeps(Model):
                 comp = "MED"  # med and cpl names are both used in runconfig
             else:
                 comp = realm.upper()
-            
+
             if comp in self.runconfig.get_component_list():
                 io_section = f"{comp}_modelio"
                 nc_type = self.runconfig.get(io_section, "pio_typename")
@@ -242,17 +242,17 @@ class CesmCmeps(Model):
                         case "netcdf4p" | "pnetcdf":
                             niotasks = int(self.runconfig.get(io_section, "pio_numiotasks"))
                             iostride = int(self.runconfig.get(io_section, "pio_stride"))
-                            if (niotasks<=0) : 
+                            if (niotasks <= 0):
                                 warn(f"The pio_numiotasks for {io_section} in {NUOPC_CONFIG} is "
                                     "not set, using model default")
-                            if (iostride<=0) : 
+                            if (iostride <= 0):
                                 warn(f"The pio_stride for {io_section} in {NUOPC_CONFIG} is "
                                     "not set, using model default")
                             if (all([
-                                    niotasks>0, 
-                                    iostride>0,
+                                    niotasks > 0, 
+                                    iostride > 0,
                                     (ioroot + (niotasks-1)*iostride) >= npes
-                                ])):
+                            ])):
                                 raise ValueError(
                                     f"The iolayout for {io_section} in {NUOPC_CONFIG} is "
                                     "requesting out of range cpus"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -221,7 +221,7 @@ class CesmCmeps(Model):
                     case "netcdf":
                         break
                     case "netcdf4p" | "pnetcdf":
-                        if self.runconfig.get(io_section, "pio_async_interface") == ".false." :
+                        if self.runconfig.get(io_section, "pio_async_interface") == ".false.":
                             niotasks = int(self.runconfig.get(io_section, "pio_numiotasks"))
                             iostride = int(self.runconfig.get(io_section, "pio_stride"))
                             if (int(ioroot) + (niotasks-1)*iostride) > npes:

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -248,11 +248,11 @@ class CesmCmeps(Model):
                             if (iostride<=0) : 
                                 warn(f"The pio_stride for {io_section} in {NUOPC_CONFIG} is "
                                     "not set, using model default")
-                            if (all(
+                            if (all([
                                     niotasks>0, 
                                     iostride>0,
-                                    ioroot + (niotasks-1)*iostride) >= npes
-                                ):
+                                    (ioroot + (niotasks-1)*iostride) >= npes
+                                ])):
                                 raise ValueError(
                                     f"The iolayout for {io_section} in {NUOPC_CONFIG} is "
                                     "requesting out of range cpus"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -251,7 +251,7 @@ class CesmCmeps(Model):
                     case _:
                         raise ValueError(
                             f"The iotype for {io_section} in {NUOPC_CONFIG} is "
-                            'invalid, valid options are "netcdf", "pnetcdf" and "netcdf4p"'
+                            'invalid, valid options: "netcdf", "pnetcdf", "netcdf4p"'
                         )
         return True
 

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -196,13 +196,13 @@ class CesmCmeps(Model):
             rootpe = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_rootpe"))
             pestride = int(self.runconfig.get("PELAYOUT_attributes", f"{realm}_pestride"))
 
-            if nthreads > 1 :
-                npes = nthreads*ntasks*pestride 
+            if nthreads > 1:
+                npes = nthreads*ntasks*pestride
                 # this is taken from https://github.com/ESCOMP/CMEPS/blob/5b7d76978e2fdc661ec2de4ba9834b985decadc6/cesm/driver/esm.F90#L1007
                 # this correct calculation might be (ntasks-1)*pestride*nthreads + nthreads
-            else: 
-                npes = (ntasks-1)*pestride + 1  
-            
+            else:
+                npes = (ntasks-1)*pestride + 1
+
             if (rootpe + npes) > cpucount:
                 raise ValueError(
                     f"Insufficient cpus for the {realm} pelayout in {NUOPC_CONFIG}"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -222,8 +222,8 @@ class CesmCmeps(Model):
 
                 if ioroot >= npes:
                     raise ValueError(
-                        f"Insufficient cpus for the {io_section} ioroot pe in "
-                        f"{NUOPC_CONFIG}"
+                        f"{io_section} pio_root exceeds available PEs (max: {npes - 1}) "
+                        f"in {NUOPC_CONFIG}."
                     )
 
                 match nc_type:

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -312,4 +312,3 @@ def test__setup_checks_bad_io(pio_numiotasks, pio_stride):
             model._setup_checks()
 
     teardown_cmeps_config()
-    

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -12,6 +12,7 @@ from test.common import make_inputs, make_exe
 
 MODEL = 'access-om3'
 
+
 def setup_module(module):
     """
     Put any test-wide setup code in here, e.g. creating test files
@@ -117,8 +118,8 @@ def test__setup_checks_npes(ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_ro
     test_runconf = copy.deepcopy(MOCK_IO_RUNCONF)
     test_runconf["PELAYOUT_attributes"].update({
         "moc_ntasks": moc_ntasks,
-        "moc_nthreads": moc_nthreads ,
-        "moc_pestride": moc_pestride ,
+        "moc_nthreads": moc_nthreads,
+        "moc_pestride": moc_pestride,
         "moc_rootpe": moc_rootpe
         })
 
@@ -155,8 +156,8 @@ def test__setup_checks_too_many_pes(ncpu, moc_ntasks, moc_nthreads, moc_pestride
     test_runconf = copy.deepcopy(MOCK_IO_RUNCONF)
     test_runconf["PELAYOUT_attributes"].update({
         "moc_ntasks": moc_ntasks,
-        "moc_nthreads": moc_nthreads ,
-        "moc_pestride": moc_pestride ,
+        "moc_nthreads": moc_nthreads,
+        "moc_pestride": moc_pestride,
         "moc_rootpe": moc_rootpe
     })
 
@@ -177,10 +178,10 @@ def test__setup_checks_too_many_pes(ncpu, moc_ntasks, moc_nthreads, moc_pestride
 
 @pytest.mark.parametrize("ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename", [
                          (1, 1, 1, 0, "netcdf"),  # min
-                         (2, 1, 1, 1, "netcdf"),  # max root 
+                         (2, 1, 1, 1, "netcdf"),  # max root
                          (2, 2, 1, 0, "netcdf4p"),  # min tasks + rootpe
                          (2, 1, 1, 1, "netcdf4p"),  # max rootpe
-                         (5, 3, 2, 0, "netcdf4p"), 
+                         (5, 3, 2, 0, "netcdf4p"),
                          (100000, 50001, 1, 2, "netcdf4p"),  # odd ncpu
                          ])
 def test__setup_checks_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename):

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -98,17 +98,17 @@ class MockRunConfig:
 
 
 @pytest.mark.parametrize("ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe", [
-                         (1, 1, 1, 1, 0), #min
-                         (4, 4, 1, 1, 0), #min tasks
-                         (4, 2, 2, 2, 0), #min tasks * threads
-                         (4, 2, 1, 1, 2), #min tasks + rootpe
-                         (4, 1, 2, 2, 2), #min threads + rootpe
-                         (4, 1, 1, 1, 3), #max rootpe
-                         (5, 2, 1, 4, 0), #max stride
-                         (13, 4, 1, 3, 1), #odd ncpu
-                         (13, 2, 3, 3, 1), #odd ncpu
-                         (100000, 50000, 1, 2, 0), #max cpu
-                         (100000, 1, 1, 1, 99999), #max cpu
+                         (1, 1, 1, 1, 0),  # min
+                         (4, 4, 1, 1, 0),  # min tasks
+                         (4, 2, 2, 2, 0),  # min tasks * threads
+                         (4, 2, 1, 1, 2),  # min tasks + rootpe
+                         (4, 1, 2, 2, 2),  # min threads + rootpe
+                         (4, 1, 1, 1, 3),  # max rootpe
+                         (5, 2, 1, 4, 0),  # max stride
+                         (13, 4, 1, 3, 1),  # odd ncpu
+                         (13, 2, 3, 3, 1),  # odd ncpu
+                         (100000, 50000, 1, 2, 0),  # max cpu
+                         (100000, 1, 1, 1, 99999),  # max cpu
                          ])
 def test__setup_checks_npes(ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe):
 
@@ -137,16 +137,16 @@ def test__setup_checks_npes(ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_ro
 
 
 @pytest.mark.parametrize("ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe", [
-                         (1, 1, 1, 1, 1), #min
-                         (4, 5, 1, 1, 0), #min tasks
-                         (4, 2, 2, 2, 1), #min tasks * threads
-                         (2, 1, 2, 1, 1), #threads > strides
-                         (4, 1, 3, 1, 2), #min threads + rootpe
-                         (4, 1, 1, 1, 4), #max rootpe
-                         (13, 4, 1, 4, 1), #odd ncpu
-                         (13, 2, 7, 7, 0), #odd ncpu
-                         (100000, 50001, 1, 2, 0), #max cpu
-                         (100000, 1, 1, 1, 100000), #max cpu
+                         (1, 1, 1, 1, 1),  # min
+                         (4, 5, 1, 1, 0),  # min tasks
+                         (4, 2, 2, 2, 1),  # min tasks * threads
+                         (2, 1, 2, 1, 1),  # threads > strides
+                         (4, 1, 3, 1, 2),  # min threads + rootpe
+                         (4, 1, 1, 1, 4),  # max rootpe
+                         (13, 4, 1, 4, 1),  # odd ncpu
+                         (13, 2, 7, 7, 0),  # odd ncpu
+                         (100000, 50001, 1, 2, 0),  # max cpu
+                         (100000, 1, 1, 1, 100000),  # max cpu
                          ])
 def test__setup_checks_too_many_pes(ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe):
 
@@ -176,12 +176,12 @@ def test__setup_checks_too_many_pes(ncpu, moc_ntasks, moc_nthreads, moc_pestride
 
 
 @pytest.mark.parametrize("ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename", [
-                         (1, 1, 1, 0, "netcdf"), #min
-                         (2, 1, 1, 1, "netcdf"), #max root 
-                         (2, 2, 1, 0, "netcdf4p"), #min tasks + rootpe
-                         (2, 1, 1, 1, "netcdf4p"), #max rootpe
+                         (1, 1, 1, 0, "netcdf"),  # min
+                         (2, 1, 1, 1, "netcdf"),  # max root 
+                         (2, 2, 1, 0, "netcdf4p"),  # min tasks + rootpe
+                         (2, 1, 1, 1, "netcdf4p"),  # max rootpe
                          (5, 3, 2, 0, "netcdf4p"), 
-                         (100000, 50001, 1, 2, "netcdf4p"), #odd ncpu
+                         (100000, 50001, 1, 2, "netcdf4p"),  # odd ncpu
                          ])
 def test__setup_checks_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename):
 
@@ -214,11 +214,11 @@ def test__setup_checks_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typena
 
 @pytest.mark.parametrize("ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename", [
                          (1, 1, 1, 0, "netcdf4c"), 
-                         (2, 1, 1, 2, "netcdf"), #root too big 
-                         (2, 3, 1, 0, "netcdf4p"), #too manu tasks
-                         (2, 2, 2, 0, "netcdf4p"), #stride too big 
-                         (5, 2, 2, 3, "netcdf4p"), #stride too big
-                         (100000, 50000, 2, 2, "netcdf4p"), #odd ncpu
+                         (2, 1, 1, 2, "netcdf"),  # root too big 
+                         (2, 3, 1, 0, "netcdf4p"),  # too manu tasks
+                         (2, 2, 2, 0, "netcdf4p"),  # stride too big 
+                         (5, 2, 2, 3, "netcdf4p"),  # stride too big
+                         (100000, 50000, 2, 2, "netcdf4p"),  # odd ncpu
                          ])
 def test__setup_checks_bad_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename):
 

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -248,3 +248,4 @@ def test__setup_checks_bad_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_ty
             model._setup_checks()
 
     teardown_cmeps_config()
+    

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -248,4 +248,3 @@ def test__setup_checks_bad_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_ty
             model._setup_checks()
 
     teardown_cmeps_config()
-    

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -214,15 +214,14 @@ def test__setup_checks_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typena
 
 
 @pytest.mark.parametrize("ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename", [
-                         (1, 1, 1, 0, "netcdf4c"), 
-                         (2, 1, 1, 2, "netcdf"),  # root too big 
+                         (1, 1, 1, 0, "netcdf4c"),
+                         (2, 1, 1, 2, "netcdf"),  # root too big
                          (2, 3, 1, 0, "netcdf4p"),  # too manu tasks
-                         (2, 2, 2, 0, "netcdf4p"),  # stride too big 
+                         (2, 2, 2, 0, "netcdf4p"),  # stride too big
                          (5, 2, 2, 3, "netcdf4p"),  # stride too big
                          (100000, 50000, 2, 2, "netcdf4p"),  # odd ncpu
                          ])
 def test__setup_checks_bad_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename):
-
     cmeps_config(ncpu)
 
     test_runconf = copy.deepcopy(MOCK_IO_RUNCONF)
@@ -249,4 +248,3 @@ def test__setup_checks_bad_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_ty
             model._setup_checks()
 
     teardown_cmeps_config()
-

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -5,95 +5,13 @@ from pathlib import Path
 import pytest
 
 import payu
-from payu.models.cesm_cmeps import Runconfig
 
 from test.common import cd, tmpdir, ctrldir, labdir, workdir, write_config, config_path
 from test.common import config as config_orig
 from test.common import make_inputs, make_exe
 
 NCPU = 24
-
-
-@pytest.fixture()
-def runconfig_path():
-    return os.path.join('test', 'resources', 'nuopc.runconfig')
-
-
-@pytest.fixture()
-def runconfig(runconfig_path):
-    return Runconfig(runconfig_path)
-
-
-# Runconfig tests:
-
-@pytest.mark.parametrize(
-    "section, variable, expected",
-    [
-        ("ALLCOMP_attributes", "OCN_model", "mom"),
-        ("CLOCK_attributes", "restart_n", "1"),
-        ("DOES_NOT_EXIST", "OCN_model", None),
-        ("ALLCOMP_attributes", "DOES_NOT_EXIST", None),
-        ("allcomp_attributes", "OCN_model", None), # verify case sensitivity in section
-        ("ALLCOMP_attributes", "ocn_model", None), # verify case sensitivity in variable
-        ("ATM_attributes", "perpetual", ".false."), # correctly read booleans
-        ("ICE_attributes", "eps_imesh", "1e-13"), # correctly read commented value
-        ("MED_attributes", "histaux_atm2med_file1_flds", "Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf"), # correctly read long colon separated value
-    ]
-)
-def test_runconfig_get(section, variable, expected, runconfig):
-    """Test getting values from a nuopc.runconfig file"""
-    assert runconfig.get(section, variable) == expected
-
-
-def test_runconfig_get_default(runconfig):
-    """Test getting default values from a nuopc.runconfig file"""
-    assert runconfig.get("DOES_NOT_EXIST", "DOES_NOT_EXIST", value="default") == "default"
-
-
-def test_runconfig_get_component_list(runconfig):
-    """Test getting component_list from a nuopc.runconfig file"""
-    COMP_LIST = ['MED', 'ATM', 'ICE', 'OCN', 'ROF']
-    assert runconfig.get_component_list() == COMP_LIST
-
-
-@pytest.mark.parametrize(
-    "section, variable, new_variable",
-    [
-        ("ALLCOMP_attributes", "OCN_model", "pop"),
-        ("CLOCK_attributes", "restart_n", "2"),
-    ]
-)
-def test_runconfig_set(section, variable, new_variable, runconfig):
-    """Test setting values in a nuopc.runconfig file"""
-    runconfig.set(section, variable, new_variable)
-
-    assert runconfig.get(section, variable) == new_variable
-
-
-def test_runconfig_set_error(runconfig):
-    """Test error setting values in a nuopc.runconfig file that don't exist"""
-    with pytest.raises(
-        NotImplementedError,
-        match='Cannot set value of variable that does not already exist'
-        ):
-        runconfig.set("DOES_NOT_EXIST", "OCN_model", "value")
-        runconfig.set("ALLCOMP_attributes", "DOES_NOT_EXIST", "value")
-
-
-def test_runconfig_set_write_get(runconfig):
-    """Test updating the values in a nuopc.runconfig file"""
-    assert runconfig.get("CLOCK_attributes", "restart_n") == "1"
-
-    runconfig.set("CLOCK_attributes", "restart_n", "2")
-
-    runconfig_path_tmp = os.path.join(tmpdir, "nuopc.runconfig.tmp")
-    runconfig.write(file=runconfig_path_tmp)
-
-    runconfig_updated = Runconfig(runconfig_path_tmp)
-    assert runconfig_updated.get("CLOCK_attributes", "restart_n") == "2"
-
-    os.remove(runconfig_path_tmp)
-
+MODEL = 'access-om3'
 
 # Tests of cesm_cmeps
 
@@ -137,7 +55,7 @@ def cmeps_config():
     # Create a config.yaml and nuopc.runconfig file
 
     config = copy.deepcopy(config_orig)
-    config['model'] = 'access-om3'
+    config['model'] = MODEL
     config['ncpus'] = NCPU
 
     write_config(config)
@@ -261,7 +179,7 @@ def test__setup_checks_io(cmeps_config, modelio_patch):
 
 
 @pytest.mark.parametrize("modelio_patch", [
-                         {"pio_typename": "netcdf4s"},
+                         {"pio_typename": "netcdf4c"},
                          {"pio_typename": "netcdf", "pio_root": NCPU+1},
                          {"pio_numiotasks": NCPU+1},
                          {"pio_numiotasks": 1, "pio_root": NCPU},

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -278,14 +278,15 @@ def test__setup_checks_pio_async(pio_typename, pio_async_interface):
 
         with pytest.warns(
             Warning, match="does not do consistency checks for asynchronous pio"
-            ):
+        ):
             model._setup_checks()
 
     teardown_cmeps_config()
 
+
 @pytest.mark.parametrize("pio_numiotasks, pio_stride", [
                          (1, -99),
-                         (-99, 1), 
+                         (-99, 1),
                          ])
 def test__setup_checks_bad_io(pio_numiotasks, pio_stride):
     cmeps_config(1)
@@ -311,3 +312,4 @@ def test__setup_checks_bad_io(pio_numiotasks, pio_stride):
             model._setup_checks()
 
     teardown_cmeps_config()
+    

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -101,13 +101,13 @@ class MockRunConfig:
 @pytest.mark.parametrize("ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe", [
                          (1, 1, 1, 1, 0),  # min
                          (4, 4, 1, 1, 0),  # min tasks
-                         (4, 2, 2, 2, 0),  # min tasks * threads
+                         (4, 2, 2, 1, 0),  # min tasks * threads
                          (4, 2, 1, 1, 2),  # min tasks + rootpe
-                         (4, 1, 2, 2, 2),  # min threads + rootpe
+                         (4, 1, 2, 2, 0),  # min threads * rootpe
                          (4, 1, 1, 1, 3),  # max rootpe
                          (5, 2, 1, 4, 0),  # max stride
                          (13, 4, 1, 3, 1),  # odd ncpu
-                         (13, 2, 3, 3, 1),  # odd ncpu
+                         (13, 2, 3, 2, 1),  # odd ncpu
                          (100000, 50000, 1, 2, 0),  # max cpu
                          (100000, 1, 1, 1, 99999),  # max cpu
                          ])
@@ -140,7 +140,7 @@ def test__setup_checks_npes(ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_ro
 @pytest.mark.parametrize("ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe", [
                          (1, 1, 1, 1, 1),  # min
                          (4, 5, 1, 1, 0),  # min tasks
-                         (4, 2, 2, 2, 1),  # min tasks * threads
+                         (4, 1, 2, 2, 1),  # min tasks * threads
                          (2, 1, 2, 1, 1),  # threads > strides
                          (4, 1, 3, 1, 2),  # min threads + rootpe
                          (4, 1, 1, 1, 4),  # max rootpe

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -249,10 +249,11 @@ def test__setup_checks_bad_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_ty
 
     teardown_cmeps_config()
 
+
 @pytest.mark.parametrize("pio_typename, pio_async_interface", [
-                         ("netcdf4p", ".true."),  
-                         ("pnetcdf", ".true."),  
-                         ("netcdf", ".true."),   
+                         ("netcdf4p", ".true."),
+                         ("pnetcdf", ".true."),
+                         ("netcdf", ".true."),
                          ])
 def test__setup_checks_pio_async(pio_typename, pio_async_interface):
 
@@ -273,7 +274,9 @@ def test__setup_checks_pio_async(pio_typename, pio_async_interface):
 
         model.runconfig = MockRunConfig(test_runconf)
 
-        with pytest.warns(Warning, match = "does not do consistency checks for asynchronous pio"):
+        with pytest.warns(
+            Warning, match="does not do consistency checks for asynchronous pio"
+            ):
             model._setup_checks()
 
     teardown_cmeps_config()

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -12,8 +12,6 @@ from test.common import make_inputs, make_exe
 
 MODEL = 'access-om3'
 
-# Tests of cesm_cmeps
-
 def setup_module(module):
     """
     Put any test-wide setup code in here, e.g. creating test files
@@ -63,7 +61,7 @@ def cmeps_config(ncpu):
 
 
 def teardown_cmeps_config():
-     # Teardown
+    # Teardown
     os.remove(config_path)
 
 
@@ -100,17 +98,17 @@ class MockRunConfig:
 
 
 @pytest.mark.parametrize("ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe", [
-                         (1,1,1,1,0), #min
-                         (4,4,1,1,0), #min tasks
-                         (4,2,2,2,0), #min tasks * threads
-                         (4,2,1,1,2), #min tasks + rootpe
-                         (4,1,2,2,2), #min threads + rootpe
-                         (4,1,1,1,3), #max rootpe
-                         (5,2,1,4,0), #max stride
-                         (13,4,1,3,1), #odd ncpu
-                         (13,2,3,3,1), #odd ncpu
-                         (100000,50000,1,2,0), #max cpu
-                         (100000,1,1,1,99999), #max cpu
+                         (1, 1, 1, 1, 0), #min
+                         (4, 4, 1, 1, 0), #min tasks
+                         (4, 2, 2, 2, 0), #min tasks * threads
+                         (4, 2, 1, 1, 2), #min tasks + rootpe
+                         (4, 1, 2, 2, 2), #min threads + rootpe
+                         (4, 1, 1, 1, 3), #max rootpe
+                         (5, 2, 1, 4, 0), #max stride
+                         (13, 4, 1, 3, 1), #odd ncpu
+                         (13, 2, 3, 3, 1), #odd ncpu
+                         (100000, 50000, 1, 2, 0), #max cpu
+                         (100000, 1, 1, 1, 99999), #max cpu
                          ])
 def test__setup_checks_npes(ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe):
 
@@ -139,16 +137,16 @@ def test__setup_checks_npes(ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_ro
 
 
 @pytest.mark.parametrize("ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe", [
-                         (1,1,1,1,1), #min
-                         (4,5,1,1,0), #min tasks
-                         (4,2,2,2,1), #min tasks * threads
-                         (2,1,2,1,1), #threads > strides
-                         (4,1,3,1,2), #min threads + rootpe
-                         (4,1,1,1,4), #max rootpe
-                         (13,4,1,4,1), #odd ncpu
-                         (13,2,7,7,0), #odd ncpu
-                         (100000,50001,1,2,0), #max cpu
-                         (100000,1,1,1,100000), #max cpu
+                         (1, 1, 1, 1, 1), #min
+                         (4, 5, 1, 1, 0), #min tasks
+                         (4, 2, 2, 2, 1), #min tasks * threads
+                         (2, 1, 2, 1, 1), #threads > strides
+                         (4, 1, 3, 1, 2), #min threads + rootpe
+                         (4, 1, 1, 1, 4), #max rootpe
+                         (13, 4, 1, 4, 1), #odd ncpu
+                         (13, 2, 7, 7, 0), #odd ncpu
+                         (100000, 50001, 1, 2, 0), #max cpu
+                         (100000, 1, 1, 1, 100000), #max cpu
                          ])
 def test__setup_checks_too_many_pes(ncpu, moc_ntasks, moc_nthreads, moc_pestride, moc_rootpe):
 
@@ -178,12 +176,12 @@ def test__setup_checks_too_many_pes(ncpu, moc_ntasks, moc_nthreads, moc_pestride
 
 
 @pytest.mark.parametrize("ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename", [
-                         (1,1,1,0,"netcdf"), #min
-                         (2,1,1,1,"netcdf"), #max root 
-                         (2,2,1,0,"netcdf4p"), #min tasks + rootpe
-                         (2,1,1,1,"netcdf4p"), #max rootpe
-                         (5,3,2,0,"netcdf4p"), 
-                         (100000,50001,1,2,"netcdf4p"), #odd ncpu
+                         (1, 1, 1, 0, "netcdf"), #min
+                         (2, 1, 1, 1, "netcdf"), #max root 
+                         (2, 2, 1, 0, "netcdf4p"), #min tasks + rootpe
+                         (2, 1, 1, 1, "netcdf4p"), #max rootpe
+                         (5, 3, 2, 0, "netcdf4p"), 
+                         (100000, 50001, 1, 2, "netcdf4p"), #odd ncpu
                          ])
 def test__setup_checks_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename):
 
@@ -215,12 +213,12 @@ def test__setup_checks_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typena
 
 
 @pytest.mark.parametrize("ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename", [
-                         (1,1,1,0,"netcdf4c"), 
-                         (2,1,1,2,"netcdf"), #root too big 
-                         (2,3,1,0,"netcdf4p"), #too manu tasks
-                         (2,2,2,0,"netcdf4p"), #stride too big 
-                         (5,2,2,3,"netcdf4p"), #stride too big
-                         (100000,50000,2,2,"netcdf4p"), #odd ncpu
+                         (1, 1, 1, 0, "netcdf4c"), 
+                         (2, 1, 1, 2, "netcdf"), #root too big 
+                         (2, 3, 1, 0, "netcdf4p"), #too manu tasks
+                         (2, 2, 2, 0, "netcdf4p"), #stride too big 
+                         (5, 2, 2, 3, "netcdf4p"), #stride too big
+                         (100000, 50000, 2, 2, "netcdf4p"), #odd ncpu
                          ])
 def test__setup_checks_bad_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_typename):
 

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -248,3 +248,61 @@ def test__setup_checks_bad_io(ncpu, pio_numiotasks, pio_stride, pio_root, pio_ty
             model._setup_checks()
 
     teardown_cmeps_config()
+
+@pytest.mark.parametrize("pio_typename, pio_async_interface", [
+                         ("netcdf4p", ".true."),  
+                         ("pnetcdf", ".true."),  
+                         ("netcdf", ".true."),   
+                         ])
+def test__setup_checks_pio_async(pio_typename, pio_async_interface):
+
+    cmeps_config(1)
+
+    test_runconf = copy.deepcopy(MOCK_IO_RUNCONF)
+    test_runconf["MOC_modelio"].update(dict(
+        pio_async_interface=pio_async_interface,
+        pio_typename=pio_typename,
+    ))
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        model.realms = ["moc"]
+
+        model.runconfig = MockRunConfig(test_runconf)
+
+        with pytest.warns(Warning, match = "does not do consistency checks for asynchronous pio"):
+            model._setup_checks()
+
+    teardown_cmeps_config()
+
+@pytest.mark.parametrize("pio_typename, pio_async_interface", [
+                         ("netcdf4p", ".false."),  
+                         ("pnetcdf", ".false."),
+                         ("netcdf", ".false."),   
+                         ])
+@pytest.mark.filterwarnings("error")
+def test__setup_checks_not_pio_async(pio_typename, pio_async_interface):
+
+    cmeps_config(1)
+
+    test_runconf = copy.deepcopy(MOCK_IO_RUNCONF)
+    test_runconf["MOC_modelio"].update(dict(
+        pio_async_interface=pio_async_interface,
+        pio_typename=pio_typename,
+    ))
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        model.realms = ["moc"]
+
+        model.runconfig = MockRunConfig(test_runconf)
+
+        model._setup_checks()
+
+    teardown_cmeps_config()

--- a/test/models/access-om3/test_runconfig.py
+++ b/test/models/access-om3/test_runconfig.py
@@ -1,0 +1,92 @@
+import os
+import pytest
+import shutil
+
+from test.common import tmpdir
+from payu.models.cesm_cmeps import Runconfig
+
+
+@pytest.fixture()
+def runconfig_path():
+    return os.path.join('test', 'resources', 'nuopc.runconfig')
+
+
+@pytest.fixture()
+def runconfig(runconfig_path):
+    return Runconfig(runconfig_path)
+
+
+# Runconfig tests:
+
+@pytest.mark.parametrize(
+    "section, variable, expected",
+    [
+        ("ALLCOMP_attributes", "OCN_model", "mom"),
+        ("CLOCK_attributes", "restart_n", "1"),
+        ("DOES_NOT_EXIST", "OCN_model", None),
+        ("ALLCOMP_attributes", "DOES_NOT_EXIST", None),
+        ("allcomp_attributes", "OCN_model", None), # verify case sensitivity in section
+        ("ALLCOMP_attributes", "ocn_model", None), # verify case sensitivity in variable
+        ("ATM_attributes", "perpetual", ".false."), # correctly read booleans
+        ("ICE_attributes", "eps_imesh", "1e-13"), # correctly read commented value
+        ("MED_attributes", "histaux_atm2med_file1_flds", "Faxa_swndr:Faxa_swvdr:Faxa_swndf:Faxa_swvdf"), # correctly read long colon separated value
+    ]
+)
+def test_runconfig_get(section, variable, expected, runconfig):
+    """Test getting values from a nuopc.runconfig file"""
+    assert runconfig.get(section, variable) == expected
+
+
+def test_runconfig_get_default(runconfig):
+    """Test getting default values from a nuopc.runconfig file"""
+    assert runconfig.get("DOES_NOT_EXIST", "DOES_NOT_EXIST", value="default") == "default"
+
+
+def test_runconfig_get_component_list(runconfig):
+    """Test getting component_list from a nuopc.runconfig file"""
+    COMP_LIST = ['MED', 'ATM', 'ICE', 'OCN', 'ROF']
+    assert runconfig.get_component_list() == COMP_LIST
+
+
+@pytest.mark.parametrize(
+    "section, variable, new_variable",
+    [
+        ("ALLCOMP_attributes", "OCN_model", "pop"),
+        ("CLOCK_attributes", "restart_n", "2"),
+    ]
+)
+def test_runconfig_set(section, variable, new_variable, runconfig):
+    """Test setting values in a nuopc.runconfig file"""
+    runconfig.set(section, variable, new_variable)
+
+    assert runconfig.get(section, variable) == new_variable
+
+
+def test_runconfig_set_error(runconfig):
+    """Test error setting values in a nuopc.runconfig file that don't exist"""
+    with pytest.raises(
+        NotImplementedError,
+        match='Cannot set value of variable that does not already exist'
+        ):
+        runconfig.set("DOES_NOT_EXIST", "OCN_model", "value")
+        runconfig.set("ALLCOMP_attributes", "DOES_NOT_EXIST", "value")
+
+
+def test_runconfig_set_write_get(runconfig):
+    """Test updating the values in a nuopc.runconfig file"""
+
+    tmpdir.mkdir()
+
+    assert runconfig.get("CLOCK_attributes", "restart_n") == "1"
+
+    runconfig.set("CLOCK_attributes", "restart_n", "2")
+
+    runconfig_path_tmp = os.path.join(tmpdir, "nuopc.runconfig.tmp")
+    runconfig.write(file=runconfig_path_tmp)
+
+    runconfig_updated = Runconfig(runconfig_path_tmp)
+    assert runconfig_updated.get("CLOCK_attributes", "restart_n") == "2"
+
+    os.remove(runconfig_path_tmp)
+
+    shutil.rmtree(tmpdir)

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -134,10 +134,8 @@ def teardown_module(module):
 
 @pytest.fixture
 def cmeps_config():
-    # Write a cmeps model config file with 1 year runtime
-
-    # Create a config.yaml file with the cice submodel and 1 year run length
-
+    # Create a config.yaml and nuopc.runconfig file
+    
     config = copy.deepcopy(config_orig)
     config['model'] = 'access-om3'
     config['ncpus'] = NCPU

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -156,16 +156,16 @@ def cmeps_config():
 #valid minimum nuopc.runconfig for _setup_checks
 MOCK_IO_RUNCONF = {
     "PELAYOUT_attributes": dict(
-        moc_ntasks = NCPU ,
-        moc_nthreads = 1 ,
-        moc_pestride = 1 , 
+        moc_ntasks = NCPU,
+        moc_nthreads = 1,
+        moc_pestride = 1, 
         moc_rootpe = 0
     ),
     "MOC_modelio": dict(
-        pio_numiotasks = 1 ,
-        pio_rearranger = 1 ,
-        pio_root = 0 ,
-        pio_stride = 1 ,
+        pio_numiotasks = 1,
+        pio_rearranger = 1,
+        pio_root = 0,
+        pio_stride = 1,
         pio_typename = 'netcdf4p',
         pio_async_interface = '.false.'
     )
@@ -185,12 +185,12 @@ class MockRunConfig:
 
 
 @pytest.mark.parametrize("PELAYOUT_patch", [
-                         {"moc_ntasks":1},
-                         {"moc_ntasks":NCPU},
-                         {"moc_ntasks":2, "moc_nthreads":NCPU/2},
-                         {"moc_ntasks":2, "moc_pestride":NCPU/2},
-                         {"moc_ntasks":2, "moc_rootpe": NCPU-2},
-                         {"moc_ntasks":NCPU/4, "moc_nthreads":2, "moc_pestride":2}, 
+                         {"moc_ntasks": 1},
+                         {"moc_ntasks": NCPU},
+                         {"moc_ntasks": 2, "moc_nthreads": NCPU/2},
+                         {"moc_ntasks": 2, "moc_pestride": NCPU/2},
+                         {"moc_ntasks": 2, "moc_rootpe": NCPU-2},
+                         {"moc_ntasks": NCPU/4, "moc_nthreads": 2, "moc_pestride": 2}, 
                          ])
 def test__setup_checks_npes(cmeps_config, PELAYOUT_patch):
 
@@ -210,11 +210,11 @@ def test__setup_checks_npes(cmeps_config, PELAYOUT_patch):
 
 
 @pytest.mark.parametrize("PELAYOUT_patch", [
-                         {"moc_ntasks":NCPU+1},
-                         {"moc_ntasks":1, "moc_nthreads":NCPU+1},
-                         {"moc_ntasks":1, "moc_pestride":NCPU+1},
+                         {"moc_ntasks": NCPU+1},
+                         {"moc_ntasks":1, "moc_nthreads": NCPU+1},
+                         {"moc_ntasks":1, "moc_pestride": NCPU+1},
                          {"moc_ntasks":1, "moc_rootpe": NCPU},
-                         {"moc_ntasks":NCPU/4+1, "moc_nthreads":2, "moc_pestride":2}, 
+                         {"moc_ntasks": NCPU/4+1, "moc_nthreads":2, "moc_pestride":2}, 
                          ])
 def test__setup_checks_too_many_pes(cmeps_config, PELAYOUT_patch):
 
@@ -235,13 +235,13 @@ def test__setup_checks_too_many_pes(cmeps_config, PELAYOUT_patch):
 
 
 @pytest.mark.parametrize("modelio_patch", [
-                         {"pio_typename":"netcdf"},
-                         {"pio_typename":"netcdf", "pio_root":NCPU-1},
-                         {"pio_typename":"netcdf", "pio_stride":1000, "pio_numiotask":1000},
-                         {"pio_numiotasks":NCPU},
-                         {"pio_numiotasks":1,"pio_root":NCPU-1},
-                         {"pio_numiotasks":1,"pio_stride":NCPU},
-                         {"pio_numiotasks":1,"pio_root":NCPU/2,"pio_stride":NCPU/2}
+                         {"pio_typename": "netcdf"},
+                         {"pio_typename": "netcdf", "pio_root":NCPU-1},
+                         {"pio_typename": "netcdf", "pio_stride":1000, "pio_numiotask":1000},
+                         {"pio_numiotasks": NCPU},
+                         {"pio_numiotasks": 1, "pio_root":NCPU-1},
+                         {"pio_numiotasks": 1, "pio_stride":NCPU},
+                         {"pio_numiotasks": 1, "pio_root":NCPU/2, "pio_stride":NCPU/2}
                          ])
 def test__setup_checks_io(cmeps_config, modelio_patch):
 
@@ -261,19 +261,19 @@ def test__setup_checks_io(cmeps_config, modelio_patch):
 
 
 @pytest.mark.parametrize("modelio_patch", [
-                         {"pio_typename":"netcdf4s"},
-                         {"pio_typename":"netcdf", "pio_root":NCPU+1},
-                         {"pio_numiotasks":NCPU+1},
-                         {"pio_numiotasks":1,"pio_root":NCPU},
-                         {"pio_numiotasks":2,"pio_stride":NCPU},
-                         {"pio_numiotasks":1,"pio_stride":NCPU+1},
-                         {"pio_numiotasks":1,"pio_root":NCPU/2,"pio_stride":NCPU/2+1}
+                         {"pio_typename": "netcdf4s"},
+                         {"pio_typename": "netcdf", "pio_root": NCPU+1},
+                         {"pio_numiotasks": NCPU+1},
+                         {"pio_numiotasks": 1, "pio_root": NCPU},
+                         {"pio_numiotasks": 2, "pio_stride": NCPU},
+                         {"pio_numiotasks": 1, "pio_stride": NCPU+1},
+                         {"pio_numiotasks": 1, "pio_root": NCPU/2, "pio_stride": NCPU/2+1}
                          ])
 def test__setup_checks_bad_io(cmeps_config, modelio_patch):
 
     test_runconf = copy.deepcopy(MOCK_IO_RUNCONF)
     test_runconf["MOC_modelio"].update(modelio_patch)
-    
+
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
@@ -281,7 +281,7 @@ def test__setup_checks_bad_io(cmeps_config, modelio_patch):
 
         model.realms = ["moc"]
 
-        model.runconfig=MockRunConfig(test_runconf)
+        model.runconfig = MockRunConfig(test_runconf)
 
         with pytest.raises(ValueError):
             model._setup_checks() 

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -7,21 +7,21 @@ import pytest
 import payu
 from payu.models.cesm_cmeps import Runconfig
 
-from test.common import cd, tmpdir, ctrldir, labdir, workdir, archive_dir, write_config, config_path
+from test.common import cd, tmpdir, ctrldir, labdir, workdir, write_config, config_path
 from test.common import config as config_orig
 from test.common import make_inputs, make_exe
-from unittest.mock import patch 
 
-verbose = True
 NCPU=24
 
 @pytest.fixture()
 def runconfig_path():
     return os.path.join('test', 'resources', 'nuopc.runconfig')
 
+
 @pytest.fixture()
 def runconfig(runconfig_path):
     return Runconfig(runconfig_path)
+
 
 # Runconfig tests:
 
@@ -43,14 +43,17 @@ def test_runconfig_get(section, variable, expected, runconfig):
     """Test getting values from a nuopc.runconfig file"""
     assert runconfig.get(section, variable) == expected
 
+
 def test_runconfig_get_default(runconfig):
     """Test getting default values from a nuopc.runconfig file"""
     assert runconfig.get("DOES_NOT_EXIST", "DOES_NOT_EXIST", value="default") == "default"
+
 
 def test_runconfig_get_component_list(runconfig):
     """Test getting component_list from a nuopc.runconfig file"""
     COMP_LIST = ['MED', 'ATM', 'ICE', 'OCN', 'ROF']
     assert runconfig.get_component_list() == COMP_LIST
+
 
 @pytest.mark.parametrize(
     "section, variable, new_variable",
@@ -65,6 +68,7 @@ def test_runconfig_set(section, variable, new_variable, runconfig):
 
     assert runconfig.get(section, variable) == new_variable
 
+
 def test_runconfig_set_error(runconfig):
     """Test error setting values in a nuopc.runconfig file that don't exist"""
     with pytest.raises(
@@ -73,6 +77,7 @@ def test_runconfig_set_error(runconfig):
         ):
         runconfig.set("DOES_NOT_EXIST", "OCN_model", "value")
         runconfig.set("ALLCOMP_attributes", "DOES_NOT_EXIST", "value")
+
 
 def test_runconfig_set_write_get(runconfig):
     """Test updating the values in a nuopc.runconfig file"""
@@ -88,14 +93,13 @@ def test_runconfig_set_write_get(runconfig):
 
     os.remove(runconfig_path_tmp)
 
+
 # Tests of cesm_cmeps
 
 def setup_module(module):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
 
     # Should be taken care of by teardown, in case remnants lying around
     try:
@@ -119,8 +123,6 @@ def teardown_module(module):
     """
     Put any test-wide teardown code in here, e.g. removing test outputs
     """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
 
     try:
         shutil.rmtree(tmpdir)
@@ -140,9 +142,8 @@ def cmeps_config():
 
     write_config(config)
 
-    Path.touch(os.path.join(ctrldir,'nuopc.runconfig'))
-
-    # shutil.copy(str(runconfig_path), ctrldir)
+    with open(os.path.join(ctrldir,'nuopc.runconfig'), "w") as f:
+        f.close()
 
     # Run test
     yield
@@ -150,8 +151,8 @@ def cmeps_config():
     # Teardown
     os.remove(config_path)
 
-# Mock runconfig for some tests
 
+# Mock runconfig for some tests
 #valid minimum nuopc.runconfig for _setup_checks
 MOCK_IO_RUNCONF = {
     "PELAYOUT_attributes": dict(
@@ -182,6 +183,7 @@ class MockRunConfig:
     def get(self, section, variable, value=None):
         return self.conf[section][variable]
 
+
 @pytest.mark.parametrize("PELAYOUT_patch", [
                          {"moc_ntasks":1},
                          {"moc_ntasks":NCPU},
@@ -205,6 +207,7 @@ def test__setup_checks_npes(cmeps_config, PELAYOUT_patch):
         model.runconfig=MockRunConfig(test_runconf)
 
         model._setup_checks()  
+
 
 @pytest.mark.parametrize("PELAYOUT_patch", [
                          {"moc_ntasks":NCPU+1},
@@ -230,6 +233,7 @@ def test__setup_checks_too_many_pes(cmeps_config, PELAYOUT_patch):
         with pytest.raises(ValueError):
             model._setup_checks() 
 
+
 @pytest.mark.parametrize("modelio_patch", [
                          {"pio_typename":"netcdf"},
                          {"pio_typename":"netcdf", "pio_root":NCPU-1},
@@ -254,6 +258,7 @@ def test__setup_checks_io(cmeps_config, modelio_patch):
         model.runconfig=MockRunConfig(test_runconf)
 
         model._setup_checks()  
+
 
 @pytest.mark.parametrize("modelio_patch", [
                          {"pio_typename":"netcdf4s"},

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -131,6 +131,7 @@ def teardown_module(module):
     except Exception as e:
         print(e)
 
+
 @pytest.fixture
 def cmeps_config():
     # Write a cmeps model config file with 1 year runtime
@@ -143,7 +144,7 @@ def cmeps_config():
 
     write_config(config)
 
-    with open(os.path.join(ctrldir,'nuopc.runconfig'), "w") as f:
+    with open(os.path.join(ctrldir, 'nuopc.runconfig'), "w") as f:
         f.close()
 
     # Run test
@@ -154,21 +155,21 @@ def cmeps_config():
 
 
 # Mock runconfig for some tests
-#valid minimum nuopc.runconfig for _setup_checks
+# valid minimum nuopc.runconfig for _setup_checks
 MOCK_IO_RUNCONF = {
     "PELAYOUT_attributes": dict(
-        moc_ntasks = NCPU,
-        moc_nthreads = 1,
-        moc_pestride = 1, 
-        moc_rootpe = 0
+        moc_ntasks= NCPU,
+        moc_nthreads= 1,
+        moc_pestride= 1, 
+        moc_rootpe= 0
     ),
     "MOC_modelio": dict(
-        pio_numiotasks = 1,
-        pio_rearranger = 1,
-        pio_root = 0,
-        pio_stride = 1,
-        pio_typename = 'netcdf4p',
-        pio_async_interface = '.false.'
+        pio_numiotasks= 1,
+        pio_rearranger= 1,
+        pio_root= 0,
+        pio_stride= 1,
+        pio_typename= 'netcdf4p',
+        pio_async_interface= '.false.'
     )
 }
 

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -31,6 +31,15 @@ def test_runconfig_get_default():
 
     assert runconfig.get("DOES_NOT_EXIST", "DOES_NOT_EXIST", value="default") == "default"
 
+def test_runconfig_get_component_list():
+    """Test getting component_list from a nuopc.runconfig file"""
+    COMP_LIST = ['MED', 'ATM', 'ICE', 'OCN', 'ROF']
+
+    runconfig_path = os.path.join('test', 'resources', 'nuopc.runconfig')
+    runconfig = Runconfig(runconfig_path)
+
+    assert runconfig.get_component_list() == COMP_LIST
+
 @pytest.mark.parametrize(
     "section, variable, new_variable",
     [
@@ -75,3 +84,4 @@ def test_runconfig_set_write_get():
     assert runconfig.get("CLOCK_attributes", "restart_n") == "2"
 
     os.remove(runconfig_path_tmp)
+

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -247,7 +247,7 @@ def test__setup_checks_io(cmeps_config, modelio_patch):
 
     test_runconf = copy.deepcopy(MOCK_IO_RUNCONF)
     test_runconf["MOC_modelio"].update(modelio_patch)
-    
+
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -211,9 +211,9 @@ def test__setup_checks_npes(cmeps_config, PELAYOUT_patch):
 
 @pytest.mark.parametrize("PELAYOUT_patch", [
                          {"moc_ntasks": NCPU+1},
-                         {"moc_ntasks":1, "moc_nthreads": NCPU+1},
-                         {"moc_ntasks":1, "moc_pestride": NCPU+1},
-                         {"moc_ntasks":1, "moc_rootpe": NCPU},
+                         {"moc_ntasks": 1, "moc_nthreads": NCPU+1},
+                         {"moc_ntasks": 1, "moc_pestride": NCPU+1},
+                         {"moc_ntasks": 1, "moc_rootpe": NCPU},
                          {"moc_ntasks": NCPU/4+1, "moc_nthreads":2, "moc_pestride":2}, 
                          ])
 def test__setup_checks_too_many_pes(cmeps_config, PELAYOUT_patch):
@@ -236,12 +236,12 @@ def test__setup_checks_too_many_pes(cmeps_config, PELAYOUT_patch):
 
 @pytest.mark.parametrize("modelio_patch", [
                          {"pio_typename": "netcdf"},
-                         {"pio_typename": "netcdf", "pio_root":NCPU-1},
-                         {"pio_typename": "netcdf", "pio_stride":1000, "pio_numiotask":1000},
+                         {"pio_typename": "netcdf", "pio_root": NCPU-1},
+                         {"pio_typename": "netcdf", "pio_stride": 1000, "pio_numiotask": 1000},
                          {"pio_numiotasks": NCPU},
-                         {"pio_numiotasks": 1, "pio_root":NCPU-1},
-                         {"pio_numiotasks": 1, "pio_stride":NCPU},
-                         {"pio_numiotasks": 1, "pio_root":NCPU/2, "pio_stride":NCPU/2}
+                         {"pio_numiotasks": 1, "pio_root": NCPU-1},
+                         {"pio_numiotasks": 1, "pio_stride": NCPU},
+                         {"pio_numiotasks": 1, "pio_root": NCPU/2, "pio_stride": NCPU/2}
                          ])
 def test__setup_checks_io(cmeps_config, modelio_patch):
 

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -214,7 +214,7 @@ def test__setup_checks_npes(cmeps_config, PELAYOUT_patch):
                          {"moc_ntasks": 1, "moc_nthreads": NCPU+1},
                          {"moc_ntasks": 1, "moc_pestride": NCPU+1},
                          {"moc_ntasks": 1, "moc_rootpe": NCPU},
-                         {"moc_ntasks": NCPU/4+1, "moc_nthreads":2, "moc_pestride":2}, 
+                         {"moc_ntasks": NCPU/4+1, "moc_nthreads": 2, "moc_pestride": 2},
                          ])
 def test__setup_checks_too_many_pes(cmeps_config, PELAYOUT_patch):
 
@@ -228,7 +228,7 @@ def test__setup_checks_too_many_pes(cmeps_config, PELAYOUT_patch):
 
         model.realms = ["moc"]
 
-        model.runconfig=MockRunConfig(test_runconf)
+        model.runconfig = MockRunConfig(test_runconf)
 
         with pytest.raises(ValueError):
             model._setup_checks() 
@@ -255,7 +255,7 @@ def test__setup_checks_io(cmeps_config, modelio_patch):
 
         model.realms = ["moc"]
 
-        model.runconfig=MockRunConfig(test_runconf)
+        model.runconfig = MockRunConfig(test_runconf)
 
         model._setup_checks()  
 

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -135,7 +135,7 @@ def teardown_module(module):
 @pytest.fixture
 def cmeps_config():
     # Create a config.yaml and nuopc.runconfig file
-    
+
     config = copy.deepcopy(config_orig)
     config['model'] = 'access-om3'
     config['ncpus'] = NCPU
@@ -156,18 +156,18 @@ def cmeps_config():
 # valid minimum nuopc.runconfig for _setup_checks
 MOCK_IO_RUNCONF = {
     "PELAYOUT_attributes": dict(
-        moc_ntasks= NCPU,
-        moc_nthreads= 1,
-        moc_pestride= 1, 
-        moc_rootpe= 0
+        moc_ntasks=NCPU,
+        moc_nthreads=1,
+        moc_pestride=1,
+        moc_rootpe=0
     ),
     "MOC_modelio": dict(
-        pio_numiotasks= 1,
-        pio_rearranger= 1,
-        pio_root= 0,
-        pio_stride= 1,
-        pio_typename= 'netcdf4p',
-        pio_async_interface= '.false.'
+        pio_numiotasks=1,
+        pio_rearranger=1,
+        pio_root=0,
+        pio_stride=1,
+        pio_typename='netcdf4p',
+        pio_async_interface='.false.'
     )
 }
 
@@ -190,7 +190,7 @@ class MockRunConfig:
                          {"moc_ntasks": 2, "moc_nthreads": NCPU/2},
                          {"moc_ntasks": 2, "moc_pestride": NCPU/2},
                          {"moc_ntasks": 2, "moc_rootpe": NCPU-2},
-                         {"moc_ntasks": NCPU/4, "moc_nthreads": 2, "moc_pestride": 2}, 
+                         {"moc_ntasks": NCPU/4, "moc_nthreads": 2, "moc_pestride": 2},
                          ])
 def test__setup_checks_npes(cmeps_config, PELAYOUT_patch):
 
@@ -204,7 +204,7 @@ def test__setup_checks_npes(cmeps_config, PELAYOUT_patch):
 
         model.realms = ["moc"]
 
-        model.runconfig=MockRunConfig(test_runconf)
+        model.runconfig = MockRunConfig(test_runconf)
 
         model._setup_checks()  
 

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -206,7 +206,7 @@ def test__setup_checks_npes(cmeps_config, PELAYOUT_patch):
 
         model.runconfig = MockRunConfig(test_runconf)
 
-        model._setup_checks()  
+        model._setup_checks()
 
 
 @pytest.mark.parametrize("PELAYOUT_patch", [
@@ -231,7 +231,7 @@ def test__setup_checks_too_many_pes(cmeps_config, PELAYOUT_patch):
         model.runconfig = MockRunConfig(test_runconf)
 
         with pytest.raises(ValueError):
-            model._setup_checks() 
+            model._setup_checks()
 
 
 @pytest.mark.parametrize("modelio_patch", [
@@ -257,7 +257,7 @@ def test__setup_checks_io(cmeps_config, modelio_patch):
 
         model.runconfig = MockRunConfig(test_runconf)
 
-        model._setup_checks()  
+        model._setup_checks()
 
 
 @pytest.mark.parametrize("modelio_patch", [
@@ -284,4 +284,4 @@ def test__setup_checks_bad_io(cmeps_config, modelio_patch):
         model.runconfig = MockRunConfig(test_runconf)
 
         with pytest.raises(ValueError):
-            model._setup_checks() 
+            model._setup_checks()

--- a/test/models/test_cesm_cmeps.py
+++ b/test/models/test_cesm_cmeps.py
@@ -11,7 +11,8 @@ from test.common import cd, tmpdir, ctrldir, labdir, workdir, write_config, conf
 from test.common import config as config_orig
 from test.common import make_inputs, make_exe
 
-NCPU=24
+NCPU = 24
+
 
 @pytest.fixture()
 def runconfig_path():
@@ -85,8 +86,8 @@ def test_runconfig_set_write_get(runconfig):
 
     runconfig.set("CLOCK_attributes", "restart_n", "2")
 
-    runconfig_path_tmp = os.path.join(tmpdir,"nuopc.runconfig.tmp")
-    runconfig.write(file = runconfig_path_tmp)
+    runconfig_path_tmp = os.path.join(tmpdir, "nuopc.runconfig.tmp")
+    runconfig.write(file=runconfig_path_tmp)
 
     runconfig_updated = Runconfig(runconfig_path_tmp)
     assert runconfig_updated.get("CLOCK_attributes", "restart_n") == "2"


### PR DESCRIPTION
This PR implements checks of the processors selected in the nuopc.runconfig file for the access-om3 payu driver.  This ensures that the processors requested for normal model operations and parallel IO are within range of the CPUs set in config.yaml and each model "realm" uses processors for IO that are within the range of processors for that realm.

It adds tests for the min/max bounds of each parameter.

Contributes to https://github.com/COSIMA/access-om3/issues/109