### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,10 +31,6 @@ jobs:
       - run: |
           python3 -m pip install --upgrade build && python3 -m build
 
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./dist
-
   conda-build:
     name: Conda Build
     runs-on: ubuntu-latest
@@ -77,11 +73,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip' # caching pip dependencies
 
-      - name: Install dependencies
-        run: pip install -r test/requirements_test.txt
-
-      - name: Install payu
-        run: pip install .
+      - name: Install payu and test dependencies
+        run: python3 -m pip install '.[test]'
 
       - name: Check payu installed correctly
         run: payu list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ dependencies = [
 test = [
     "pytest",
     "pylint",
-    "Sphinx"
+    "Sphinx",
+    "pytest-cov",
+    "mnctools"
 ]
 mitgcm = ["mnctools>=0.2"]
 

--- a/test/requirements_test.txt
+++ b/test/requirements_test.txt
@@ -1,9 +1,0 @@
-coverage
-coveralls
-pytest>=4.6; python_version>"2.7"
-pylint
-mnctools
-Sphinx
-pytest-cov
-numpy>=1.16.0
-cftime


### PR DESCRIPTION
- Removed upload artefact step in Build-PyPA job as its not used anywhere
- Try installing test dependencies using optional test dependencies in `pyproject.toml` and removing `test/requirements_test.txt`

Closes #559