### PR TITLE
Fix log compression bug when no logs specified

### DIFF
--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -332,6 +332,9 @@ class Cice(Model):
         -------
         log_files: list of paths to model log files.
         """
+        if not self.logs_to_compress:
+            return
+
         log_files = []
         for filename in os.listdir(self.work_path):
             if re.match("|".join(self.logs_to_compress), filename):
@@ -343,6 +346,9 @@ class Cice(Model):
         Compress model log files into tarball.
         """
         log_files = self.get_log_files()
+        if not log_files:
+            return
+
         with tarfile.open(name=os.path.join(self.work_path, self.log_tar_name),
                           mode="w:gz") as tar:
             for file in log_files:

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -595,3 +595,37 @@ def test_log_compression(config, cice4_log_files, non_log_file,
             with tar.extractfile(entry) as open_entry:
                 file_contents = open_entry.read().decode("utf-8")
                 assert file_contents == cice4_log_files[entry_name]
+
+
+@pytest.mark.parametrize("config", [CONFIG_WITH_COMPRESSION],
+                         indirect=True)
+def test_log_compression_no_logs(config, cice4_log_files, non_log_file,
+                                 cice_nml   # Required by expt.__init__
+                                 ):
+    """
+    Check that log compression does nothing when no logfiles are
+    specifed.
+    """
+    with cd(ctrldir):
+        # Initialise laboratory and experiment
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    model = expt.models[0]
+
+    initial_workdir_contents = dir_contents_and_dates(expt_workdir)
+    # Specify no files for compression
+    model.logs_to_compress = []
+    # Function to test
+    model.compress_log_files()
+
+    final_workdir_contents = dir_contents_and_dates(expt_workdir)
+    assert final_workdir_contents == initial_workdir_contents
+
+
+def dir_contents_and_dates(dir_path):
+    """
+    Return a dict of filenames and their modification dates.
+    """
+    return {name: os.path.getmtime(os.path.join(dir_path, name))
+            for name in os.listdir(dir_path)}


### PR DESCRIPTION
This PR closes #541.

Regex patterns for finding log files previously broke when no log files were specified, as done for CICE5. Instead of matching no files, the `get_log_files()` method would match every file in the model work directory.

This PR adds checks at the start of the `get_log_files()` and `compress_log_files()` methods, causing them to exit early when no log files are specified, and when no log files are found.

It also adds a unit test `test_log_compression_no_logs()` to `test_cice.py` which makes sure that the compression method does nothing when no log files are specified.

With these changes, OM2 runs without any issues.