### PR TITLE
Staged cable improve resubmission and restart handling

### DIFF
--- a/payu/models/staged_cable.py
+++ b/payu/models/staged_cable.py
@@ -32,7 +32,7 @@ class StagedCable(Model):
 
         # We want people to be able to use payu during testing, which
         # often means additions of new namelists due to new science
-        # modules. I would like to set 
+        # modules. I would like to set
         # optional_config_files = glob.glob("*.nml")
         # but this feels like a bit of an abuse of feature.
         self.config_files = ['stage_config.yaml']
@@ -128,39 +128,6 @@ class StagedCable(Model):
                 # Finish handling of single step stage
         return cable_stages
 
-    def _get_further_restarts(self):
-        """Get the restarts from stages further in the past where necessary."""
-
-        # Often we take restarts from runs which are not the most recent run as
-        # inputs for particular science modules, which means we have to extend
-        # the existing functionality around retrieving restarts.
-
-        # We can't supercede the parent get_prior_restart_files, since the
-        # files returned by said function are prepended by
-        # self.prior_restart_path, which is not desirable in this instance.
-
-        num_completed_stages = len(self.configuration_log['completed_stages'])
-
-        for stage_number in reversed(range(num_completed_stages - 1)):
-            respath = os.path.join(
-                self.expt.archive_path,
-                f'restart{stage_number:03d}'
-            )
-            for f_name in os.listdir(respath):
-                if os.path.isfile(os.path.join(respath, f_name)):
-                    f_orig = os.path.join(respath, f_name)
-                    f_link = os.path.join(self.work_init_path_local, f_name)
-                    # Check whether a given link already exists in the
-                    # manifest, so we don't write over a newer version of a
-                    # restart
-                    if f_link not in self.expt.manifest.manifests['restart']:
-                        self.expt.manifest.add_filepath(
-                            'restart',
-                            f_link,
-                            f_orig,
-                            self.copy_restarts
-                        )
-
     def set_model_pathnames(self):
         super(StagedCable, self).set_model_pathnames()
 
@@ -228,7 +195,7 @@ class StagedCable(Model):
         slot, then copy the configuration log to the working directory."""
 
         self.configuration_log['current_stage'] = \
-                self.configuration_log['queued_stages'].pop(0)
+            self.configuration_log['queued_stages'].pop(0)
 
         self._save_configuration_log()
         conf_log_p = os.path.join(self.control_path, 'configuration_log.yaml')
@@ -277,8 +244,7 @@ configuration log."""
             for f in os.listdir(prior_restart_path):
                 if f not in generated_restarts:
                     shutil.copy(os.path.join(prior_restart_path, f),
-                            self.work_restart_path)
-
+                                self.work_restart_path)
 
         # Move the files in work_path/restart first
         for f in os.listdir(self.work_restart_path):

--- a/test/models/test_staged_cable.py
+++ b/test/models/test_staged_cable.py
@@ -131,7 +131,7 @@ def test_staged_cable():
 
         # Since we've called the initialiser, we should be able to inspect the
         # stages immediately (through the configuration log)
-        expected_queued_stages = [
+        expected_q_stages = [
             'stage_2',
             'stage_3',
             'stage_4',
@@ -141,7 +141,7 @@ def test_staged_cable():
             'stage_6',
             'stage_6',
             'stage_7']
-        assert model.configuration_log['queued_stages'] == expected_queued_stages
+        assert model.configuration_log['queued_stages'] == expected_q_stages
         assert model.configuration_log['current_stage'] == 'stage_1'
 
         # Now check the namelist
@@ -165,7 +165,7 @@ def test_staged_cable():
 
         # Archive the stage and make sure the configuration log is correct
         model.archive()
-        expected_comp_stages = ['stage_1']
-        expected_current_stage = ''
-        assert model.configuration_log['completed_stages'] == expected_comp_stages
-        assert model.configuration_log['current_stage'] == expected_current_stage
+        ex_comp_stages = ['stage_1']
+        ex_curr_stage = ''
+        assert model.configuration_log['completed_stages'] == ex_comp_stages
+        assert model.configuration_log['current_stage'] == ex_curr_stage


### PR DESCRIPTION
## Improvements to ```staged_cable``` driver
I made some improvements to the ```staged_cable``` driver to hopefully make it more easily understandable, and more easily shareable. Summary of changes:

* Changed the way older restarts are handled. Previously, when setting up the current work directory, we would also run through older restart directories to retrieve any "unique" restarts (any with file name not matching a current restart). I've changed it so that at the end of a stage, we grab any "unique" restart from the previous restarts and copy it into the current restart work directory. Quick example: we've finished stage 1, which created restarts ```climate_rst.nc``` and ```cable_rst.nc```, which live in ```{archive}/restart000```. We run stage 2, which created restarts ```casa_rst.nc``` and ```cable_nc.nc```. We look back at ```{archive}/restart000```, see that there's no new version of ```climate_rst.nc```, so copy that to the work restart directory. The contents of the work restart directory are then moved to ```{archive}/restart001```. This makes restarts much more easily shareable.
* Changed the way the remaining number of runs are set. Previously, on initialisation of the model, the configuration log was read and the environment variable dictating the number of runs was modified. I realised I can set ```expt.n_runs``` instead of the environment variable, which is persistent. Now the configuration log work is only done where necessary in ```setup()``` and archive```, rather than every initialisation.

Coming with this is the removal of a fair bit of now-dead code.

Edit: One thing I forgot to mention is the handling of potentially new namelists. I would like it to be possible for people adding new science (or perhaps ```cable``` configurations I don't know about yet) to be able to use the tool. Unfortunately, I can't know a priori which namelists will be required in these instances. To get around this, I could simply set

```
self.optional_config_files = glob.glob('*/nml')
```

rather than the predefined list of namelists, but it feels like a bit of an abuse of process. Thoughts?