### PR TITLE
 Fix missing origin repository bug

### DIFF
--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -129,7 +129,10 @@ class GitRepository:
             except git.exc.GitCommandError:
                 warnings.warn(
                     f"Failed to fetch from remote repository: {remote.name} " +
-                    f"(url: {remote.url})",
+                    f"(url: {remote.url}). Payu is not able to determine " +
+                    "remote branch names, which are used in payu checkout " +
+                    "to check if a branch already exists, or when creating " +
+                    "a new branch from a remote branch.",
                     PayuGitWarning
                 )
                 continue

--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -124,7 +124,16 @@ class GitRepository:
         objects"""
         branch_names_dict = {}
         for remote in self.repo.remotes:
-            remote.fetch()
+            try:
+                remote.fetch()
+            except git.exc.GitCommandError:
+                warnings.warn(
+                    f"Failed to fetch from remote repository: {remote.name} " +
+                    f"(url: {remote.url})",
+                    PayuGitWarning
+                )
+                continue
+
             for ref in remote.refs:
                 branch_names_dict[ref.remote_head] = ref
         return branch_names_dict


### PR DESCRIPTION
In #405, `payu checkout` raises an error when it is no longer able to fetch branches from the remote repository. This happens when cloning from a remote repository using a path, and then that path gets deleted at a later point of time.

I changed it to catch the exception, and to display a warning to the user instead that payu was not able to fetch from the remote repository.