### PR TITLE
Add error handling for payu checkout with non-writable laboratory

### DIFF
--- a/payu/branch.py
+++ b/payu/branch.py
@@ -22,20 +22,12 @@ from payu.metadata import Metadata, UUID_FIELD, METADATA_FILENAME
 from payu.git_utils import GitRepository, git_clone, PayuBranchError
 
 LAB_WRITE_ACCESS_ERROR = """
-Do not have write access to the configured laboratory directory.
-Skipping creating metadata, setting up restart configuration, and archive/work
-symlinks.
+Failed to initialise laboratory directories. Skipping creating metadata,
+setting up restart configuration, and archive/work symlinks.
 
-To fix the errors, edit one (or more) of the following config.yaml options that
-determine the laboratory path:
-    - 'laboratory': (Top-level directory for the model laboratory 
-        Default: /scratch/${PROJECT}/${USER}/${MODEL}
-    - 'shortpath' (Top-level directory for laboratory.
-        Default: /scratch/${PROJECT}
-    - 'project': (The project to use for payu PBS jobs. Default: ${PROJECT})
-
-Then either run 'payu setup' or rerun checkout command with the current git
-branch, e.g. `payu checkout -r  <RESTART_PATH> <CURRENT_BRANCH>`
+To fix, first modify/remove the config.yaml options that determine laboratory
+path. Then either run 'payu setup' or rerun checkout command with the current
+git branch, e.g. `payu checkout -r  <RESTART_PATH> <CURRENT_BRANCH>`
 """
 
 NO_CONFIG_FOUND_MESSAGE = """No configuration file found on this branch.
@@ -138,15 +130,6 @@ def check_config_path(config_path: Optional[Path] = None) -> Optional[Path]:
     return config_path
 
 
-def check_laboratory_path(lab_basepath: str) -> None:
-    """Check if a laboratory path has write access"""
-    if not os.access(lab_basepath, os.W_OK | os.X_OK):
-        print(LAB_WRITE_ACCESS_ERROR)
-        raise PermissionError(
-            f"Laboratory directory does not have write access: {lab_basepath}"
-        )
-
-
 def checkout_branch(branch_name: str,
                     is_new_branch: bool = False,
                     is_new_experiment: bool = False,
@@ -198,7 +181,11 @@ def checkout_branch(branch_name: str,
 
     # Initialise Lab
     lab = Laboratory(model_type, config_path, lab_path)
-    check_laboratory_path(lab.basepath)
+    try:
+        lab.initialize()
+    except PermissionError:
+        print(LAB_WRITE_ACCESS_ERROR)
+        raise
 
     # Initialise metadata
     metadata = Metadata(Path(lab.archive_path),

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -239,8 +239,7 @@ def switch_symlink(lab_dir_path: Path, control_path: Path,
     sym_path = control_path / sym_dir
 
     # Remove symlink if it already exists
-    # TODO: FIX for when target dir no longer exists (just check for symlink) and write test
-    if sym_path.exists() and sym_path.is_symlink:
+    if sym_path.is_symlink():
         previous_path = sym_path.resolve()
         sym_path.unlink()
         print(f"Removed {sym_dir} symlink to {previous_path}")

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -52,6 +52,8 @@ class Experiment(object):
 
     def __init__(self, lab, reproduce=False, force=False, metadata_off=False):
         self.lab = lab
+        # Check laboratory directories are writable
+        self.lab.initialize()
 
         if not force:
             # check environment for force flag under PBS

--- a/payu/laboratory.py
+++ b/payu/laboratory.py
@@ -14,11 +14,11 @@ LAB_INITIALIZE_ERROR = """
 The configured laboratory directory may not have write access. Edit/remove one
 (or more) of the following config.yaml options that determine the laboratory
 path:
+    - 'project': The project to use for payu PBS jobs. Default: ${PROJECT}
+    - 'shortpath' Top-level directory for laboratory
+        Default: /scratch/${PROJECT}
     - 'laboratory': Top-level directory for the model laboratory
         Default: /scratch/${PROJECT}/${USER}/${MODEL}
-    - 'shortpath' Top-level directory for laboratory.
-        Default: /scratch/${PROJECT}
-    - 'project': The project to use for payu PBS jobs. Default: ${PROJECT}
 """
 
 

--- a/payu/laboratory.py
+++ b/payu/laboratory.py
@@ -10,6 +10,17 @@ import pwd
 
 from payu.fsops import mkdir_p, read_config
 
+LAB_INITIALIZE_ERROR = """
+The configured laboratory directory may not have write access. Edit/remove one
+(or more) of the following config.yaml options that determine the laboratory
+path:
+    - 'laboratory': Top-level directory for the model laboratory
+        Default: /scratch/${PROJECT}/${USER}/${MODEL}
+    - 'shortpath' Top-level directory for laboratory.
+        Default: /scratch/${PROJECT}
+    - 'project': The project to use for payu PBS jobs. Default: ${PROJECT}
+"""
+
 
 class Laboratory(object):
     """Interface to the numerical model's laboratory."""
@@ -84,7 +95,13 @@ class Laboratory(object):
 
     def initialize(self):
         """Create the laboratory directories."""
-        mkdir_p(self.archive_path)
-        mkdir_p(self.bin_path)
-        mkdir_p(self.codebase_path)
-        mkdir_p(self.input_basepath)
+        try:
+            mkdir_p(self.archive_path)
+            mkdir_p(self.bin_path)
+            mkdir_p(self.codebase_path)
+            mkdir_p(self.input_basepath)
+        except PermissionError as e:
+            print(LAB_INITIALIZE_ERROR)
+            raise PermissionError(
+                f"Failed to initialise laboratory directories. Error: {e}"
+            )

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -530,7 +530,7 @@ def test_checkout_laboratory_path_error(mock_lab_initialise):
 
     # Assert new commit has not been added
     assert repo.active_branch.object.hexsha == current_commit
-    
+
     assert str(repo.active_branch) == "Branch1"
     assert not (ctrldir / "metadata.yaml").exists()
 

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -216,6 +216,27 @@ def test_switch_symlink_when_no_symlink_exists_and_no_archive():
     assert not archive_symlink.is_symlink()
 
 
+def test_switch_symkink_when_previous_symlink_dne():
+    # Point archive symlink to a directory that does not exist anymore
+    lab_archive = labdir / "archive"
+    previous_archive_dir = lab_archive / "ExperimentDNE"
+
+    archive_symlink = ctrldir / "archive"
+    archive_symlink.symlink_to(previous_archive_dir)
+
+    # New Experiment
+    experiment_name = "Experiment1"
+    archive_dir = lab_archive / experiment_name
+    archive_dir.mkdir(parents=True)
+
+    # Test Function
+    switch_symlink(lab_archive, ctrldir, experiment_name, "archive")
+
+    # Assert new symlink is created
+    assert archive_symlink.exists() and archive_symlink.is_symlink()
+    assert archive_symlink.resolve() == archive_dir
+
+
 def check_metadata(expected_uuid,
                    expected_experiment,
                    expected_parent_uuid=None,

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from payu.branch import add_restart_to_config, check_restart, switch_symlink
 from payu.branch import checkout_branch, clone, list_branches
+from payu.branch import check_laboratory_path
 from payu.metadata import MetadataWarning
 from payu.fsops import read_config
 
@@ -487,6 +488,22 @@ def test_checkout_branch_with_restart_path(mock_uuid):
                           expected_uuid=uuid2,
                           expected_experiment=experiment2_name,
                           expected_parent_uuid=uuid1)
+
+
+@patch("os.access")
+def test_check_laboratory_path(mock_os_access):
+    # Test seems a bit useless as was unsure on how to create a directory
+    # without write permissions without locking myself out the directory
+    mock_os_access.return_value = False
+    with cd(ctrldir):
+        # Test raises a permission error
+        with pytest.raises(PermissionError):
+            check_laboratory_path("some/path")
+    
+    mock_os_access.return_value = True
+    with cd(ctrldir):
+        # Test check runs without errors
+        check_laboratory_path("some/path")
 
 
 @patch("uuid.uuid4")

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -364,12 +364,16 @@ def test_checkout_existing_branch_with_no_metadata(mock_uuid):
     expected_no_uuid_msg = (
         "No experiment uuid found in metadata. Generating a new uuid"
     )
+    expected_no_archive_msg = (
+        "No pre-existing archive found. Generating a new uuid"
+    )
 
     with cd(ctrldir):
         # Test checkout existing branch with no existing metadata
         with pytest.warns(MetadataWarning, match=expected_no_uuid_msg):
-            checkout_branch(branch_name="Branch1",
-                            lab_path=labdir)
+            with pytest.warns(MetadataWarning, match=expected_no_archive_msg):
+                checkout_branch(branch_name="Branch1",
+                                lab_path=labdir)
 
     # Check metadata was created and commited
     branch1_experiment_name = f"{ctrldir_basename}-Branch1-574ea2c9"

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 
 from payu.branch import add_restart_to_config, check_restart, switch_symlink
 from payu.branch import checkout_branch, clone, list_branches
-from payu.branch import check_laboratory_path
 from payu.metadata import MetadataWarning
 from payu.fsops import read_config
 
@@ -515,20 +514,37 @@ def test_checkout_branch_with_restart_path(mock_uuid):
                           expected_parent_uuid=uuid1)
 
 
-@patch("os.access")
-def test_check_laboratory_path(mock_os_access):
-    # Test seems a bit useless as was unsure on how to create a directory
-    # without write permissions without locking myself out the directory
-    mock_os_access.return_value = False
+@patch("payu.laboratory.Laboratory.initialize")
+def test_checkout_laboratory_path_error(mock_lab_initialise):
+    mock_lab_initialise.side_effect = PermissionError
+
+    repo = setup_control_repository()
+    current_commit = repo.active_branch.object.hexsha
+
     with cd(ctrldir):
         # Test raises a permission error
         with pytest.raises(PermissionError):
-            check_laboratory_path("some/path")
+            checkout_branch(branch_name="Branch1",
+                            is_new_branch=True,
+                            lab_path=labdir)
+
+    # Assert new commit has not been added
+    assert repo.active_branch.object.hexsha == current_commit
     
-    mock_os_access.return_value = True
+    assert str(repo.active_branch) == "Branch1"
+    assert not (ctrldir / "metadata.yaml").exists()
+
+    # Test removing lab directory
+    shutil.rmtree(labdir)
+    mock_lab_initialise.side_effect = None
     with cd(ctrldir):
-        # Test check runs without errors
-        check_laboratory_path("some/path")
+        # Test runs without an error - directory is initialised
+        checkout_branch(branch_name="Branch2",
+                        is_new_branch=True,
+                        lab_path=labdir)
+
+    # Assert new commit has been added
+    assert repo.active_branch.object.hexsha != current_commit
 
 
 @patch("uuid.uuid4")


### PR DESCRIPTION
This PR:

- In payu checkout - initialise laboratory directories before generating any metadata. This will fail with PermissionError if directories are non-writable, and prints some information on how to recover
- Fix a small error with changing archive symlinks when a previous directory has been deleted - added test
- Fix a uncaught warning when running payu checkout pytests

I was running with the idea of checking out a git branch - running checks on that branch and then if they failed, reverting the checkout back to the previous branch (and delete any new branches that were created). Though I then finally realised that it would make it difficult for the user to apply fixes on the branch/tag/commit they were starting from, e.g. fix project/shortpath/laboratory in config.yaml. It would require adding command-line args to payu clone/checkout that will require modifications to config.yaml.

There is the pre-existing `--laboratory` command-line flag to `payu clone/checkout`. It doesn't modify the `config.yaml` so will either need to be passed to subsequent `payu` commands or `shortpath/laboratory/project` options will need to modified manually in `config.yaml`.

I initialised laboratory directories (using `mkdir_p`) rather just checking for write access using `os.access`, so it wouldn't fail when a laboratory base directory does not exist but it can be created by a user. I added laboratory specific error messaging to Laboratory class method, and also call `laboratory.initialize()` in `Experiment()` as when running `payu setup/sweep/run` it would be good to know first thing if the laboratory directory is even writable. 

Closes #524