### PR TITLE
Add restart pruning to OM3 driver

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -217,9 +217,9 @@ configuration.
    For example, ``restart_freq: 10YS`` would save earliest restart of the year,
    10 years from the last permanently archived restart's datetime.
 
-   Please note that currently, only ACCESS-OM2, MOM5 and MOM6 models support
-   date-based restart frequency, as it depends on the payu model driver being
-   able to parse restarts files for a datetime.
+   Please note that currently, only ACCESS-ESM1.5, ACCESS-OM2, ACCESS-OM3, MOM5 
+   and MOM6 models support  date-based restart frequency, as it depends on the payu 
+   model driver being able to parse restarts files for a datetime.
 
 ``restart_history``
     Specifies how many of the most recent restart files to retain regardless of 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -218,7 +218,7 @@ configuration.
    10 years from the last permanently archived restart's datetime.
 
    Please note that currently, only ACCESS-ESM1.5, ACCESS-OM2, ACCESS-OM3, MOM5 
-   , MOM6 and UM7 models support  date-based restart frequency, as it depends on the payu 
+   , MOM6 and UM7 models support date-based restart frequency, as it depends on the payu 
    model driver being able to parse restarts files for a datetime.
 
 ``restart_history``

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -218,7 +218,7 @@ configuration.
    10 years from the last permanently archived restart's datetime.
 
    Please note that currently, only ACCESS-ESM1.5, ACCESS-OM2, ACCESS-OM3, MOM5 
-   and MOM6 models support  date-based restart frequency, as it depends on the payu 
+   , MOM6 and UM7 models support  date-based restart frequency, as it depends on the payu 
    model driver being able to parse restarts files for a datetime.
 
 ``restart_history``

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -362,6 +362,7 @@ class CesmCmeps(Model):
         seconds = int(seconds)
         hour = seconds // 3600 ; min = (seconds % 3600) // 60 ; sec = seconds % 60
 
+        # TODO: change to self.control_path if https://github.com/payu-org/payu/issues/509 is implemented
         self.get_runconfig(self.expt.control_path)
         run_calendar = self.runconfig.get("CLOCK_attributes", "calendar")
 

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -24,7 +24,9 @@ from payu.models.mom6 import mom6_add_parameter_files
 NUOPC_CONFIG = "nuopc.runconfig"
 NUOPC_RUNSEQ = "nuopc.runseq"
 
-#mapping of runconfig to cftime calendars:
+# mapping of runconfig to cftime calendars:
+# these match the supported calendars in CMEPS
+# https://github.com/ESCOMP/CMEPS/blob/bc29792d76c16911046dbbfcfc7f4c3ae89a6f00/cesm/driver/ensemble_driver.F90#L196
 CFTIME_CALENDARS = {
     "NO_LEAP" : "noleap" ,
     "GREGORIAN" : "proleptic_gregorian"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -355,7 +355,7 @@ class CesmCmeps(Model):
         date_str = lines[0].split('.')[3]
         year, month, day, hms = date_str.split('-')
 
-        self.get_runconfig(self.expt.work_path)
+        self.get_runconfig(self.expt.control_path)
         run_calendar = self.runconfig.get("CLOCK_attributes", "calendar")
 
         cftime_calendars = {

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -358,6 +358,7 @@ class CesmCmeps(Model):
         date_str = lines[0].split('.')[3]
         year, month, day, seconds = date_str.split('-')
 
+        # convert seconds into hours, mins, seconds
         seconds = int(seconds)
         hour = seconds // 3600 ; min = (seconds % 3600) // 60 ; sec = seconds % 60
 
@@ -366,11 +367,11 @@ class CesmCmeps(Model):
 
         try:
             cf_cal = CFTIME_CALENDARS[run_calendar]
-        except KeyError:
-            warn(
-                f"Unsupported calendar for restart pruning: {run_calendar},"
-                f" try {' or '.join(CFTIME_CALENDARS.keys())}"
-            )
+        except KeyError as e:
+            raise RuntimeError(
+                f"Unsupported calendar for restart pruning: {run_calendar}, in {NUOPC_CONFIG}."
+                f" Try {' or '.join(CFTIME_CALENDARS.keys())}"
+            ) from e
             return False
 
         return cftime.datetime(

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -414,8 +414,8 @@ def test_get_restart_datetime_badcal(start_dt, calendar, cmeps_calendar, expecte
         print(model.runconfig.get("CLOCK_attributes","calendar"))
 
     restart_path = list_expt_archive_dirs()[0]
-    with pytest.warns(
-            Warning, match="Unsupported calendar"
+    with pytest.raises(
+            RuntimeError, match="Unsupported calendar"
         ):
         expt.model.get_restart_datetime(restart_path)
     


### PR DESCRIPTION
Closes #506 

This adds support for date based restart pruning to the access-om3 driver.

This uses the payu framework for restart pruning, the only addition is a `get_restart_datetime()`
 function with the a access-om3 class.


