### PR TITLE
Remove setting restart time in access-om3 driver

### DIFF
--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -159,13 +159,7 @@ class CesmCmeps(Model):
 
         # run checks on nuopc.runfig
         self._setup_checks()
-
-        # Ensure that restarts will be written at the end of each run
-        stop_n = self.runconfig.get("CLOCK_attributes", "stop_n")
-        stop_option = self.runconfig.get("CLOCK_attributes", "stop_option")
-        self.runconfig.set("CLOCK_attributes", "restart_n", stop_n)
-        self.runconfig.set("CLOCK_attributes", "restart_option", stop_option)
-        
+       
         mkdir_p(os.path.join(self.work_path, 'log'))
         mkdir_p(os.path.join(self.work_path, 'timing'))
 


### PR DESCRIPTION
Closes #555 

This lets the user set the restart time as they desire!