### PR TITLE
Add support for cloning configuration using a commit hash

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -128,7 +128,7 @@ new branch name::
 To create a new git branch starting from a tag or commit, use ``-s/--start-point``
 flag::
 
-      payu clone -b ${NEW_BRANCH} -s {COMMIT_HASH} ${REPOSITORY} my_expt
+      payu clone -b ${NEW_BRANCH} -s {COMMIT_HASH|TAG} ${REPOSITORY} my_expt
 
 To see more configuration options for ``payu clone``, 
 run:: 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -115,15 +115,20 @@ For example::
 Where ``${REPOSITORY}`` is the git URL or path of the repository to clone from, 
 for example, https://github.com/payu-org/mom-example.git.
 
-To clone and checkout an existing git branch, use the ``--branch`` flag and 
+To clone and checkout an existing git branch, use the ``-B/--branch`` flag and
 specify the branch name::
 
       payu clone --branch ${EXISTING_BRANCH} ${REPOSITORY} my_expt
 
-To create and checkout a new git branch use ``--new-branch`` and specify a 
-new branch name:
+To create and checkout a new git branch use ``-b/--new-branch`` and specify a
+new branch name::
 
       payu clone --new-branch ${NEW_BRANCH} ${REPOSITORY} my_expt
+
+To create a new git branch starting from a tag or commit, use ``-s/--start-point``
+flag::
+
+      payu clone -b ${NEW_BRANCH} -s {COMMIT_HASH} ${REPOSITORY} my_expt
 
 To see more configuration options for ``payu clone``, 
 run:: 

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -212,6 +212,7 @@ def switch_symlink(lab_dir_path: Path, control_path: Path,
 def clone(repository: str,
           directory: Path,
           branch: Optional[str] = None,
+          start_point: Optional[str] = None,
           new_branch_name: Optional[str] = None,
           keep_uuid: bool = False,
           model_type: Optional[str] = None,
@@ -227,11 +228,11 @@ def clone(repository: str,
         directory: Path
             The control directory where the repository will be cloned
         branch: Optional[str]
-            Name of branch to clone and checkout
+            Name of branch to checkout during the git clone
+        start_point: Optional[str]
+            Branch-name/commit/tag to start new branch from
         new_branch_name: Optional[str]
-            Name of new branch to create and checkout.
-            If branch is also defined, the new branch will start from the
-            latest commit of the branch.
+            Name of new branch to create and checkout
         keep_uuid: bool, default False
             Keep UUID unchanged, if it exists
         config_path: Optional[Path]
@@ -248,6 +249,10 @@ def clone(repository: str,
             Parent experiment UUID to add to generated metadata
 
     Returns: None
+
+    Note: branch, if defined, can be set to avoid initially checking out the
+    default branch during git clone - this is useful for repositories where
+    the default branch is not a payu configuration.
     """
     # Resolve directory to an absolute path
     control_path = directory.resolve()
@@ -278,7 +283,8 @@ def clone(repository: str,
                             control_path=control_path,
                             model_type=model_type,
                             lab_path=lab_path,
-                            parent_experiment=parent_experiment)
+                            parent_experiment=parent_experiment,
+                            start_point=start_point)
         else:
             # Checkout branch
             if branch is None:

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -191,6 +191,17 @@ clone_branch = {
     }
 }
 
+# Clone branch
+clone_start_point = {
+    'flags': ('--start-point', '-s'),
+    'parameters': {
+        'action':   'store',
+        'dest': 'start_point',
+        'default':  None,
+        'help': 'New branch will start from this commit or tag'
+    }
+}
+
 # Clone create branch
 new_branch_name = {
     'flags': ('--new-branch', '-b'),

--- a/payu/subcommands/clone_cmd.py
+++ b/payu/subcommands/clone_cmd.py
@@ -18,7 +18,7 @@ arguments = [args.model, args.config, args.laboratory,
              args.keep_uuid, args.clone_branch,
              args.repository, args.local_directory,
              args.new_branch_name, args.restart_path,
-             args.parent_experiment]
+             args.parent_experiment, args.clone_start_point]
 
 
 def transform_strings_to_path(path_str=None):
@@ -27,7 +27,7 @@ def transform_strings_to_path(path_str=None):
 
 def runcmd(model_type, config_path, lab_path, keep_uuid,
            branch, repository, local_directory, new_branch_name, restart_path,
-           parent_experiment):
+           parent_experiment, start_point):
     """Execute the command."""
     config_path = transform_strings_to_path(config_path)
     restart_path = transform_strings_to_path(restart_path)
@@ -43,7 +43,8 @@ def runcmd(model_type, config_path, lab_path, keep_uuid,
           lab_path=lab_path,
           new_branch_name=new_branch_name,
           restart_path=restart_path,
-          parent_experiment=parent_experiment)
+          parent_experiment=parent_experiment,
+          start_point=start_point)
 
 
 runscript = runcmd


### PR DESCRIPTION
Added `--start-point/-s` argument to `payu clone` to specify what commit/tag/branch name to start new branches from. 

So there is still `-B/--branch` flag which initially checks out a branch during the `git clone` command. This was initially done (I think?) to avoid checking out a default branch first. For example, the [access-om2-configs repository](https://github.com/ACCESS-NRI/access-om2-configs/), the `main` branch is not a payu configuration.

The start point is used similarly to the `payu checkout`'s  positional argument, so 

 ```
payu clone -b ${NEW_BRANCH_NAME} -s ${COMMIT_OR_TAG} ${REPOSITORY} ${DIR}
```

is equivalent to running 

```
payu clone ${REPOSITORY} ${DIR}
payu checkout -b ${NEW_BRANCH_NAME} ${COMMIT_OR_TAG}
```


Closes #503