### PR TITLE
Override yatm model class method for prior restarts

### DIFF
--- a/payu/models/yatm.py
+++ b/payu/models/yatm.py
@@ -37,11 +37,13 @@ class Yatm(Model):
         self.work_input_path = os.path.join(self.work_path, 'INPUT')
 
     def archive(self):
-
-        # Create an empty restart directory
-        mkdir_p(self.restart_path)
-
         shutil.rmtree(self.work_input_path)
 
     def collate(self):
         pass
+
+    def get_prior_restart_files(self):
+        """Override model class method to avoid displaying an error
+        when there is no prior restart files. yatm reads from data files
+        so it should not require prior restarts"""
+        return []

--- a/test/models/test_yatm.py
+++ b/test/models/test_yatm.py
@@ -1,0 +1,21 @@
+
+from unittest.mock import Mock
+
+import payu.experiment
+import payu.models
+
+def test_get_prior_restart_files(capsys, tmpdir):
+    with capsys.disabled():
+        expt = Mock(spec=payu.experiment.Experiment)
+        model_config = {'model': 'yatm'}
+        model = payu.models.Yatm(expt, 'atmosphere', model_config)
+        model.prior_restart_path = str(tmpdir / 'unexistent_dir')
+
+    restart_files = model.get_prior_restart_files()
+
+    # Check nothing written to standard output
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    assert captured.err == ''
+
+    assert restart_files == []


### PR DESCRIPTION
Implements solution described here: https://github.com/payu-org/payu/issues/523#issuecomment-2398858187, which was to add an override the parent class `get_prior_restart_files` in `yatm`, to return just an empty array. This is to prevent error messaging on a missing prior restart directory when `yatm` driver does not require any.

Closes #523