### PR TITLE
Fix job.yaml qstat call

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -21,7 +21,7 @@ import payu
 import payu.envmod as envmod
 from payu.fsops import is_conda
 from payu.models import index as supported_models
-from payu.schedulers import index as scheduler_index
+from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
 import payu.subcommands
 
 # Default configuration
@@ -164,7 +164,7 @@ def submit_job(script, config, vars=None):
     """Submit a userscript the scheduler."""
 
     # TODO: Temporary stub to replicate the old approach
-    sched_name = config.get('scheduler', 'pbs')
+    sched_name = config.get('scheduler', DEFAULT_SCHEDULER_CONFIG)
     sched_type = scheduler_index[sched_name]
     sched = sched_type()
     cmd = sched.submit(script, config, vars)

--- a/payu/schedulers/__init__.py
+++ b/payu/schedulers/__init__.py
@@ -7,3 +7,5 @@ index = {
     'pbs': PBS,
     'slurm': Slurm,
 }
+
+DEFAULT_SCHEDULER_CONFIG = 'pbs'

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -202,9 +202,8 @@ def pbs_env_init():
 # even if still fails return None
 @retry(stop=stop_after_delay(10), retry_error_callback=lambda a: None)
 def get_qstat_info(qflag, header, projects=None, users=None):
-
-    qstat = os.path.join(os.environ['PBS_EXEC'], 'bin', 'qstat')
-    cmd = '{} {}'.format(qstat, qflag)
+    # qstat command seems to be accessible from the path on PBS jobs
+    cmd = f'qstat {qflag}'
 
     cmd = shlex.split(cmd)
     output = subprocess.check_output(cmd)

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -10,6 +10,7 @@ import re
 import sys
 import shlex
 import subprocess
+from typing import Any, Dict, Optional
 
 import payu.envmod as envmod
 from payu.fsops import check_exe_path
@@ -137,43 +138,53 @@ class PBS(Scheduler):
 
         return cmd
 
+    def get_job_id(self, short: bool = True) -> Optional[str]:
+        """Get PBS job ID
 
-# TODO: These support functions can probably be integrated into the class
+        Parameters
+        ----------
+        short: bool, default True
+            Return shortened form of the job ID
 
-def get_job_id(short=True):
-    """
-    Return PBS job id
-    """
+        Returns
+        ----------
+        Optional[str]
+            Job id if defined, None otherwise
+        """
 
-    jobid = os.environ.get('PBS_JOBID', '')
+        jobid = os.environ.get('PBS_JOBID', '')
 
-    if short:
-        # Strip off '.rman2'
-        jobid = jobid.split('.')[0]
+        if short:
+            # Strip off '.rman2'
+            jobid = jobid.split('.')[0]
 
-    return(jobid)
+        return(jobid)
 
+    def get_job_info(self) -> Optional[Dict[str, Any]]:
+        """
+        Get information about the job from the PBS server
 
-def get_job_info():
-    """
-    Get information about the job from the PBS server
-    """
-    jobid = get_job_id()
+        Returns
+        ----------
+        Optional[Dict[str, Any]]
+            Dictionary of information extracted from qstat output
+        """
+        jobid = self.get_job_id()
 
-    info = None
+        info = None
 
-    if not jobid == '':
-        info = get_qstat_info('-ft {0}'.format(jobid), 'Job Id:')
+        if not jobid == '':
+            info = get_qstat_info('-ft {0}'.format(jobid), 'Job Id:')
 
-    if info is not None:
-        # Select the dict for this job (there should only be one
-        # entry in any case)
-        info = info['Job Id: {}'.format(jobid)]
+        if info is not None:
+            # Select the dict for this job (there should only be one
+            # entry in any case)
+            info = info['Job Id: {}'.format(jobid)]
 
-        # Add the jobid to the dict and then return
-        info['Job_ID'] = jobid
+            # Add the jobid to the dict and then return
+            info['Job_ID'] = jobid
 
-    return info
+        return info
 
 
 def pbs_env_init():

--- a/payu/schedulers/scheduler.py
+++ b/payu/schedulers/scheduler.py
@@ -8,6 +8,9 @@
 # expanded to provide greater functionality in the future.
 
 
+from typing import Any, Dict, Optional
+
+
 class Scheduler(object):
     """Abstract scheduler class."""
 
@@ -17,3 +20,28 @@ class Scheduler(object):
 
     def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None):
         raise NotImplementedError
+
+    def get_job_info(self) -> Optional[Dict[str, Any]]:
+        """Get information about the currently running job
+
+        Returns
+        ----------
+        Optional[Dict[str, Any]]
+            Dictionary of information queried from the scheduler
+        """
+        pass
+
+    def get_job_id(self, short: bool = True) -> Optional[str]:
+        """Get scheduler-specific job ID
+
+        Parameters
+        ----------
+        short: bool, default True
+            Return shortened form of the job ID
+
+        Returns
+        ----------
+        Optional[str]
+            Job id if defined, None otherwise
+        """
+        pass


### PR DESCRIPTION
Closes #545 

This fixes the PBS scheduler `get_qstat_info()` method which was always failing due to `PBS_EXEC` no longer being defined in the environment. Because it is wrapped in a  `tenancity` retry, it would retry the command for 10s. I've changed  to call `qstat` command directly as this seems available on the `$PATH` in PBS jobs. This now results in PBS specific job information being added to the `job.yaml` in the output archive directory.

I've also done a small change to move `get_job_info()` and `get_job_id()` to scheduler class methods - that are extended in the PBS scheduler subclass. This to avoid importing `scheduler.pbs` in `experiment.py`.

Tested that the `job.yaml` populated with PBS run info when running a small [MOM6 config](https://github.com/aidanheerdegen/mom6_double_gyre). Also tested it didn't add PBS specific info when running on the model on the login node using `payu-run`.
