### PR TITLE
Default shortpath project bug

### DIFF
--- a/payu/laboratory.py
+++ b/payu/laboratory.py
@@ -67,7 +67,7 @@ class Laboratory(object):
         # Default path settings
 
         # Append project name if present (NCI-specific)
-        default_project = os.environ.get('PROJECT', '')
+        default_project = config.get('project', os.environ.get('PROJECT', ''))
         default_short_path = os.path.join(self.base, default_project)
         default_user = pwd.getpwuid(os.getuid()).pw_name
 


### PR DESCRIPTION
Closes #502 

If `project` is defined in `config.yaml`, use this project for default shortpaths. This is to prevent a mismatch of default shortpath when running commands on a login-node vs on a PBS `payu run` submission.

I also refactored the tests for laboratory basepaths to make each test a bit more isolated. I also added a couple more test cases.
