### PR TITLE
Readthedocs version tag

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_build:
+      - payu --version # Display version of payu
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -23,6 +26,8 @@ formats:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
+python:
+  install:
+    - method: pip
+      path: . # Installs payu
 #     - requirements: docs/requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,11 +1,4 @@
-import os
-import sys
-
-sys.path.insert(1, '../../')
 import payu
-
-# Path to extensions
-sys.path.insert(0, os.path.dirname(os.path.abspath(os.pardir)))
 
 # Sphinx setup
 #needs_sphinx = '1.0'


### PR DESCRIPTION
As brought up in #494, the `readthedocs` versions are `1.1.5+0.g78f67ff.dirty` for `1.1.5`. I think the reason why is due to new files during added during readthedocs build (`docs/source/_build/` and `_readthedocs/`), and auto-generated content is added to `docs/source/conf.py`. Due to these modifications in the repository, when payu is imported in `docs/source/conf.py`  and the version is determined,  `versioneer` marks the versions as `dirty`.

To prevent this, I've added an local pip install of `payu` to run before the docs build step, so the version is unaffected by the modified files. The documentation build for this PR now has no `dirty` tag: https://payu--505.org.readthedocs.build/en/505/.

With some local testing, if an `1.1.5` tag is checked out, there a modification to a file and then payu is locally installed, the version is `1.1.5+0.g78f67ff.dirty` (`payu --version`). If there are no modifications, the version is `1.1.5`. 
