### PR TITLE
Don't require `cice_in.nml` namelist in CICE5 restarts

### DIFF
--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -325,8 +325,9 @@ class Cice(Model):
             if os.path.isfile(test_path):
                 input_path = test_path
                 break
-        raise RuntimeError(
-            f"Cannot find previous restart file, expected {fpath} to exist"
-        )
+        if input_path is None:
+            raise RuntimeError(
+                f"Cannot find previous restart file, expected {fpath} to exist"
+            )
 
         make_symlink(input_path, input_work_path)

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -185,8 +185,7 @@ class Cice(Model):
                 iced_restart_file = sorted(iced_restart_files)[-1]
 
             if iced_restart_file is None:
-                print('payu: error: No restart file available.')
-                sys.exit(errno.ENOENT)
+                raise RuntimeError('payu: error: No restart file available.')
 
             res_ptr_path = os.path.join(self.work_init_path,
                                         'ice.restart_file')
@@ -326,6 +325,8 @@ class Cice(Model):
             if os.path.isfile(test_path):
                 input_path = test_path
                 break
-        assert input_path
+        raise RuntimeError(
+            f"Cannot find previous restart file, expected {fpath} to exist"
+        )
 
         make_symlink(input_path, input_work_path)

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -167,12 +167,6 @@ class Cice(Model):
             self.ice_in.patch(history_nml)
 
         setup_nml = self.ice_in['setup_nml']
-        init_date = datetime.date(year=setup_nml['year_init'], month=1, day=1)
-
-        if setup_nml['days_per_year'] == 365:
-            caltype = cal.NOLEAP
-        else:
-            caltype = cal.GREGORIAN
 
         if self.prior_restart_path:
             # Generate ice.restart_file
@@ -200,15 +194,38 @@ class Cice(Model):
             setup_nml['runtype'] = 'continue'
             setup_nml['restart'] = True
 
-            prior_nml_path = os.path.join(self.prior_restart_path,
-                                          self.ice_nml_fname)
+        else:
+            # Locate and link any restart files (if required)
+            if not setup_nml['ice_ic'] in ('none', 'default'):
+                self.link_restart(setup_nml['ice_ic'])
 
+            if setup_nml['restart']:
+                self.link_restart(setup_nml['pointer_file'])
+
+        self.calc_timestep_runtime(setup_nml)
+
+        # Write any changes to the work directory copy of the cice
+        # namelist
+        nml_path = os.path.join(self.work_path, self.ice_nml_fname)
+        self.ice_in.write(nml_path, force=True)
+
+    def calc_timestep_runtime(self, setup_nml):
+        init_date = datetime.date(year=setup_nml['year_init'], month=1, day=1)
+        if setup_nml['days_per_year'] == 365:
+            caltype = cal.NOLEAP
+        else:
+            caltype = cal.GREGORIAN
+
+        if self.prior_restart_path:
+
+            prior_nml_path = os.path.join(self.prior_restart_path,
+                                        self.ice_nml_fname)
             # With later versions this file exists in the prior restart path,
             # but this was not always the case, so check, and if not there use
             # prior output path
             if not os.path.exists(prior_nml_path) and self.prior_output_path:
                 prior_nml_path = os.path.join(self.prior_output_path,
-                                              self.ice_nml_fname)
+                                                self.ice_nml_fname)
 
             # If we cannot find a prior namelist, then we cannot determine
             # the start time and must abort the run.
@@ -220,22 +237,16 @@ class Cice(Model):
             prior_setup_nml = f90nml.read(prior_nml_path)['setup_nml']
 
             # The total time in seconds since the beginning of the experiment
-            total_runtime = prior_setup_nml['istep0'] + prior_setup_nml['npt']
-            total_runtime = total_runtime * prior_setup_nml['dt']
+            prior_runtime = prior_setup_nml['istep0'] + prior_setup_nml['npt']
+            prior_runtime_seconds = prior_runtime * prior_setup_nml['dt']
+
         else:
-            # Locate and link any restart files (if required)
-            if not setup_nml['ice_ic'] in ('none', 'default'):
-                self.link_restart(setup_nml['ice_ic'])
-
-            if setup_nml['restart']:
-                self.link_restart(setup_nml['pointer_file'])
-
             # Initialise runtime
-            total_runtime = 0
+            prior_runtime_seconds = 0
 
         # Set runtime for this run.
         if self.expt.runtime:
-            run_start_date = cal.date_plus_seconds(init_date, total_runtime,
+            run_start_date = cal.date_plus_seconds(init_date, prior_runtime_seconds,
                                                    caltype)
             run_runtime = cal.runtime_from_date(
                 run_start_date,
@@ -247,14 +258,17 @@ class Cice(Model):
             )
         else:
             run_runtime = setup_nml['npt']*setup_nml['dt']
-
-        # Now write out new run start date and total runtime.
+        
+        # Add the prior runtime and new runtime to the working copy of the
+        # CICE namelist.
         setup_nml['npt'] = run_runtime / setup_nml['dt']
-        assert(total_runtime % setup_nml['dt'] == 0)
-        setup_nml['istep0'] = int(total_runtime / setup_nml['dt'])
+        assert (prior_runtime_seconds % setup_nml['dt'] == 0)
+        setup_nml['istep0'] = int(prior_runtime_seconds / setup_nml['dt'])
 
-        nml_path = os.path.join(self.work_path, self.ice_nml_fname)
-        self.ice_in.write(nml_path, force=True)
+        
+
+
+
 
     def set_local_timestep(self, t_step):
         dt = self.ice_in['setup_nml']['dt']

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -214,10 +214,7 @@ class Cice(Model):
         Calculate 1: the previous number of timesteps simulated, and 2:
         the number of timesteps to simulate in the next run.
 
-        Note 1: This method is overridden in the cice5 driver, as cice5
-        in ACCESS OM2 does not require the calculated runtime information.
-        Instead it performs the calculations within the model using the
-        restart files and OM2 namelist.
+        Note 1: This method is overridden in the cice5 driver.
 
         Note 2: For ESM1.5, the actual model start date and run time are
         controlled via the separate input_ice.nml namelist, with relevant

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -235,10 +235,6 @@ class Cice(Model):
             prior_nml_path = os.path.join(self.prior_restart_path,
                                           self.ice_nml_fname)
 
-            # TODO: Are there any models which leave cice_in.nml in
-            # the output rather than restart directory? If not we can remove
-            # this.
-
             # With later versions this file exists in the prior restart path,
             # but this was not always the case, so check, and if not there use
             # prior output path

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -282,6 +282,7 @@ class Cice(Model):
         # Add the prior runtime and new runtime to the working copy of the
         # CICE namelist.
         setup_nml['npt'] = run_runtime / setup_nml['dt']
+        assert (prior_runtime_seconds % setup_nml['dt'] == 0)
         setup_nml['istep0'] = int(prior_runtime_seconds / setup_nml['dt'])
 
     def set_local_timestep(self, t_step):

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -74,7 +74,7 @@ class Cice5(Cice):
 
     def _calc_runtime(self):
         """
-        Overrides the cice driver method, as CICE5 in OM2 does not use
+        Overrides the cice driver method, as CICE5 can store the timing information in restart files does not use
         the timing information in the cice_in.nml namelist.
         """
         pass

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -71,3 +71,6 @@ class Cice5(Cice):
         # TODO: Figure out some way to move this to the ACCESS driver
         # Re-read ice timestep and move this over there
         self.set_local_timestep(t_step)
+
+    def calc_runtime(self, setup_nml):
+        pass

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -72,7 +72,7 @@ class Cice5(Cice):
         # Re-read ice timestep and move this over there
         self.set_local_timestep(t_step)
 
-    def calc_runtime(self, setup_nml):
+    def _calc_runtime(self):
         """
         Overrides the cice driver method, as CICE5 in OM2 does not use
         the timing information in the cice_in.nml namelist.

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -53,7 +53,7 @@ class Cice5(Cice):
         self.ice_in.write(ice_in_path, force=True)
 
     def setup(self):
-       # Force creation of a dump (restart) file at end of run
+        # Force creation of a dump (restart) file at end of run
         self.ice_in['setup_nml']['dump_last'] = True
 
         super(Cice5, self).setup()
@@ -73,4 +73,8 @@ class Cice5(Cice):
         self.set_local_timestep(t_step)
 
     def calc_runtime(self, setup_nml):
+        """
+        Overrides the cice driver method, as CICE5 in OM2 does not use
+        the timing information in the cice_in.nml namelist.
+        """
         pass

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -10,9 +10,10 @@ import git
 
 
 from test.common import cd
-from test.common import tmpdir, ctrldir, labdir, expt_workdir, ctrldir_basename
+from test.common import tmpdir, ctrldir, labdir, expt_workdir
+from test.common import expt_archive_dir, ctrldir_basename
 from test.common import write_config, write_metadata
-from test.common import make_inputs, make_exe
+from test.common import make_exe
 
 verbose = True
 
@@ -23,7 +24,7 @@ DEFAULT_CICE_NML = {
         "year_init": 9999,
         "days_per_year": 360,
         "ice_ic": "default",
-        "restart": ".false.",
+        "restart": False,
         "pointer_file": "./RESTART/ice.restart_file",
         "runtype": "initial",
         "npt": 99999,
@@ -35,6 +36,8 @@ DEFAULT_CICE_NML = {
 CICE_NML_NAME = "cice_in.nml"
 HIST_NML_NAME = "ice_history.nml"
 RESTART_NAME = "./RESTART/iced.r"
+ICED_RESTART_NAME = "iced.18510101"
+RESTART_POINTER_NAME = "ice.restart_file"
 
 
 def setup_module(module):
@@ -54,8 +57,7 @@ def setup_module(module):
         tmpdir.mkdir()
         labdir.mkdir()
         ctrldir.mkdir()
-        expt_workdir.mkdir(parents=True)
-        make_inputs()
+        expt_archive_dir.mkdir(parents=True)
         make_exe()
         write_metadata()
     except Exception as e:
@@ -85,26 +87,32 @@ def teardown_module(module):
     except Exception as e:
         print(e)
 
-@pytest.fixture
+
+@pytest.fixture(autouse=True)
+def empty_workdir():
+    """
+    Tests involving cloning + specified restarts require
+    a clean work directory
+    """
+    expt_workdir.mkdir(parents=True)
+    print(f"SPENCER {os.path.abspath('.')}")
+
+    yield expt_workdir
+    shutil.rmtree(expt_workdir)
+
+
+# Important to test None case without separate ice history file
+@pytest.fixture(params=[None,
+                        {"icefields_nml": {"f_icy": "m"}},
+                        {"icefields_nml": {"f_icy": "m", "f_new": "y"}}])
 def cice_config_files(request):
+    """
+    Write the default cice_in.nml namelist, and if included, separate ice
+    history namelist used by ESM1.5. Important to also test OM2/CICE5 case
+    without separate ice history namelist.
+    """
     cice_nml = DEFAULT_CICE_NML
-    if hasattr(request,'param'): 
-        ice_history = request.param
-    else:
-        ice_history = None
-
-    # create the files parsed by setup:
-    # 1. a restart pointer file
-    with cd(expt_workdir):
-        os.mkdir(cice_nml["setup_nml"]["restart_dir"])
-
-        with open(RESTART_NAME, "w") as f:
-            f.write("blank")
-            f.close()
-
-        with open(cice_nml["setup_nml"]["pointer_file"], "w") as f:
-            f.write(RESTART_NAME)
-            f.close()
+    ice_history = request.param
 
     with cd(ctrldir):
         # 2. Create config.nml
@@ -116,28 +124,20 @@ def cice_config_files(request):
     yield {'ice_history': ice_history}
 
     # cleanup
-    with cd(expt_workdir):
-        shutil.rmtree(cice_nml["setup_nml"]["restart_dir"])
     with cd(ctrldir):
         os.remove(CICE_NML_NAME)
         if ice_history:
             os.remove(HIST_NML_NAME)
 
-        
 
-# Confirm that 1: payu overwrites cice_in with ice_history
-# 2: payu works without ice_history.nml
-# 3: payu overwrites cice_in and allows additional fields
-# In all cases confirm dump_last is not added to model_type='cice'
-@pytest.mark.parametrize(
-    "cice_config_files",
-    [
-        {"icefields_nml": { "f_icy": "m" }},
-        False,
-        {"icefields_nml": {"f_icy": "m", "f_new": "y"}},
-    ], indirect=True
-)
 def test_setup(cice_config_files):
+    """
+    Confirm that
+        1: payu overwrites cice_in with ice_history
+        2: payu works without ice_history.nml
+        3: payu overwrites cice_in and allows additional fields
+    In all cases confirm dump_last is not added to model_type='cice'
+    """
 
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
@@ -156,7 +156,8 @@ def test_setup(cice_config_files):
     work_input_fpath = os.path.join(model.work_path, CICE_NML_NAME)
     input_nml = f90nml.read(work_input_fpath)
     if cice_config_files['ice_history']:
-        assert input_nml["icefields_nml"] == cice_config_files["ice_history"]["icefields_nml"]
+        assert (input_nml["icefields_nml"] ==
+                cice_config_files["ice_history"]["icefields_nml"])
     else:
         assert input_nml["icefields_nml"] == DEFAULT_CICE_NML["icefields_nml"]
 
@@ -165,16 +166,18 @@ def test_setup(cice_config_files):
         input_nml["setup_nml"]["dump_last"]
 
 
-#test that pytest raises an error if it can't find the restart pointer
 def test_no_restart_ptr(cice_config_files):
-
-    with cd(expt_workdir):
-        os.remove(DEFAULT_CICE_NML["setup_nml"]["pointer_file"])
-
-    assert 'RESTART' in os.listdir(expt_workdir)
+    """
+    Test that payu raises an error if no prior restart path is specified,
+    restart is `true` in cice_in.nml, and the restart pointer is missing.
+    """
+    cice_in_patch = {"setup_nml": {"restart": True}}
+    with cd(ctrldir):
+        cice_in_default = f90nml.read(CICE_NML_NAME)
+        cice_in_default.patch(cice_in_patch)
+        cice_in_default.write(CICE_NML_NAME, force=True)
 
     with cd(ctrldir):
-            
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
         model = expt.models[0]
@@ -184,108 +187,146 @@ def test_no_restart_ptr(cice_config_files):
             model.setup()
 
 
-@pytest.mark.parametrize("cice_config_files", 
-    [False, {"icefields_nml": { "f_icy": "m" }}],
-    indirect=True)
-def test_clone(cice_config_files):
-    with cd(ctrldir):
-            
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-        model = expt.models[0]
+class TestClone:
+    """
+    Test setting up the cice model in cloned control directories.
+    """
 
-        # Function to test
-        model.setup()
+    @pytest.fixture
+    def prior_restart_dir_cice4(self, scope="class"):
+        """
+        Create fake prior restart files required by CICE4's setup.
+        """
+        prior_restart_path = expt_archive_dir / "restartxyz"
+        os.mkdir(prior_restart_path)
 
-    # Initialise a control repo
-    repo = git.Repo.init(ctrldir)
-    repo.index.add("*")
-    # Commit the changes
-    repo.index.commit("First commit - initialising repository")
-    source_main = str(repo.active_branch)
+        # Previous cice_in namelist with time information
+        restart_cice_in = {"setup_nml": {
+                "istep0": 100,
+                "npt": 10,
+                "dt": 123
+            }}
+        f90nml.write(restart_cice_in, prior_restart_path/CICE_NML_NAME)
 
-    # Clone
-    cloned_repo_path = tmpdir / "clonedRepo"
-    clone(str(ctrldir), cloned_repo_path, lab_path=labdir)
+        # Additional restart files required by CICE4 setup
+        (prior_restart_path/ICED_RESTART_NAME).touch()
+        (prior_restart_path/RESTART_POINTER_NAME).touch()
 
-    cloned_repo = git.Repo(cloned_repo_path)
-    cloned_repo.git.checkout(source_main)
+        yield prior_restart_path
 
-    ctrl_path_files = os.listdir(cloned_repo_path)
-    assert CICE_NML_NAME in ctrl_path_files
+        # Teardown
+        shutil.rmtree(prior_restart_path)
 
-    if cice_config_files['ice_history']:
-        assert HIST_NML_NAME in ctrl_path_files
+    @pytest.fixture
+    def ctrldir_repo(self, cice_config_files):
+        """
+        Initialise a git repository in the control directory.
+        """
+        repo = git.Repo.init(ctrldir)
+        repo.index.add("*")
 
-    # Setup
+        # Commit the changes
+        repo.index.commit("First commit - initialising repository")
 
-    with cd(cloned_repo_path):
+        yield repo
 
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-        model = expt.models[0]
+        # Remove git from control dir after tests
+        git.rmtree(ctrldir/".git")
 
-        # Function to test
-        model.setup()
+    @pytest.fixture
+    def clone_control_dir(self, ctrldir_repo):
+        """
+        Yield function for cloning the control directory. Cloning
+        is not done directly in fixture to allow for an optional
+        restart path to be supplied.
+        """
+        cloned_repo_path = tmpdir / "clonedRepo"
 
-    work_path_files = os.listdir(model.work_path)
-    assert CICE_NML_NAME in work_path_files
+        def _clone_control_dir(restart_path=None):
+            clone(str(ctrldir),
+                  cloned_repo_path,
+                  lab_path=labdir,
+                  restart_path=restart_path)
+            return cloned_repo_path
 
-    shutil.rmtree(cloned_repo_path)
+        yield _clone_control_dir
 
+        # Teardown: Delete the cloned repository
+        try:
+            git.rmtree(cloned_repo_path)
+        except FileNotFoundError:
+            # Cloned repo won't exist if yielded function not called
+            pass
 
-@pytest.mark.parametrize("cice_config_files", 
-    [False, {"icefields_nml": { "f_icy": "m" }}],
-    indirect=True)
-def test_restart_clone(cice_config_files):
+    def test_clone(self, cice_config_files, ctrldir_repo,
+                   clone_control_dir):
+        """
+        Test that setting up cice from a cloned control directory works.
+        """
+        source_main = str(ctrldir_repo.active_branch)
 
-    # To-do a restart clone we need to make a folder like archive/restart000 ?
-    with cd(ctrldir):
-            
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-        model = expt.models[0]
+        # Clone control directory
+        cloned_repo_path = clone_control_dir(restart_path=None)
+        cloned_repo = git.Repo(cloned_repo_path)
+        cloned_repo.git.checkout(source_main)
 
-        # Function to test
-        model.setup()
+        cloned_ctrl_dir_files = os.listdir(cloned_repo_path)
+        assert CICE_NML_NAME in cloned_ctrl_dir_files
 
-    assert 'RESTART' in os.listdir(expt_workdir)
+        if cice_config_files['ice_history']:
+            assert HIST_NML_NAME in cloned_ctrl_dir_files
 
-    # Initialise a control repo
-    repo = git.Repo.init(ctrldir)
-    repo.index.add("*")
-    # Commit the changes
-    repo.index.commit("First commit - initialising repository")
-    source_main = str(repo.active_branch)
+        # Set up experiment
+        with cd(cloned_repo_path):
+            lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+            expt = payu.experiment.Experiment(lab, reproduce=False)
+            model = expt.models[0]
 
-    # Clone
-    cloned_repo_path = tmpdir / "clonedRepo"
-    clone(str(ctrldir), cloned_repo_path, lab_path=labdir, restart_path=ctrldir)
+            # Test that model setup runs without issue
+            model.setup()
 
-    cloned_repo = git.Repo(cloned_repo_path)
-    cloned_repo.git.checkout(source_main)
+        work_path_files = os.listdir(model.work_path)
+        assert CICE_NML_NAME in work_path_files
 
-    ctrl_path_files = os.listdir(cloned_repo_path)
-    assert CICE_NML_NAME in ctrl_path_files
-    assert 'RESTART' in ctrl_path_files
+    def test_restart_clone(self, cice_config_files, ctrldir_repo,
+                           clone_control_dir, prior_restart_dir_cice4):
+        """
+        Test that seting up an experiment from a cloned control directory
+        works when a restart directory is specified.
 
+        Use a restart directory mimicking the CICE4 restarts required by setup.
+        """
+        source_main = str(ctrldir_repo.active_branch)
 
-    if request.param:
-        assert HIST_NML_NAME in ctrl_path_files
+        # Clone control directory
+        cloned_repo_path = clone_control_dir(
+                                restart_path=prior_restart_dir_cice4
+                            )
+        cloned_repo = git.Repo(cloned_repo_path)
+        cloned_repo.git.checkout(source_main)
 
+        cloned_ctrl_dir_files = os.listdir(cloned_repo_path)
 
-    # Setup
+        assert CICE_NML_NAME in cloned_ctrl_dir_files
+        if cice_config_files['ice_history']:
+            assert HIST_NML_NAME in cloned_ctrl_dir_files
 
-    with cd(cloned_repo_path):
+        # Setup experiment
+        with cd(cloned_repo_path):
 
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-        model = expt.models[0]
+            lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+            expt = payu.experiment.Experiment(lab, reproduce=False)
+            model = expt.models[0]
 
-        # Function to test
-        model.setup()
+            # Test that model setup runs without issue
+            model.setup()
 
-    work_path_files = os.listdir(model.work_path)
-    assert CICE_NML_NAME in work_path_files
+        work_path_files = os.listdir(model.work_path)
+        assert CICE_NML_NAME in work_path_files
 
-    shutil.rmtree(cloned_repo_path)
+        # Check restart files were copied to cloned experiment's
+        # work directory.
+        cice_work_restart_files = os.listdir(model.work_restart_path)
+
+        for file in [CICE_NML_NAME, ICED_RESTART_NAME, RESTART_POINTER_NAME]:
+            assert file in cice_work_restart_files

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -5,6 +5,9 @@ import pytest
 import f90nml
 
 import payu
+from payu.branch import clone
+import git
+
 
 from test.common import cd
 from test.common import tmpdir, ctrldir, labdir, expt_workdir, ctrldir_basename
@@ -31,6 +34,7 @@ DEFAULT_CICE_NML = {
 }
 CICE_NML_NAME = "cice_in.nml"
 HIST_NML_NAME = "ice_history.nml"
+RESTART_NAME = "./RESTART/iced.r"
 
 
 def setup_module(module):
@@ -81,36 +85,61 @@ def teardown_module(module):
     except Exception as e:
         print(e)
 
+@pytest.fixture
+def cice_config_files(request):
+    cice_nml = DEFAULT_CICE_NML
+    if hasattr(request,'param'): 
+        ice_history = request.param
+    else:
+        ice_history = None
+
+    # create the files parsed by setup:
+    # 1. a restart pointer file
+    with cd(expt_workdir):
+        os.mkdir(cice_nml["setup_nml"]["restart_dir"])
+
+        with open(RESTART_NAME, "w") as f:
+            f.write("blank")
+            f.close()
+
+        with open(cice_nml["setup_nml"]["pointer_file"], "w") as f:
+            f.write(RESTART_NAME)
+            f.close()
+
+    with cd(ctrldir):
+        # 2. Create config.nml
+        f90nml.write(cice_nml, CICE_NML_NAME)
+
+        if ice_history:
+            f90nml.write(ice_history, HIST_NML_NAME)
+
+    yield {'ice_history': ice_history}
+
+    # cleanup
+    with cd(expt_workdir):
+        shutil.rmtree(cice_nml["setup_nml"]["restart_dir"])
+    with cd(ctrldir):
+        os.remove(CICE_NML_NAME)
+        if ice_history:
+            os.remove(HIST_NML_NAME)
+
+        
 
 # Confirm that 1: payu overwrites cice_in with ice_history
 # 2: payu works without ice_history.nml
 # 3: payu overwrites cice_in and allows additional fields
 # In all cases confirm dump_last is not added to model_type='cice'
 @pytest.mark.parametrize(
-    "ice_history",
+    "cice_config_files",
     [
         {"icefields_nml": { "f_icy": "m" }},
         False,
         {"icefields_nml": {"f_icy": "m", "f_new": "y"}},
-    ],
+    ], indirect=True
 )
-def test_setup(ice_history):
-    cice_nml = DEFAULT_CICE_NML
-
-    # create the files parsed by setup:
-    # 1. a restart pointer file
-    with cd(expt_workdir):
-        os.mkdir(cice_nml["setup_nml"]["restart_dir"])
-        with open(cice_nml["setup_nml"]["pointer_file"], "w") as f:
-            f.write("./RESTART/ice.r")
-            f.close()
+def test_setup(cice_config_files):
 
     with cd(ctrldir):
-        # 2. Create config.nml
-        f90nml.write(cice_nml, CICE_NML_NAME)
-        if ice_history:
-            f90nml.write(ice_history, HIST_NML_NAME)
-
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
         model = expt.models[0]
@@ -121,12 +150,13 @@ def test_setup(ice_history):
     # Check config files are moved to model's work path
     work_path_files = os.listdir(model.work_path)
     assert CICE_NML_NAME in work_path_files
+    assert HIST_NML_NAME not in work_path_files
 
     # Check cice_in was patched with ice_history
     work_input_fpath = os.path.join(model.work_path, CICE_NML_NAME)
     input_nml = f90nml.read(work_input_fpath)
-    if ice_history:
-        assert input_nml["icefields_nml"] == ice_history["icefields_nml"]
+    if cice_config_files['ice_history']:
+        assert input_nml["icefields_nml"] == cice_config_files["ice_history"]["icefields_nml"]
     else:
         assert input_nml["icefields_nml"] == DEFAULT_CICE_NML["icefields_nml"]
 
@@ -134,11 +164,128 @@ def test_setup(ice_history):
     with pytest.raises(KeyError, match="dump_last"):
         input_nml["setup_nml"]["dump_last"]
 
-    # cleanup
+
+#test that pytest raises an error if it can't find the restart pointer
+def test_no_restart_ptr(cice_config_files):
+
     with cd(expt_workdir):
-        os.remove(cice_nml["setup_nml"]["pointer_file"])
-        os.rmdir(cice_nml["setup_nml"]["restart_dir"])
+        os.remove(DEFAULT_CICE_NML["setup_nml"]["pointer_file"])
+
+    assert 'RESTART' in os.listdir(expt_workdir)
+
     with cd(ctrldir):
-        os.remove(CICE_NML_NAME)
-        if ice_history:
-            os.remove(HIST_NML_NAME)
+            
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        with pytest.raises(RuntimeError):
+            model.setup()
+
+
+@pytest.mark.parametrize("cice_config_files", 
+    [False, {"icefields_nml": { "f_icy": "m" }}],
+    indirect=True)
+def test_clone(cice_config_files):
+    with cd(ctrldir):
+            
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        model.setup()
+
+    # Initialise a control repo
+    repo = git.Repo.init(ctrldir)
+    repo.index.add("*")
+    # Commit the changes
+    repo.index.commit("First commit - initialising repository")
+    source_main = str(repo.active_branch)
+
+    # Clone
+    cloned_repo_path = tmpdir / "clonedRepo"
+    clone(str(ctrldir), cloned_repo_path, lab_path=labdir)
+
+    cloned_repo = git.Repo(cloned_repo_path)
+    cloned_repo.git.checkout(source_main)
+
+    ctrl_path_files = os.listdir(cloned_repo_path)
+    assert CICE_NML_NAME in ctrl_path_files
+
+    if cice_config_files['ice_history']:
+        assert HIST_NML_NAME in ctrl_path_files
+
+    # Setup
+
+    with cd(cloned_repo_path):
+
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        model.setup()
+
+    work_path_files = os.listdir(model.work_path)
+    assert CICE_NML_NAME in work_path_files
+
+    shutil.rmtree(cloned_repo_path)
+
+
+@pytest.mark.parametrize("cice_config_files", 
+    [False, {"icefields_nml": { "f_icy": "m" }}],
+    indirect=True)
+def test_restart_clone(cice_config_files):
+
+    # To-do a restart clone we need to make a folder like archive/restart000 ?
+    with cd(ctrldir):
+            
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        model.setup()
+
+    assert 'RESTART' in os.listdir(expt_workdir)
+
+    # Initialise a control repo
+    repo = git.Repo.init(ctrldir)
+    repo.index.add("*")
+    # Commit the changes
+    repo.index.commit("First commit - initialising repository")
+    source_main = str(repo.active_branch)
+
+    # Clone
+    cloned_repo_path = tmpdir / "clonedRepo"
+    clone(str(ctrldir), cloned_repo_path, lab_path=labdir, restart_path=ctrldir)
+
+    cloned_repo = git.Repo(cloned_repo_path)
+    cloned_repo.git.checkout(source_main)
+
+    ctrl_path_files = os.listdir(cloned_repo_path)
+    assert CICE_NML_NAME in ctrl_path_files
+    assert 'RESTART' in ctrl_path_files
+
+
+    if request.param:
+        assert HIST_NML_NAME in ctrl_path_files
+
+
+    # Setup
+
+    with cd(cloned_repo_path):
+
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        model.setup()
+
+    work_path_files = os.listdir(model.work_path)
+    assert CICE_NML_NAME in work_path_files
+
+    shutil.rmtree(cloned_repo_path)

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -135,7 +135,7 @@ def empty_workdir():
 def cice_config_files(request):
     """
     Write the default cice_in.nml namelist, and if included, separate ice
-    history namelist used by ESM1.5. 
+    history namelist used by ESM1.5.
     """
     cice_nml = DEFAULT_CICE_NML
     ice_history = request.param
@@ -287,5 +287,6 @@ def test_no_restart_ptr(config, cice_config_files):
         model = expt.models[0]
 
         # Function to test
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError,
+                           match="Cannot find previous restart file"):
             model.setup()

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -135,8 +135,7 @@ def empty_workdir():
 def cice_config_files(request):
     """
     Write the default cice_in.nml namelist, and if included, separate ice
-    history namelist used by ESM1.5. Important to also test OM2/CICE5 case
-    without separate ice history namelist.
+    history namelist used by ESM1.5. 
     """
     cice_nml = DEFAULT_CICE_NML
     ice_history = request.param

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -176,7 +176,7 @@ def prior_restart_dir_cice5():
     """
     Create fake prior restart files required by CICE5's setup.
     """
-    prior_restart_path = expt_archive_dir / "restartXYZ"
+    prior_restart_path = RESTART_PATH
     os.mkdir(prior_restart_path)
 
     # Restart files required by CICE5 setup
@@ -203,11 +203,6 @@ def test_restart_setup(config, cice_config_files, prior_restart_dir_cice5):
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
-
-        # Add a runtime to test calculated cice runtime values
-        expt.runtime = {"years": 0,
-                        "months": 0,
-                        "days": 2}
         model = expt.models[0]
 
         # Function to test

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -1,0 +1,184 @@
+import os
+import shutil
+
+import pytest
+import f90nml
+
+import payu
+from payu.branch import clone
+import git
+
+
+from test.common import cd
+from test.common import tmpdir, ctrldir, labdir, expt_workdir, ctrldir_basename
+from test.common import write_config, write_metadata
+from test.common import make_inputs, make_exe
+
+verbose = True
+
+DEFAULT_CICE_NML = {
+    "setup_nml": {
+        "history_dir": "./HISTORY/",
+        "restart_dir": "./RESTART/",
+        "year_init": 9999,
+        "days_per_year": 360,
+        "ice_ic": "default",
+        "restart": ".false.",
+        "pointer_file": "./RESTART/ice.restart_file",
+        "runtype": "initial",
+        "npt": 99999,
+        "dt": 1,
+    },
+    "grid_nml": {"grid_file": "./INPUT/grid.nc", "kmt_file": "./INPUT/kmt.nc"},
+    "icefields_nml": {"f_icy": "x"},
+}
+CICE_NML_NAMES = ["cice_in.nml", "input_ice.nml", "input_ice_gfdl.nml", "input_ice_monin.nml"]
+
+def setup_module(module):
+    """
+    Put any test-wide setup code in here, e.g. creating test files
+    """
+    if verbose:
+        print("setup_module      module:%s" % module.__name__)
+
+    # Should be taken care of by teardown, in case remnants lying around
+    try:
+        shutil.rmtree(tmpdir)
+    except FileNotFoundError:
+        pass
+
+    try:
+        tmpdir.mkdir()
+        labdir.mkdir()
+        ctrldir.mkdir()
+        expt_workdir.mkdir(parents=True)
+        make_inputs()
+        make_exe()
+        write_metadata()
+    except Exception as e:
+        print(e)
+
+    config = {
+        "laboratory": "lab",
+        "jobname": "testrun",
+        "model": "cice5",
+        "exe": "test.exe",
+        "experiment": ctrldir_basename,
+        "metadata": {"enable": False},
+    }
+    write_config(config)
+
+
+def teardown_module(module):
+    """
+    Put any test-wide teardown code in here, e.g. removing test outputs
+    """
+    if verbose:
+        print("teardown_module   module:%s" % module.__name__)
+
+    try:
+        shutil.rmtree(tmpdir)
+        print("removing tmp")
+    except Exception as e:
+        print(e)
+
+@pytest.fixture
+def cice_config_files():
+    cice_nml = DEFAULT_CICE_NML
+
+    # create the files parsed by setup:
+    # 1. a restart pointer file
+    with cd(expt_workdir):
+        os.mkdir(cice_nml["setup_nml"]["restart_dir"])
+        with open(cice_nml["setup_nml"]["pointer_file"], "w") as f:
+            f.write("./RESTART/ice.r")
+            f.close()
+
+    with cd(ctrldir):
+        # 2. Create config.nml
+        f90nml.write(cice_nml, CICE_NML_NAMES[0])
+        for name in CICE_NML_NAMES[1:]:
+            with open(name, "w") as f:
+                f.close()
+
+    yield
+
+    # cleanup
+    with cd(expt_workdir):
+        os.remove(cice_nml["setup_nml"]["pointer_file"])
+        os.rmdir(cice_nml["setup_nml"]["restart_dir"])
+    with cd(ctrldir):
+        for name in CICE_NML_NAMES:
+            os.remove(name)
+        
+
+# Confirm that 1: payu setup works 
+def test_setup(cice_config_files):
+
+    with cd(ctrldir):
+
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        model.setup()
+
+    # Check config files are moved to model's work path
+    work_path_files = os.listdir(model.work_path)
+    for name in CICE_NML_NAMES:
+        assert name in work_path_files
+
+    # Check cice_in was not patched with ice_history
+    work_input_fpath = os.path.join(model.work_path, CICE_NML_NAMES[0])
+    input_nml = f90nml.read(work_input_fpath)
+    assert input_nml["icefields_nml"] == DEFAULT_CICE_NML["icefields_nml"]
+
+    # Check dump_last 
+    assert input_nml["setup_nml"]["dump_last"] is True
+
+
+def test_clone(cice_config_files):
+    with cd(ctrldir):
+            
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        model.setup()
+
+    # Initialise a control repo
+    repo = git.Repo.init(ctrldir)
+    repo.index.add("*")
+    # Commit the changes
+    repo.index.commit("First commit - initialising repository")
+    source_main = str(repo.active_branch)
+
+    # Clone
+    cloned_repo_path = tmpdir / "clonedRepo"
+    clone(str(ctrldir), cloned_repo_path, lab_path=labdir)
+
+    cloned_repo = git.Repo(cloned_repo_path)
+    cloned_repo.git.checkout(source_main)
+
+    ctrl_path_files = os.listdir(cloned_repo_path)
+    for name in CICE_NML_NAMES:
+        assert name in ctrl_path_files
+
+    # Setup
+
+    with cd(cloned_repo_path):
+
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        # Function to test
+        model.setup()
+
+    work_path_files = os.listdir(model.work_path)
+    for name in CICE_NML_NAMES:
+        assert name in ctrl_path_files
+
+    shutil.rmtree(cloned_repo_path)

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -94,7 +94,6 @@ def empty_workdir():
     a clean work directory
     """
     expt_workdir.mkdir(parents=True)
-    print(f"SPENCER {expt_workdir}")
 
     yield expt_workdir
     shutil.rmtree(expt_workdir)
@@ -224,7 +223,7 @@ class TestClone:
         """
         Create fake prior restart files required by CICE5's setup.
         """
-        prior_restart_path = expt_archive_dir / "restartxyz"
+        prior_restart_path = expt_archive_dir / "restartXYZ"
         os.mkdir(prior_restart_path)
 
         # Restart files required by CICE5 setup

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -227,7 +227,7 @@ class TestClone:
         prior_restart_path = expt_archive_dir / "restartxyz"
         os.mkdir(prior_restart_path)
 
-        # Additional restart files required by CICE4 setup
+        # Restart files required by CICE5 setup
         (prior_restart_path/ICED_RESTART_NAME).touch()
         (prior_restart_path/RESTART_POINTER_NAME).touch()
 
@@ -278,5 +278,5 @@ class TestClone:
         # work directory.
         cice_work_restart_files = os.listdir(model.work_restart_path)
 
-        for file in [CICE_NML_NAME, ICED_RESTART_NAME, RESTART_POINTER_NAME]:
+        for file in [ICED_RESTART_NAME, RESTART_POINTER_NAME]:
             assert file in cice_work_restart_files

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -10,9 +10,10 @@ import git
 
 
 from test.common import cd
-from test.common import tmpdir, ctrldir, labdir, expt_workdir, ctrldir_basename
+from test.common import tmpdir, ctrldir, labdir, expt_workdir
+from test.common import expt_archive_dir, ctrldir_basename
 from test.common import write_config, write_metadata
-from test.common import make_inputs, make_exe
+from test.common import make_exe
 
 verbose = True
 
@@ -23,7 +24,7 @@ DEFAULT_CICE_NML = {
         "year_init": 9999,
         "days_per_year": 360,
         "ice_ic": "default",
-        "restart": ".false.",
+        "restart": False,
         "pointer_file": "./RESTART/ice.restart_file",
         "runtype": "initial",
         "npt": 99999,
@@ -32,7 +33,11 @@ DEFAULT_CICE_NML = {
     "grid_nml": {"grid_file": "./INPUT/grid.nc", "kmt_file": "./INPUT/kmt.nc"},
     "icefields_nml": {"f_icy": "x"},
 }
-CICE_NML_NAMES = ["cice_in.nml", "input_ice.nml", "input_ice_gfdl.nml", "input_ice_monin.nml"]
+CICE_NML_NAMES = ["cice_in.nml", "input_ice.nml",
+                  "input_ice_gfdl.nml", "input_ice_monin.nml"]
+ICED_RESTART_NAME = "iced.18510101"
+RESTART_POINTER_NAME = "ice.restart_file"
+
 
 def setup_module(module):
     """
@@ -51,8 +56,7 @@ def setup_module(module):
         tmpdir.mkdir()
         labdir.mkdir()
         ctrldir.mkdir()
-        expt_workdir.mkdir(parents=True)
-        make_inputs()
+        expt_archive_dir.mkdir(parents=True)
         make_exe()
         write_metadata()
     except Exception as e:
@@ -82,17 +86,23 @@ def teardown_module(module):
     except Exception as e:
         print(e)
 
+
+@pytest.fixture(autouse=True)
+def empty_workdir():
+    """
+    Tests involving cloning + specified restarts require
+    a clean work directory
+    """
+    expt_workdir.mkdir(parents=True)
+    print(f"SPENCER {expt_workdir}")
+
+    yield expt_workdir
+    shutil.rmtree(expt_workdir)
+
+
 @pytest.fixture
 def cice_config_files():
     cice_nml = DEFAULT_CICE_NML
-
-    # create the files parsed by setup:
-    # 1. a restart pointer file
-    with cd(expt_workdir):
-        os.mkdir(cice_nml["setup_nml"]["restart_dir"])
-        with open(cice_nml["setup_nml"]["pointer_file"], "w") as f:
-            f.write("./RESTART/ice.r")
-            f.close()
 
     with cd(ctrldir):
         # 2. Create config.nml
@@ -103,18 +113,15 @@ def cice_config_files():
 
     yield
 
-    # cleanup
-    with cd(expt_workdir):
-        os.remove(cice_nml["setup_nml"]["pointer_file"])
-        os.rmdir(cice_nml["setup_nml"]["restart_dir"])
     with cd(ctrldir):
         for name in CICE_NML_NAMES:
             os.remove(name)
-        
 
-# Confirm that 1: payu setup works 
+
 def test_setup(cice_config_files):
-
+    """
+    # Confirm that payu setup works
+    """
     with cd(ctrldir):
 
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
@@ -134,51 +141,142 @@ def test_setup(cice_config_files):
     input_nml = f90nml.read(work_input_fpath)
     assert input_nml["icefields_nml"] == DEFAULT_CICE_NML["icefields_nml"]
 
-    # Check dump_last 
+    # Check dump_last
     assert input_nml["setup_nml"]["dump_last"] is True
 
 
-def test_clone(cice_config_files):
-    with cd(ctrldir):
-            
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-        model = expt.models[0]
+class TestClone:
+    """
+    Test setting up the cice model in cloned control directories.
+    """
 
-        # Function to test
-        model.setup()
+    @pytest.fixture
+    def ctrldir_repo(self, cice_config_files):
+        """
+        Initialise a git repository in the control directory.
+        """
+        repo = git.Repo.init(ctrldir)
+        repo.index.add("*")
 
-    # Initialise a control repo
-    repo = git.Repo.init(ctrldir)
-    repo.index.add("*")
-    # Commit the changes
-    repo.index.commit("First commit - initialising repository")
-    source_main = str(repo.active_branch)
+        # Commit the changes
+        repo.index.commit("First commit - initialising repository")
 
-    # Clone
-    cloned_repo_path = tmpdir / "clonedRepo"
-    clone(str(ctrldir), cloned_repo_path, lab_path=labdir)
+        yield repo
 
-    cloned_repo = git.Repo(cloned_repo_path)
-    cloned_repo.git.checkout(source_main)
+        # Remove git from control dir after tests
+        git.rmtree(ctrldir/".git")
 
-    ctrl_path_files = os.listdir(cloned_repo_path)
-    for name in CICE_NML_NAMES:
-        assert name in ctrl_path_files
+    @pytest.fixture
+    def clone_control_dir(self, ctrldir_repo):
+        """
+        Yield function for cloning the control directory. Cloning
+        is not done directly in fixture to allow for an optional
+        restart path to be supplied.
+        """
+        cloned_repo_path = tmpdir / "clonedRepo"
 
-    # Setup
+        def _clone_control_dir(restart_path=None):
+            clone(str(ctrldir),
+                  cloned_repo_path,
+                  lab_path=labdir,
+                  restart_path=restart_path)
+            return cloned_repo_path
 
-    with cd(cloned_repo_path):
+        yield _clone_control_dir
 
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-        model = expt.models[0]
+        # Teardown: Delete the cloned repository
+        try:
+            git.rmtree(cloned_repo_path)
+        except FileNotFoundError:
+            # Cloned repo won't exist if yielded function not called
+            pass
 
-        # Function to test
-        model.setup()
+    def test_clone(self, cice_config_files, ctrldir_repo, clone_control_dir):
+        """
+        Test that setting up cice works from a cloned control directory.
+        """
+        source_main = str(ctrldir_repo.active_branch)
 
-    work_path_files = os.listdir(model.work_path)
-    for name in CICE_NML_NAMES:
-        assert name in ctrl_path_files
+        # Clone control directory
+        cloned_repo_path = clone_control_dir(restart_path=None)
+        cloned_repo = git.Repo(cloned_repo_path)
+        cloned_repo.git.checkout(source_main)
 
-    shutil.rmtree(cloned_repo_path)
+        cloned_ctrl_path_files = os.listdir(cloned_repo_path)
+        for name in CICE_NML_NAMES:
+            assert name in cloned_ctrl_path_files
+
+        # Set up experiment
+        with cd(cloned_repo_path):
+            lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+            expt = payu.experiment.Experiment(lab, reproduce=False)
+            model = expt.models[0]
+
+            # Test that model setup runs without issue
+            model.setup()
+
+        work_path_files = os.listdir(model.work_path)
+        for name in CICE_NML_NAMES:
+            assert name in work_path_files
+
+    @pytest.fixture
+    def prior_restart_dir_cice5(self, scope="class"):
+        """
+        Create fake prior restart files required by CICE5's setup.
+        """
+        prior_restart_path = expt_archive_dir / "restartxyz"
+        os.mkdir(prior_restart_path)
+
+        # Additional restart files required by CICE4 setup
+        (prior_restart_path/ICED_RESTART_NAME).touch()
+        (prior_restart_path/RESTART_POINTER_NAME).touch()
+
+        yield prior_restart_path
+
+        # Teardown
+        shutil.rmtree(prior_restart_path)
+
+    def test_restart_clone(self, cice_config_files, ctrldir_repo,
+                           clone_control_dir, prior_restart_dir_cice5):
+
+        """
+        Test that seting up an experiment from a cloned control directory
+        works when a restart directory is specified.
+
+        Use a restart directory mimicking the CICE5 restarts required by setup.
+        This differs from the cice4 test in that 'cice_in.nml' doesn't exist.
+        """
+        source_main = str(ctrldir_repo.active_branch)
+
+        # Clone control directory
+        cloned_repo_path = clone_control_dir(
+                                restart_path=prior_restart_dir_cice5
+                            )
+        cloned_repo = git.Repo(cloned_repo_path)
+        cloned_repo.git.checkout(source_main)
+
+        cloned_ctrl_path_files = os.listdir(cloned_repo_path)
+
+        for name in CICE_NML_NAMES:
+            assert name in cloned_ctrl_path_files
+
+        # Setup experiment
+        with cd(cloned_repo_path):
+
+            lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+            expt = payu.experiment.Experiment(lab, reproduce=False)
+            model = expt.models[0]
+
+            # Test that model setup runs without issue
+            model.setup()
+
+        work_path_files = os.listdir(model.work_path)
+        for name in CICE_NML_NAMES:
+            assert name in work_path_files
+
+        # Check restart files were copied to cloned experiment's
+        # work directory.
+        cice_work_restart_files = os.listdir(model.work_restart_path)
+
+        for file in [CICE_NML_NAME, ICED_RESTART_NAME, RESTART_POINTER_NAME]:
+            assert file in cice_work_restart_files


### PR DESCRIPTION
Attempts to close #499 

This pull request modifies the `cice.py` driver, by pulling the timing calculations out from `setup()` into a separate `calc_runtime()` method. This method is then overridden in the `cice5.py` driver,  allowing the `cice_in.nml` namelist file to be absent from the restart directory, since OM2 does not use the information from these calculations. This in turn will allow OM2 to be run after using `payu clone -r` with a specified OM2 restart directory.

Most of the code changes are in the tests, which require a bit of intricate set up. Given that we're skipping `payu setup` and directly running `model.setup()` (in order to avoid more complicated pre-test setup), it's difficult to know how well we've matched the conditions for setting up a real experiment. E.g. When setting up the tests, inadvertent changes to the directories that existed at the start of the test led to payu using different work restart directories during different parts of the setup, and different restart files were moved to different places in a way that was tricky to understand. And so while the tests are working, they do feel a bit precarious. If you have any suggestions that would be very welcome!

The main relevabt tests are the `test_restart_clone` tests for both [CICE 4 ](https://github.com/payu-org/payu/blob/10f5122a16798d9ca12e4453809a9b4399b91b4f/test/models/test_cice.py#L296-L303)and [CICE 5](https://github.com/payu-org/payu/blob/10f5122a16798d9ca12e4453809a9b4399b91b4f/test/models/test_cice5.py#L238-L247). These do the following:

1. Create a restart directory with fake restart files required by CICE4/5.
2. Clone an experiment and point to the created restart directory.
3. Set up CICE within the cloned control directory to see if it works. 

The CICE 5 version of `test_restart_clone` passes with the new cice driver changes, and would have failed previously.

One thing I'm unsure about: Do you think it's necessary to include the cloning steps in the tests. I think the main issue was payu requiring restart files that cice5 didn't use. This came up when trying to clone, but I don't think the issue came from the cloning step itself. Perhaps it's still useful to be testing the whole clone/setup process though.

Any feedback/suggestions would be very welcome! I'd be keen to get some other ideas before trying to finalise this, and so have marked this PR as a draft. 
