### PR TITLE
Drop Python 3.9 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
     # Run the job for different versions of python
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -26,7 +26,7 @@ requirements:
         - setuptools >=61.0.0
         - versioneer
     run:
-        - python >=3.9
+        - python >=3.10
         {% for dep in project.get('dependencies', []) %}
         - {{ dep }}
         {% endfor %}


### PR DESCRIPTION
Remove Python 3.9 from CI tests, and update minimum python in `run` requirements in conda meta.yaml. 

Closes #497 