### PR TITLE
Add minimum payu version check 

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -571,3 +571,11 @@ Miscellaneous
 
       module use /path/to/module/directory
       payu run
+
+``payu_minimum_version``
+   Specify the minimum version of payu required to run the configuration.
+   At the start of experiment setup, payu checks whether its current version
+   is an earlier version, and if so, payu will refuse to run.
+   This is useful for models that require features that are in later versions
+   of payu.
+   Note that this check will only run with payu versions later than `1.1.5`.

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 # Extensions
 import yaml
+from packaging import version
 
 # Local
 from payu import envmod
@@ -387,7 +388,31 @@ class Experiment(object):
         for model in self.models:
             model.build_model()
 
+    def check_payu_version(self):
+        """Check current payu version is greater than minimum required
+        payu version, if configured"""
+        # TODO: Move this function to a setup file if setup is moved to
+        # a separate file?
+        if "payu_minimum_version" not in self.config:
+            # Skip version check
+            return
+
+        minimum_version = str(self.config['payu_minimum_version'])
+
+        # Get the current version of the package
+        current_version = payu.__version__
+
+        # Compare versions
+        if version.parse(current_version) < version.parse(minimum_version):
+            raise RuntimeError(
+                f"Payu version {current_version} does not meet the configured "
+                f"minimum version. A version >= {minimum_version} is "
+                "required to run this configuration."
+            )
+
     def setup(self, force_archive=False):
+        # Check version
+        self.check_payu_version()
 
         # Confirm that no output path already exists
         if os.path.exists(self.output_path):

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -393,17 +393,26 @@ class Experiment(object):
         payu version, if configured"""
         # TODO: Move this function to a setup file if setup is moved to
         # a separate file?
-        if "payu_minimum_version" not in self.config:
+        minimum_version_fieldname = "payu_minimum_version"
+        if minimum_version_fieldname not in self.config:
             # Skip version check
             return
 
-        minimum_version = str(self.config['payu_minimum_version'])
+        minimum_version = str(self.config[minimum_version_fieldname])
+        try:
+            # Attempt to parse the version
+            parsed_minimum_version = version.parse(minimum_version)
+        except version.InvalidVersion:
+            raise ValueError(
+                "Invalid version in configuration file (config.yaml) for "
+                f"'{minimum_version_fieldname}': {minimum_version}"
+            )
 
         # Get the current version of the package
         current_version = payu.__version__
 
         # Compare versions
-        if version.parse(current_version) < version.parse(minimum_version):
+        if version.parse(current_version) < parsed_minimum_version:
             raise RuntimeError(
                 f"Payu version {current_version} does not meet the configured "
                 f"minimum version. A version >= {minimum_version} is "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "tenacity >=8.0.0",
     "cftime",
     "GitPython >=3.1.40",
-    "ruamel.yaml >=0.18.5"
+    "ruamel.yaml >=0.18.5",
+    "packaging"
 ]
 
 [project.optional-dependencies]

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pdb
 import pytest
 import shutil
+from unittest.mock import patch
 import yaml
 
 import payu
@@ -136,3 +137,68 @@ def test_setup():
     for i in range(1, 4):
         assert((workdir/'input_00{i}.bin'.format(i=i)).stat().st_size
                == 1000**2 + i)
+
+
+@pytest.mark.parametrize(
+    "current_version, min_version",
+    [
+        ("2.0.0", "1.0.0"),
+        ("v0.11.2", "v0.11.1"),
+        ("1.0.0", "1.0.0"),
+        ("1.0.0+4.gabc1234", "1.0.0"),
+        ("1.0.0+0.gxyz987.dirty", "1.0.0"),
+        ("1.1.5", 1.1)
+    ]
+)
+def test_check_payu_version_pass(current_version, min_version):
+    # Mock the payu version
+    with patch('payu.__version__', current_version):
+        # Avoid running Experiment init method
+        with patch.object(payu.experiment.Experiment, '__init__',
+                          lambda x: None):
+            expt = payu.experiment.Experiment()
+
+            # Mock config.yaml
+            expt.config = {
+                "payu_minimum_version": min_version
+            }
+            expt.check_payu_version()
+
+
+@pytest.mark.parametrize(
+    "current_version, min_version",
+    [
+        ("1.0.0", "2.0.0"),
+        ("v0.11", "v0.11.1"),
+        ("1.0.0+4.gabc1234", "1.0.1"),
+        ("1.0.0+0.gxyz987.dirty", "v1.2"),
+    ]
+)
+def test_check_payu_version_fail(current_version, min_version):
+    with patch('payu.__version__', current_version):
+        with patch.object(payu.experiment.Experiment, '__init__',
+                          lambda x: None):
+            expt = payu.experiment.Experiment()
+
+            expt.config = {
+                "payu_minimum_version": min_version
+            }
+
+            with pytest.raises(RuntimeError):
+                expt.check_payu_version()
+
+
+@pytest.mark.parametrize(
+    "current_version", ["1.0.0", "1.0.0+4.gabc1234"]
+)
+def test_check_payu_version_pass_with_no_minimum_version(current_version):
+    with patch('payu.__version__', current_version):
+        with patch.object(payu.experiment.Experiment, '__init__',
+                          lambda x: None):
+            expt = payu.experiment.Experiment()
+
+            # Leave version out of config.yaml
+            expt.config = {}
+
+            # Check runs without an error
+            expt.check_payu_version()

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -202,3 +202,20 @@ def test_check_payu_version_pass_with_no_minimum_version(current_version):
 
             # Check runs without an error
             expt.check_payu_version()
+
+
+@pytest.mark.parametrize(
+    "minimum_version", ["abcdefg", None]
+)
+def test_check_payu_version_configured_invalid_version(minimum_version):
+    with patch('payu.__version__', "1.0.0"):
+        with patch.object(payu.experiment.Experiment, '__init__',
+                          lambda x: None):
+            expt = payu.experiment.Experiment()
+
+            expt.config = {
+                "payu_minimum_version": minimum_version
+            }
+
+            with pytest.raises(ValueError):
+                expt.check_payu_version()


### PR DESCRIPTION
Add a `payu_minimum_version` option to `config.yaml`. This runs a check at the start of the `Experimet.setup` comparing the current payu version and raises a `RuntimeError` if version is earlier than the configured minimum version.

I added a dependency on the `packaging` lib to parse and compare versions, which seems to the recommended library for parsing version strings (https://stackoverflow.com/a/11887885, https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools). I could do some regex parsing, but this library can handle already handles versions like `1.0`, `v0.1`, `1.0.0+4.gabc1234`  etc. So hopefully it'll be less buggy and will be able to support future version formats..

I added the check to the start of the setup method to the experiment class which seemed the logical place for it at the moment. So unfortunately it's adding more logic to an already long file. I thought about adding a `setup.py` file for setup helper methods, but I am not sure whether that'll make it better having one file for one small function?

Closes #147 