### PR TITLE
fix cice5 restart pointers

### DIFF
--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -47,12 +47,14 @@ class Access(Model):
                 model.copy_restarts = True
 
                 model.set_timestep = model.set_access_timestep
-                model.get_ptr_restart_dir = model.get_access_ptr_restart_dir
 
             if model.model_type == 'cice5':
                 model.access_restarts.extend(['u_star.nc', 'sicemass.nc'])
 
             if model.model_type == 'cice':
+                # The ACCESS build of CICE assumes that restart_dir is 'RESTART'
+                model.get_ptr_restart_dir = lambda : '.'
+
                 # Structure of model coupling namelist
                 model.cpl_fname = 'input_ice.nml'
                 model.cpl_group = 'coupling'

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -150,11 +150,6 @@ class Cice(Model):
     def get_ptr_restart_dir(self):
         return os.path.relpath(self.work_init_path, self.work_path)
 
-    def get_access_ptr_restart_dir(self):
-        # The ACCESS build of CICE assumes that restart_dir is 'RESTART'
-        # TODO: Move to ACCESS driver
-        return '.'
-
     def setup(self):
         super(Cice, self).setup()
 


### PR DESCRIPTION
Closes #534 

For CICE4 with AUSCOM set, restart pointer file contains:

`./iced.xxxx`

for CICE5, restart pointer file contains

`./RESTART/iced.xxxx`