### PR TITLE
Model log compression

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -276,10 +276,11 @@ section for details.
 Archiving
 ---------
 
-``archiving``
+``archive``
       On completion of a model run, payu moves model output, restart, and log
       files from the temporary work area to the experiment archive directory.
       The following settings control the steps taken during the archive step:
+
       ``enable`` (*Default:* ``True``)
             Flag to enable/disable the archive step. If ``False`` all output, restart,
             and log files will remain in the work directory, and any collation, post-processing,

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -503,7 +503,7 @@ class Experiment(object):
 
         # Check restart pruning for valid configuration values and
         # warns user if more restarts than expected would be pruned
-        if self.config.get('archive', True):
+        if self.archiving():
             self.get_restarts_to_prune()
 
     def run(self, *user_flags):
@@ -769,8 +769,25 @@ class Experiment(object):
         if run_script:
             self.run_userscript(run_script)
 
+    def archiving(self):
+        """
+        Determine whether to run archive step based on config.yaml settings.
+        Default to True when archive settings are absent.
+        """
+        archive_config = self.config.get('archive', {})
+        if isinstance(archive_config, dict):
+            return archive_config.get('enable', True)
+
+        # Backwards compatibility for configs with boolean archive setting
+        elif isinstance(archive_config, bool):
+            return archive_config
+
+        else:
+            msg = "Incorrect format for archive settings in config.yaml"
+            raise RuntimeError(msg)
+
     def archive(self, force_prune_restarts=False):
-        if not self.config.get('archive', True):
+        if not self.archiving():
             print('payu: not archiving due to config.yaml setting.')
             return
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -775,16 +775,7 @@ class Experiment(object):
         Default to True when archive settings are absent.
         """
         archive_config = self.config.get('archive', {})
-        if isinstance(archive_config, dict):
-            return archive_config.get('enable', True)
-
-        # Backwards compatibility for configs with boolean archive setting
-        elif isinstance(archive_config, bool):
-            return archive_config
-
-        else:
-            msg = "Incorrect format for archive settings in config.yaml"
-            raise RuntimeError(msg)
+        return archive_config.get('enable', True)
 
     def archive(self, force_prune_restarts=False):
         if not self.archiving():

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -126,6 +126,12 @@ def read_config(config_fname=None):
 
     config['collate'] = collate_config
 
+    # Transform legacy archive config options
+    archive_config = config.pop('archive', {})
+    if type(archive_config) is bool:
+        archive_config = {'enable': archive_config}
+    config['archive'] = archive_config
+
     # Transform legacy modules config options
     modules_config = config.pop('modules', {})
     if type(modules_config) is list:

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -367,8 +367,7 @@ class Cice(Model):
         """
         log_files = []
         for filename in os.listdir(self.work_path):
-            if any((re.match(pattern, filename)
-                    for pattern in self.logs_to_compress)):
+            if re.match("|".join(self.logs_to_compress), filename):
                 log_files.append(os.path.join(self.work_path, filename))
         return log_files
 

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -342,19 +342,10 @@ class Cice(Model):
         else:
             shutil.rmtree(self.work_input_path)
 
-        if self.compression_enabled():
-            self.compress_log_files()
-
-    def compression_enabled(self):
-        """
-        Determine whether to run log compression based on config.yaml settings.
-        Default to True when 'compress_logs' setting is absent.
-        """
         archive_config = self.expt.config.get('archive', {})
-        if isinstance(archive_config, dict):
-            return archive_config.get('compress_logs', True)
-        else:
-            return True
+        compressing_logs = archive_config.get('compress_logs', True)
+        if compressing_logs:
+            self.compress_log_files()
 
     def get_log_files(self):
         """

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -381,7 +381,10 @@ class Cice(Model):
                           mode="w:gz") as tar:
             for file in log_files:
                 tar.add(file, arcname=os.path.basename(file))
-                os.remove(file)
+
+        # Delete files after tarball is written
+        for file in log_files:
+            os.remove(file)
 
     def collate(self):
         pass

--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -42,6 +42,9 @@ class Cice5(Cice):
         self.copy_restarts = True
         self.copy_inputs = True
 
+        # Empty list means no log files will be compressed
+        self.logs_to_compress = []
+
     def set_local_timestep(self, t_step):
         dt = self.ice_in['setup_nml']['dt']
         npt = self.ice_in['setup_nml']['npt']

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -364,7 +364,7 @@ def non_log_file():
 @pytest.mark.parametrize("config", [CONFIG_WITH_COMPRESSION],
                          indirect=True)
 def test_log_compression(config, cice4_log_files, non_log_file,
-                         cice_nml # Required by expt.__init__
+                         cice_nml   # Required by expt.__init__
                          ):
     """
     Test that logfiles produced by cice during ESM1.5 simulations are

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -150,6 +150,7 @@ def test_read_config():
     assert(config.pop('collate') == {})
     assert(config.pop('control_path') == os.getcwd())
     assert(config.pop('modules') == {})
+    assert(config.pop('archive') == {})
     assert(config == {})
 
     os.remove(config_tmp)


### PR DESCRIPTION
This draft PR addresses #527.

It adds a `compress_log_files` method, initially just to the `cice.py` driver. This  is called during the `archive` step and compresses all the log files matching some specified regex patterns into a tarball. A `compress_logs` option in the `config.yaml` file controls whether to run the compression.

I've marked this PR as a draft, as I'd be keen to see if the implementation looks reasonable to others, and if so I think it would be good to move the changes over to the general `model` class making it available to each model.