### PR TITLE
Support symbolic links in input files

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -144,7 +144,7 @@ configuration.
 ``input``
    Listing of the directories containing model input fields, linked to the
    experiment during setup. This can either be the name of a directory in the
-   laboratory's ``input`` directory::
+   control directory or in laboratory's ``input`` directory::
 
       input: core_inputs
 

--- a/payu/models/test.py
+++ b/payu/models/test.py
@@ -15,6 +15,7 @@ config_files = [
             'diag',
             'input.nml'
         ]
+optional_config_files = ['opt_data']
 
 
 class Test(Model):
@@ -29,3 +30,4 @@ class Test(Model):
         self.default_exec = 'test.exe'
 
         self.config_files = config_files
+        self.optional_config_files = optional_config_files

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -1,5 +1,6 @@
 import argparse
 from argparse import Namespace
+import copy
 import os
 from pathlib import Path
 import shutil
@@ -18,12 +19,15 @@ from payu.schedulers import index as scheduler_index
 
 from .common import cd, make_random_file, get_manifests
 from .common import tmpdir, ctrldir, labdir, workdir, payudir
-from .common import config, sweep_work, payu_init, payu_setup
+from .common import sweep_work, payu_init, payu_setup
+from .common import config as original_config
 from .common import write_config
 from .common import make_exe, make_inputs, make_restarts
 from .common import make_payu_exe, make_all_files
 
 verbose = True
+
+config = copy.deepcopy(original_config)
 
 
 def setup_module(module):

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -1,84 +1,54 @@
 import copy
-import os
 from pathlib import Path
-import pdb
 import pytest
 import shutil
 from unittest.mock import patch
-import yaml
 
 import payu
-import payu.models.test
 
 from .common import cd, make_random_file, get_manifests
 from .common import tmpdir, ctrldir, labdir, workdir
-from .common import sweep_work, payu_init, payu_setup
+from .common import payu_init, payu_setup
 from .common import config as config_orig
 from .common import write_config
-from .common import make_exe, make_inputs, make_restarts, make_all_files
+from .common import make_exe
 
-verbose = True
+# Config files in the test model driver
+CONFIG_FILES = ['data', 'diag', 'input.nml']
+INPUT_NML_FILENAME = 'input.nml'
 
-config = copy.deepcopy(config_orig)
+# INPUT PATHS
+INPUT_TO_PATHS = {
+    # Inputs in lab directory
+    "lab_inputs": labdir / 'input' / 'lab_inputs',
+    # Inputs in control directory
+    "ctrl_inputs": ctrldir / 'ctrl_inputs',
+    # Inputs in tmp directory - that will be symlinked to control directory
+    "tmp_inputs": tmpdir / 'tmp_inputs'
+}
 
 
-def make_config_files():
-    """
-    Create files required for test model
-    """
-
-    config_files = payu.models.test.config_files
-    for file in config_files:
-        make_random_file(ctrldir/file, 29)
-
-
-def setup_module(module):
-    """
-    Put any test-wide setup code in here, e.g. creating test files
-    """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
+@pytest.fixture(autouse=True)
+def setup_and_teardown():
+    # Create tmp, lab and control directories
     try:
         tmpdir.mkdir()
         labdir.mkdir()
         ctrldir.mkdir()
-        make_all_files()
     except Exception as e:
         print(e)
 
-    write_config(config)
+    yield
 
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
+    # Remove tmp directory
     try:
-        # shutil.rmtree(tmpdir)
-        print('removing tmp')
+        shutil.rmtree(tmpdir)
     except Exception as e:
         print(e)
-
-# These are integration tests. They have an undesirable dependence on each
-# other. It would be possible to make them independent, but then they'd
-# be reproducing previous "tests", like init. So this design is deliberate
-# but compromised. It means when running an error in one test can cascade
-# and cause other tests to fail.
-#
-# Unfortunate but there you go.
 
 
 def test_init():
+    write_config(config_orig)
 
     # Initialise a payu laboratory
     with cd(ctrldir):
@@ -89,54 +59,131 @@ def test_init():
         assert((labdir / subdir).is_dir())
 
 
-def test_setup():
+def create_configuration_files():
+    """Create model config files in control directory"""
+    for file in CONFIG_FILES:
+        if file != INPUT_NML_FILENAME:
+            make_random_file(ctrldir / file, 8)
 
-    # Create some input and executable files
-    make_inputs()
+    # For input.nml, create a file symlink in control directory
+    input_nml_realpath = tmpdir / INPUT_NML_FILENAME
+    input_nml_symlink = ctrldir / INPUT_NML_FILENAME
+    make_random_file(input_nml_realpath, 8)
+    input_nml_symlink.symlink_to(input_nml_realpath)
+    assert input_nml_symlink.is_symlink()
+
+
+def check_configuration_files():
+    """Test model config_files are copied to work directory,
+    and that any symlinks are followed"""
+    for file in CONFIG_FILES + ['config.yaml']:
+        filepath = workdir / file
+        # Check file has been copied to work path
+        assert filepath.exists() and filepath.is_file()
+
+        # Check file is not a symlink
+        assert not filepath.is_symlink()
+
+        # Check file contents are copied
+        assert filepath.read_bytes() == (ctrldir / file).read_bytes()
+
+
+def create_inputs():
+    """Create inputs in laboratory, control and a temporary
+    directory - that are symlinked to the control directory"""
+    # Make inputs
+    for inputs, path in INPUT_TO_PATHS.items():
+        path.mkdir(parents=True, exist_ok=True)
+        for i in range(1, 4):
+            make_random_file(path / f'{inputs}_input_00{i}.bin',
+                            1000**2 + i)
+
+    # Create symlink in work directory
+    (ctrldir / 'tmp_inputs').symlink_to(INPUT_TO_PATHS['tmp_inputs'])
+
+
+def check_inputs():
+    """Check inputs are symlinked to work directory,
+    and added in input manifest
+    """
+    input_manifest = get_manifests(ctrldir/'manifests')['input.yaml']
+    for inputs, path in INPUT_TO_PATHS.items():
+        for i in range(1, 4):
+            filename = f'{inputs}_input_00{i}.bin'
+            work_input = workdir / filename
+
+            # Check file exists and file size is expected
+            assert work_input.exists() and work_input.is_symlink()
+            assert work_input.stat().st_size == 1000**2 + i
+
+            # Check relative input path is added to manifest
+            filepath = str(Path('work') / filename)
+            assert filepath in input_manifest
+
+            # Check manifest fullpath
+            expected_fullpath = path / filename
+            manifest_fullpath_str = input_manifest[filepath]['fullpath']
+            assert manifest_fullpath_str == str(expected_fullpath)
+
+            # Check fullpath is a resolved path
+            manifest_fullpath = Path(manifest_fullpath_str)
+            assert manifest_fullpath.is_absolute()
+            assert not manifest_fullpath.is_symlink()
+
+
+def check_exe(exe_name):
+    """Test executable has been added to work directory"""
+    bin_exe = labdir / 'bin' / exe_name
+    work_exe = workdir / exe_name
+    assert work_exe.exists() and work_exe.is_symlink()
+    assert work_exe.resolve() == bin_exe.resolve()
+
+
+def check_workdir(config):
+    """Test work directory is setup as expected"""
+    assert workdir.is_symlink and workdir.is_dir()
+
+    # Check configuration files, inputs and executables are moved to work dir
+    check_configuration_files()
+    check_inputs()
+    check_exe(config['exe'])
+
+
+def test_setup():
+    """Test work directory is setup as expected, e.g. configuratiom files are
+    copied across, and inputs and executables are symlinked"""
+    config = copy.deepcopy(config_orig)
+
+    # Create test configuration files, excutables, and inputs
+    create_configuration_files()
+    create_inputs()
     make_exe()
 
-    bindir = labdir / 'bin'
-    exe = config['exe']
+    # Over-ride input in default configuration
+    config['input'] = [input for input in INPUT_TO_PATHS]
+    write_config(config)
 
-    make_config_files()
+    # Initialise a payu laboratory
+    with cd(ctrldir):
+        payu_init(None, None, str(labdir))
 
     # Run setup
     payu_setup(lab_path=str(labdir))
 
-    assert(workdir.is_symlink())
-    assert(workdir.is_dir())
-    assert((workdir/exe).resolve() == (bindir/exe).resolve())
-    workdirfull = workdir.resolve()
+    # Check files in work directory are setup as expected
+    check_workdir(config)
 
-    config_files = payu.models.test.config_files
-
-    for f in config_files + ['config.yaml']:
-        assert((workdir/f).is_file())
-
-    for i in range(1, 4):
-        assert((workdir/'input_00{i}.bin'.format(i=i)).stat().st_size
-               == 1000**2 + i)
-
+    # Re-run setup - expect an error
     with pytest.raises(SystemExit,
                        match="work path already exists") as setup_error:
         payu_setup(lab_path=str(labdir), sweep=False, force=False)
     assert setup_error.type == SystemExit
 
+    # Re-run payu setup with force=True
     payu_setup(lab_path=str(labdir), sweep=False, force=True)
 
-    assert(workdir.is_symlink())
-    assert(workdir.is_dir())
-    assert((workdir/exe).resolve() == (bindir/exe).resolve())
-    workdirfull = workdir.resolve()
-
-    config_files = payu.models.test.config_files
-
-    for f in config_files + ['config.yaml']:
-        assert((workdir/f).is_file())
-
-    for i in range(1, 4):
-        assert((workdir/'input_00{i}.bin'.format(i=i)).stat().st_size
-               == 1000**2 + i)
+    # Check files in work directory are setup as expected
+    check_workdir(config)
 
 
 @pytest.mark.parametrize(

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -11,21 +11,12 @@ from .common import tmpdir, ctrldir, labdir, workdir
 from .common import payu_init, payu_setup
 from .common import config as config_orig
 from .common import write_config
-from .common import make_exe
+from .common import make_exe, make_inputs
 
 # Config files in the test model driver
 CONFIG_FILES = ['data', 'diag', 'input.nml']
+OPTIONAL_CONFIG_FILES = ['opt_data']
 INPUT_NML_FILENAME = 'input.nml'
-
-# INPUT PATHS
-INPUT_TO_PATHS = {
-    # Inputs in lab directory
-    "lab_inputs": labdir / 'input' / 'lab_inputs',
-    # Inputs in control directory
-    "ctrl_inputs": ctrldir / 'ctrl_inputs',
-    # Inputs in tmp directory - that will be symlinked to control directory
-    "tmp_inputs": tmpdir / 'tmp_inputs'
-}
 
 
 @pytest.fixture(autouse=True)
@@ -59,9 +50,40 @@ def test_init():
         assert((labdir / subdir).is_dir())
 
 
-def create_configuration_files():
-    """Create model config files in control directory"""
+def make_config_files():
+    """
+    Create files required for test model
+    """
     for file in CONFIG_FILES:
+        make_random_file(ctrldir/file, 29)
+
+
+def run_payu_setup(config=config_orig, create_inputs=False,
+                   create_config_files=True):
+    """Helper function to write config.yaml files, make inputs,
+    config files and run experiment setup"""
+    # Setup files
+    write_config(config)
+    make_exe()
+    if create_inputs:
+        make_inputs()
+    if create_config_files:
+        make_config_files()
+
+    # Initialise a payu laboratory
+    with cd(ctrldir):
+        payu_init(None, None, str(labdir))
+
+    # Run payu setup
+    payu_setup(lab_path=str(labdir))
+
+
+def test_setup_configuration_files():
+    """Test model config_files are copied to work directory,
+    and that any symlinks are followed"""
+    # Create configuration files
+    all_config_files = CONFIG_FILES + OPTIONAL_CONFIG_FILES
+    for file in all_config_files:
         if file != INPUT_NML_FILENAME:
             make_random_file(ctrldir / file, 8)
 
@@ -72,106 +94,79 @@ def create_configuration_files():
     input_nml_symlink.symlink_to(input_nml_realpath)
     assert input_nml_symlink.is_symlink()
 
+    # Run payu setup
+    run_payu_setup(create_inputs=True)
 
-def check_configuration_files():
-    """Test model config_files are copied to work directory,
-    and that any symlinks are followed"""
-    for file in CONFIG_FILES + ['config.yaml']:
+    # Check config files have been copied to work path
+    for file in all_config_files + ['config.yaml']:
         filepath = workdir / file
-        # Check file has been copied to work path
         assert filepath.exists() and filepath.is_file()
-
-        # Check file is not a symlink
         assert not filepath.is_symlink()
-
-        # Check file contents are copied
         assert filepath.read_bytes() == (ctrldir / file).read_bytes()
 
 
-def create_inputs():
-    """Create inputs in laboratory, control and a temporary
-    directory - that are symlinked to the control directory"""
+@pytest.mark.parametrize(
+    "input_path, is_symlink, is_absolute",
+    [
+        (labdir / 'input' / 'lab_inputs', False, False),
+        (ctrldir / 'ctrl_inputs', False, False),
+        (tmpdir / 'symlinked_inputs', True, False),
+        (tmpdir / 'tmp_inputs', False, True)
+    ]
+)
+def test_setup_inputs(input_path, is_symlink, is_absolute):
+    """Test inputs are symlinked to work directory,
+    and added in input manifest"""
     # Make inputs
-    for inputs, path in INPUT_TO_PATHS.items():
-        path.mkdir(parents=True, exist_ok=True)
-        for i in range(1, 4):
-            make_random_file(path / f'{inputs}_input_00{i}.bin',
-                            1000**2 + i)
+    input_path.mkdir(parents=True, exist_ok=True)
+    for i in range(1, 4):
+        make_random_file(input_path / f'input_00{i}.bin', 1000**2 + i)
 
-    # Create symlink in work directory
-    (ctrldir / 'tmp_inputs').symlink_to(INPUT_TO_PATHS['tmp_inputs'])
+    if is_symlink:
+        # Create an input symlink in control directory
+        (ctrldir / input_path.name).symlink_to(input_path)
 
+    # Modify config to specify input path
+    config = copy.deepcopy(config_orig)
+    config['input'] = str(input_path) if is_absolute else input_path.name
 
-def check_inputs():
-    """Check inputs are symlinked to work directory,
-    and added in input manifest
-    """
+    # Run payu setup
+    run_payu_setup(config=config, create_config_files=True)
+
     input_manifest = get_manifests(ctrldir/'manifests')['input.yaml']
-    for inputs, path in INPUT_TO_PATHS.items():
-        for i in range(1, 4):
-            filename = f'{inputs}_input_00{i}.bin'
-            work_input = workdir / filename
+    for i in range(1, 4):
+        filename = f'input_00{i}.bin'
+        work_input = workdir / filename
 
-            # Check file exists and file size is expected
-            assert work_input.exists() and work_input.is_symlink()
-            assert work_input.stat().st_size == 1000**2 + i
+        # Check file exists and file size is expected
+        assert work_input.exists() and work_input.is_symlink()
+        assert work_input.stat().st_size == 1000**2 + i
 
-            # Check relative input path is added to manifest
-            filepath = str(Path('work') / filename)
-            assert filepath in input_manifest
+        # Check relative input path is added to manifest
+        filepath = str(Path('work') / filename)
+        assert filepath in input_manifest
 
-            # Check manifest fullpath
-            expected_fullpath = path / filename
-            manifest_fullpath_str = input_manifest[filepath]['fullpath']
-            assert manifest_fullpath_str == str(expected_fullpath)
+        # Check manifest fullpath
+        manifest_fullpath = input_manifest[filepath]['fullpath']
+        assert manifest_fullpath == str(input_path / filename)
 
-            # Check fullpath is a resolved path
-            manifest_fullpath = Path(manifest_fullpath_str)
-            assert manifest_fullpath.is_absolute()
-            assert not manifest_fullpath.is_symlink()
-
-
-def check_exe(exe_name):
-    """Test executable has been added to work directory"""
-    bin_exe = labdir / 'bin' / exe_name
-    work_exe = workdir / exe_name
-    assert work_exe.exists() and work_exe.is_symlink()
-    assert work_exe.resolve() == bin_exe.resolve()
-
-
-def check_workdir(config):
-    """Test work directory is setup as expected"""
-    assert workdir.is_symlink and workdir.is_dir()
-
-    # Check configuration files, inputs and executables are moved to work dir
-    check_configuration_files()
-    check_inputs()
-    check_exe(config['exe'])
+        # Check fullpath is a resolved path
+        assert Path(manifest_fullpath).is_absolute()
+        assert not Path(manifest_fullpath).is_symlink()
 
 
 def test_setup():
-    """Test work directory is setup as expected, e.g. configuratiom files are
-    copied across, and inputs and executables are symlinked"""
-    config = copy.deepcopy(config_orig)
+    """Test work directory and executable are setup as expected,
+    and re-running setup requires a force=True"""
+    run_payu_setup(create_inputs=True, create_config_files=True)
 
-    # Create test configuration files, excutables, and inputs
-    create_configuration_files()
-    create_inputs()
-    make_exe()
+    assert workdir.is_symlink and workdir.is_dir()
 
-    # Over-ride input in default configuration
-    config['input'] = [input for input in INPUT_TO_PATHS]
-    write_config(config)
-
-    # Initialise a payu laboratory
-    with cd(ctrldir):
-        payu_init(None, None, str(labdir))
-
-    # Run setup
-    payu_setup(lab_path=str(labdir))
-
-    # Check files in work directory are setup as expected
-    check_workdir(config)
+    # Check executable symlink is in work directory
+    bin_exe = labdir / 'bin' / config_orig['exe']
+    work_exe = workdir / config_orig['exe']
+    assert work_exe.exists() and work_exe.is_symlink()
+    assert work_exe.resolve() == bin_exe.resolve()
 
     # Re-run setup - expect an error
     with pytest.raises(SystemExit,
@@ -179,11 +174,7 @@ def test_setup():
         payu_setup(lab_path=str(labdir), sweep=False, force=False)
     assert setup_error.type == SystemExit
 
-    # Re-run payu setup with force=True
-    payu_setup(lab_path=str(labdir), sweep=False, force=True)
-
-    # Check files in work directory are setup as expected
-    check_workdir(config)
+    assert workdir.is_symlink and workdir.is_dir()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR:
 - adds a step to model setup to resolve the input directory paths to absolute paths and resolve symlinks.
-  pass `follow_symlink=True` to copy commands when copying config files. However this is already a default value but I added in so it clear in the code that it's intentional.
- more tests for the above

In 0daf9115b65468e05f1db4bd8285fdc9a896c923, I had just one test that would run `payu setup` once and test that inputs, configuration files and executables that were set up as expected. In 6d975159f4102ac184ab13544f1dbbb451e2225e, I split up the tests to try(?) make it simpler to read and have one test for one thing. My concern was that it would make running tests slower as were running a `payu setup` multiple times. It ended up only adding a couple seconds to the tests..

To check how current manifests are changed due to these changes, I ran `payu setup` for `release-1deg_jra55_ryf` branch in `access-om2-configs`(https://github.com/ACCESS-NRI/access-om2-configs/tree/release-1deg_jra55_ryf). One of the full path changes are in `input.yaml` manifest are:

```
 work/INPUT/JRA55_MOM1_conserve2nd.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.1deg/2020.05.30/JRA55_MOM1_conserve2nd.nc
   hashes:
-    binhash: abe66e4b33cbb75d25c010ea5f96f053
+    binhash: 3ba86d1ae2c7641a29dce1179c55ad64
     md5: 00be8ec0f1126055b65dc68178ce4eb5
```

(as `/g/data/vk83/experiments/` is a symlink for `/g/data/vk83/configurations`)

Closes #385
Closes #450