### PR TITLE
Commit MOM_parameter_doc.* into docs folder of config

### DIFF
--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -102,7 +102,7 @@ class GitRepository:
         untracked_files = [Path(self.repo_path) / path
                            for path in self.repo.untracked_files]
         for path in paths_to_commit:
-            if self.repo.git.diff(None, path) or path in untracked_files:
+            if self.repo.git.diff(None, path) or Path(path) in untracked_files:
                 self.repo.index.add([path])
                 changes = True
 

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -33,7 +33,7 @@ component_info = {
         "optional_config_files": [
             "field_table",
             "data_table",
-        ]
+        ],
     },
     "cice": {
         "config_files": ["ice_in"],

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -18,7 +18,7 @@ from warnings import warn
 from payu.fsops import mkdir_p, make_symlink
 from payu.models.model import Model
 from payu.models.fms import fms_collate
-from payu.models.mom6 import mom6_add_parameter_files
+from payu.models.mom6 import mom6_add_parameter_files, mom6_save_docs_files
 
 NUOPC_CONFIG = "nuopc.runconfig"
 NUOPC_RUNSEQ = "nuopc.runseq"
@@ -33,7 +33,7 @@ component_info = {
         "optional_config_files": [
             "field_table",
             "data_table",
-        ],
+        ]
     },
     "cice": {
         "config_files": ["ice_in"],
@@ -263,6 +263,11 @@ class CesmCmeps(Model):
         return True
 
     def archive(self):
+
+        # Move any the MOM_parameter_docs output back into the control repo and commit it for documentation
+        if 'mom' in self.components.values() :
+            mom6_save_docs_files(self)
+
         super().archive()
 
         mkdir_p(self.restart_path)
@@ -336,14 +341,21 @@ class AccessOm3(CesmCmeps):
     def get_components(self):
         super().get_components()
 
-        assert self.components["atm"] == "datm", (
-            "Access-OM3 comprises a data atmosphere model, but the atmospheric model in nuopc.runconfig is set "
-            f"to {self.components['atm']}."
-        )
-        assert self.components["rof"] == "drof", (
-            "Access-OM3 comprises a data runoff model, but the runoff model in nuopc.runconfig is set "
-            f"to {self.components['rof']}."
-        )
+        if (self.components["atm"] != "datm") :
+            raise RuntimeError(
+                "Access-OM3 comprises a data atmosphere model, but the atmospheric model in nuopc.runconfig is set "
+                f"to {self.components['atm']}."
+            )
+        if (self.components["rof"] != "drof") :
+            raise RuntimeError(
+                "Access-OM3 comprises a data runoff model, but the runoff model in nuopc.runconfig is set "
+                f"to {self.components['rof']}."
+            )
+        
+    def archive(self):
+        
+
+        super().archive()
 
 
 class Runconfig:

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -402,11 +402,6 @@ class AccessOm3(CesmCmeps):
                 "Access-OM3 comprises a data runoff model, but the runoff model in nuopc.runconfig is set "
                 f"to {self.components['rof']}."
             )
-        
-    def archive(self):
-        
-
-        super().archive()
 
 
 class Runconfig:

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -59,7 +59,7 @@ def mom6_save_docs_files(model):
         except Exception as e:
             warn(e)
 
-    if model.expt.config.get('runlog', True): #if runlog true, default to true
+    if model.expt.runlog.enabled: #if runlog true, default to true
         # commit new files to the control dir
         repo = GitRepository(repo_path = model.control_path)
 

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -23,7 +23,7 @@ from payu.models.fms import Fms
 from payu.models.mom_mixin import MomMixin
 from payu.git_utils import GitRepository
 
-MOM6_DOCS = "MOM_parameter_doc.*"
+MOM6_DOCS = ["MOM_parameter_doc.*","available_diags.*"]
 
 def mom6_add_parameter_files(model):
     """Add parameter files defined in input.nml to model configuration files.
@@ -53,19 +53,25 @@ def mom6_save_docs_files(model):
     mkdir_p(docs_folder)
 
     # copy everything that matches MOM_parameter_doc.* to the control dir
-    for f in glob(os.path.join(model.work_path, MOM6_DOCS)):
-        try:
-            shutil.copy(f, docs_folder)
-        except Exception as e:
-            warn(e)
+    for pattern in MOM6_DOCS:
+        for f in glob(os.path.join(model.work_path, pattern)):
+            try:
+                shutil.copy(f, docs_folder)
+            except Exception as e:
+                warn(e)
 
     if model.expt.runlog.enabled: #if runlog true, default to true
         # commit new files to the control dir
         repo = GitRepository(repo_path = model.control_path)
 
+        paths_to_commit = []
+        for pattern in MOM6_DOCS:
+            for i in glob(os.path.join(docs_folder, pattern)):
+                paths_to_commit.append(i)
+
         repo.commit(
             commit_message = "payu archive: documentation of MOM6 run-time configuration" ,
-            paths_to_commit = glob(os.path.join(docs_folder, MOM6_DOCS))
+            paths_to_commit = paths_to_commit
         )
 
 class Mom6(MomMixin, Fms):

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -67,7 +67,7 @@ def mom6_save_docs_files(model):
 
         repo.commit(
             commit_message = "payu archive: documentation of MOM6 run-time configuration" ,
-            paths_to_commit = glob(os.path.join(docs_folder,MOM6_DOCS))
+            paths_to_commit = glob(os.path.join(docs_folder, MOM6_DOCS))
         )
 
 class Mom6(MomMixin, Fms):

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -53,7 +53,7 @@ def mom6_save_docs_files(model):
     mkdir_p(docs_folder)
 
     # copy everything that matches MOM_parameter_doc.* to the control dir
-    for f in glob(os.path.join(model.work_path,MOM6_DOCS)):
+    for f in glob(os.path.join(model.work_path, MOM6_DOCS)):
         try:
             shutil.copy(f, docs_folder)
         except Exception as e:

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -13,11 +13,17 @@ import os
 
 # Extensions
 import f90nml
+import shutil
+from warnings import warn
+from glob import glob
 
 # Local
+from payu.fsops import mkdir_p
 from payu.models.fms import Fms
 from payu.models.mom_mixin import MomMixin
+from payu.git_utils import GitRepository
 
+MOM6_DOCS = "MOM_parameter_doc.*"
 
 def mom6_add_parameter_files(model):
     """Add parameter files defined in input.nml to model configuration files.
@@ -41,6 +47,28 @@ def mom6_add_parameter_files(model):
         else:
             model.config_files.extend(filenames)
 
+def mom6_save_docs_files(model):
+    """Add docs files created as MOM output back to the configuration repository"""
+    docs_folder = os.path.join(model.control_path, 'docs')
+    mkdir_p(docs_folder)
+
+    # copy everything that matches MOM_parameter_doc.* to the control dir
+    for f in glob(os.path.join(model.work_path,MOM6_DOCS)):
+        try:
+            shutil.copy(f, docs_folder)
+        except Exception as e:
+            warn(e)
+
+    if model.config.get("runlog", True): #if runlog true, default to true
+        # commit new files to the control dir
+        repo = GitRepository(repo_path = model.control_path)
+
+        i = repo.get_hash()
+
+        repo.commit(
+            commit_message = "payu archive: documentation of MOM6 run-time configuration" ,
+            paths_to_commit = glob(os.path.join(docs_folder,MOM6_DOCS))
+        )
 
 class Mom6(MomMixin, Fms):
     """Interface to GFDL's MOM6 ocean model."""
@@ -93,3 +121,10 @@ class Mom6(MomMixin, Fms):
             input_nml['SIS_input_nml']['input_filename'] = input_type
 
         f90nml.write(input_nml, input_fpath, force=True)
+
+    def archive(self):
+        # Move any the MOM_parameter_docs output back into the control repo 
+        # and commit it for documentation
+        mom6_save_docs_files(self)
+
+        super().archive()

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -59,11 +59,9 @@ def mom6_save_docs_files(model):
         except Exception as e:
             warn(e)
 
-    if model.config.get("runlog", True): #if runlog true, default to true
+    if model.expt.config.get('runlog', True): #if runlog true, default to true
         # commit new files to the control dir
         repo = GitRepository(repo_path = model.control_path)
-
-        i = repo.get_hash()
 
         repo.commit(
             commit_message = "payu archive: documentation of MOM6 run-time configuration" ,

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -48,7 +48,7 @@ def mom6_add_parameter_files(model):
             model.config_files.extend(filenames)
 
 def mom6_save_docs_files(model):
-    """Add docs files created as MOM output back to the configuration repository"""
+    """Add docs files created as MOM output back to the control directory"""
     docs_folder = os.path.join(model.control_path, 'docs')
     mkdir_p(docs_folder)
 

--- a/test/common.py
+++ b/test/common.py
@@ -7,8 +7,6 @@ import shutil
 
 import yaml
 
-import payu
-
 # Namespace clash if import setup_cmd.runcmd as setup. For
 # consistency use payu_ prefix for all commands
 from payu.subcommands.init_cmd import runcmd as payu_init

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -420,37 +420,3 @@ def test_get_restart_datetime_badcal(start_dt, calendar, cmeps_calendar, expecte
     
     teardown_cmeps_config()
     remove_expt_archive_dirs(type='restart')
-
-
-# During archiving, we use model.expt.runlog.enabled to determine if the runlog is set
-# Confirm all permutations set/don't set this.
-@pytest.mark.parametrize(
-        "runlog, enabled", 
-        [
-            (True, True), 
-            (False, False), 
-            ({"enable":True}, True),
-            ({"enable":False}, False)
-         ]
-)
-@pytest.mark.filterwarnings("error")
-def test_setup_runlog(runlog, enabled):
-    # set runlog differet to cmeps_config():
-    config = copy.deepcopy(config_orig)
-    config['model'] = MODEL
-    config['ncpus'] = 1
-    config['runlog'] = runlog
-
-    write_config(config)
-
-    with open(os.path.join(ctrldir, 'nuopc.runconfig'), "w") as f:
-        f.close()
-
-    with cd(ctrldir):
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-        model = expt.models[0]
-
-    assert model.expt.runlog.enabled == enabled
-
-    teardown_cmeps_config()

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -1,7 +1,6 @@
 import copy
 import os
 import shutil
-from pathlib import Path
 import pytest
 
 import payu
@@ -422,3 +421,36 @@ def test_get_restart_datetime_badcal(start_dt, calendar, cmeps_calendar, expecte
     teardown_cmeps_config()
     remove_expt_archive_dirs(type='restart')
 
+
+# During archiving, we use model.expt.runlog.enabled to determine if the runlog is set
+# Confirm all permutations set/don't set this.
+@pytest.mark.parametrize(
+        "runlog, enabled", 
+        [
+            (True, True), 
+            (False, False), 
+            ({"enable":True}, True),
+            ({"enable":False}, False)
+         ]
+)
+@pytest.mark.filterwarnings("error")
+def test_setup_runlog(runlog, enabled):
+    # set runlog differet to cmeps_config():
+    config = copy.deepcopy(config_orig)
+    config['model'] = MODEL
+    config['ncpus'] = 1
+    config['runlog'] = runlog
+
+    write_config(config)
+
+    with open(os.path.join(ctrldir, 'nuopc.runconfig'), "w") as f:
+        f.close()
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+    assert model.expt.runlog.enabled == enabled
+
+    teardown_cmeps_config()

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -152,7 +152,7 @@ def mom_parameter_doc(request):
 
 @pytest.mark.parametrize(
         "mom_parameter_doc", 
-        [["MOM_parameter_doc.all","MOM_parameter_doc.debug","MOM_parameter_docs.debug"]],
+        [["MOM_parameter_doc.all","MOM_parameter_doc.debug","MOM_parameter_docs.debug", "available_diags.000000"]],
         indirect=True
 )
 @pytest.mark.filterwarnings("error")
@@ -167,7 +167,7 @@ def test_mom6_save_doc_files(mom_parameter_doc):
     payu.models.mom6.mom6_save_docs_files(mom_parameter_doc)
 
     # Check MOM_parameter_doc.* are added to control_path
-    for file in ["MOM_parameter_doc.all","MOM_parameter_doc.debug"]:
+    for file in ["MOM_parameter_doc.all","MOM_parameter_doc.debug", "available_diags.000000"]:
         filename = os.path.join(mom_parameter_doc.control_path, "docs", file)
         assert os.path.isfile(filename)==True , "Payu did not move MOM_parameter_doc.* files into docs folder"
         os.remove(filename)

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -159,7 +159,7 @@ def test_mom6_save_doc_files(mom_parameter_doc):
     # and doesn't move files that don't match that name
 
     # don't try and commit during tests
-    mom_parameter_doc.config["runlog"] = False
+    mom_parameter_doc.expt.config["runlog"] = False
 
     # Function to test
     payu.models.mom6.mom6_save_docs_files(mom_parameter_doc)
@@ -200,7 +200,34 @@ def test_mom6_commit_doc_files(mom_parameter_doc):
         os.remove(filename)
     
     assert repo.head.commit != initial_commit,  "Payu did not commit MOM_parameter_doc.layout"
+
+@pytest.mark.parametrize(
+        "mom_parameter_doc", 
+        [["MOM_parameter_doc.layout"]],
+        indirect=True
+)
+@pytest.mark.filterwarnings("error")
+def test_mom6_not_commit_doc_files(mom_parameter_doc):
+    # Confirm that mom6_save_doc_files doesn't commits files if runlog is False
+
+    mom_parameter_doc.expt.config["runlog"] = False
+
+    #init a git repo
+    repo = create_new_repo(Path(mom_parameter_doc.control_path))
+    initial_commit = repo.head.commit
+
+    # Function to test
+    payu.models.mom6.mom6_save_docs_files(mom_parameter_doc)
+
+    # Check files are added to control_path
+    for file in ["MOM_parameter_doc.layout"]:
+        filename = os.path.join(mom_parameter_doc.control_path, "docs", file)
+        assert os.path.isfile(filename)==True , "docs/MOM_parameter_doc.* do not exist"
+        os.remove(filename)
     
+    assert repo.head.commit == initial_commit,  "Payu did not commit MOM_parameter_doc.layout"
+    
+
 
 def test_setup():
     input_nml = {

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -245,7 +245,7 @@ def test_mom6_not_commit_doc_files(mom_parameter_doc):
         assert os.path.isfile(filename)==True , "docs/MOM_parameter_doc.* do not exist"
         os.remove(filename)
     
-    assert repo.head.commit == initial_commit,  "Payu did not commit MOM_parameter_doc.layout"
+    assert repo.head.commit == initial_commit,  "Payu incorrectly committed MOM_parameter_docs.layout"
 
 
 def test_setup():

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -1,7 +1,6 @@
-import copy
 import os
 import shutil
-import git
+from pathlib import Path
 
 import pytest
 import f90nml
@@ -12,6 +11,7 @@ from test.common import cd
 from test.common import tmpdir, ctrldir, labdir, expt_workdir, ctrldir_basename
 from test.common import write_config, write_metadata
 from test.common import make_random_file, make_inputs, make_exe
+from test.test_git_utils import create_new_repo
 
 verbose = True
 
@@ -184,13 +184,10 @@ def test_mom6_save_doc_files(mom_parameter_doc):
 @pytest.mark.filterwarnings("error")
 def test_mom6_commit_doc_files(mom_parameter_doc):
     # Confirm that mom6_save_doc_files commits files named MOM_parameter_doc.* into the docs folder of a config
-    
-    #commit during tests
-    mom_parameter_doc.config["runlog"] = True
+    # default is to commit during runs
 
-    #init a git repo and initial commit
-    repo = git.Repo.init(mom_parameter_doc.control_path)
-    repo.git.commit("-m", "Initial commit", "--allow-empty")
+    #init a git repo
+    repo = create_new_repo(Path(mom_parameter_doc.control_path))
     initial_commit = repo.head.commit
 
     # Function to test

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -136,16 +136,18 @@ def mom_parameter_doc(request):
         model = expt.models[0]
 
    # Create docs
-    for file in request.param:
-        filename = os.path.join(model.work_path, file)
-        make_random_file(filename, 8)
+    if (request.param != None) :
+        for file in request.param:
+            filename = os.path.join(model.work_path, file)
+            make_random_file(filename, 8)
 
     yield model
 
     # and Tidy up 
-    for file in request.param:
-        filename = os.path.join(model.work_path, file)
-        os.remove(filename)
+    if (request.param != None) :
+        for file in request.param:
+            filename = os.path.join(model.work_path, file)
+            os.remove(filename)
 
 
 @pytest.mark.parametrize(
@@ -246,6 +248,24 @@ def test_mom6_not_commit_doc_files(mom_parameter_doc):
         os.remove(filename)
     
     assert repo.head.commit == initial_commit,  "Payu incorrectly committed MOM_parameter_docs.layout"
+
+@pytest.mark.parametrize(
+        "mom_parameter_doc", 
+        [None],
+        indirect=True
+)
+@pytest.mark.filterwarnings("error")
+def test_mom6_not_commit_doc_files(mom_parameter_doc):
+    # Confirm that mom6_save_doc_files doesn't commits files if runlog is False
+
+    #init a git repo
+    repo = create_new_repo(Path(mom_parameter_doc.control_path))
+    initial_commit = repo.head.commit
+
+    # Function to test
+    payu.models.mom6.mom6_save_docs_files(mom_parameter_doc)
+   
+    assert repo.head.commit == initial_commit,  "Payu incorrectly committed with no docs to add"
 
 
 def test_setup():

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -201,6 +201,27 @@ def test_mom6_commit_doc_files(mom_parameter_doc):
     
     assert repo.head.commit != initial_commit,  "Payu did not commit MOM_parameter_doc.layout"
 
+    # Confirm it doesn't commit twice if unchanged
+    initial_commit = repo.head.commit
+    payu.models.mom6.mom6_save_docs_files(mom_parameter_doc)
+
+    assert repo.head.commit == initial_commit,  "Payu commit MOM_parameter_doc incorrectly"
+
+    # Confirm it does commit twice correctly
+    file = "MOM_parameter_doc.all"
+    filename = os.path.join(mom_parameter_doc.work_path, file)
+    make_random_file(filename, 8)
+
+    payu.models.mom6.mom6_save_docs_files(mom_parameter_doc)
+
+    assert repo.head.commit != initial_commit,  "Payu did not commit MOM_parameter_doc.all"
+
+    # and Tidy up 
+    filename = os.path.join(mom_parameter_doc.work_path, file)
+    os.remove(filename)
+
+
+
 @pytest.mark.parametrize(
         "mom_parameter_doc", 
         [["MOM_parameter_doc.layout"]],
@@ -226,6 +247,8 @@ def test_mom6_not_commit_doc_files(mom_parameter_doc):
         os.remove(filename)
     
     assert repo.head.commit == initial_commit,  "Payu did not commit MOM_parameter_doc.layout"
+
+
     
 
 

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -159,7 +159,7 @@ def test_mom6_save_doc_files(mom_parameter_doc):
     # and doesn't move files that don't match that name
 
     # don't try and commit during tests
-    mom_parameter_doc.expt.config["runlog"] = False
+    mom_parameter_doc.expt.runlog.enabled = False
 
     # Function to test
     payu.models.mom6.mom6_save_docs_files(mom_parameter_doc)
@@ -184,7 +184,7 @@ def test_mom6_save_doc_files(mom_parameter_doc):
 @pytest.mark.filterwarnings("error")
 def test_mom6_commit_doc_files(mom_parameter_doc):
     # Confirm that mom6_save_doc_files commits files named MOM_parameter_doc.* into the docs folder of a config
-    # default is to commit during runs
+    mom_parameter_doc.expt.runlog.enabled = True
 
     #init a git repo
     repo = create_new_repo(Path(mom_parameter_doc.control_path))
@@ -221,7 +221,6 @@ def test_mom6_commit_doc_files(mom_parameter_doc):
     os.remove(filename)
 
 
-
 @pytest.mark.parametrize(
         "mom_parameter_doc", 
         [["MOM_parameter_doc.layout"]],
@@ -231,7 +230,7 @@ def test_mom6_commit_doc_files(mom_parameter_doc):
 def test_mom6_not_commit_doc_files(mom_parameter_doc):
     # Confirm that mom6_save_doc_files doesn't commits files if runlog is False
 
-    mom_parameter_doc.expt.config["runlog"] = False
+    mom_parameter_doc.expt.runlog.enabled = False
 
     #init a git repo
     repo = create_new_repo(Path(mom_parameter_doc.control_path))
@@ -247,9 +246,6 @@ def test_mom6_not_commit_doc_files(mom_parameter_doc):
         os.remove(filename)
     
     assert repo.head.commit == initial_commit,  "Payu did not commit MOM_parameter_doc.layout"
-
-
-    
 
 
 def test_setup():

--- a/test/test_git_utils.py
+++ b/test/test_git_utils.py
@@ -27,11 +27,23 @@ def setup_and_teardown():
         print(e)
 
 
-def create_new_repo(repo_path):
-    """Helper function to initialise a repo and create first commit"""
+def create_new_repo(repo_path, set_user=False):
+    """Helper function to initialise a repo and create first commit
+    Set the git username if required"""
     repo = git.Repo.init(repo_path)
     init_file = repo_path / "init.txt"
     add_file_and_commit(repo, init_file)
+
+    if set_user :
+        try:
+            # Set config that is local to temporary test repository only
+            subprocess.run('git config user.name "TestUserName"',
+                        check=True,
+                        shell=True,
+                        cwd=repo_path)
+            print("User name set successfully.")
+        except subprocess.CalledProcessError as e:
+            print(f"Error setting user name: {e}")
     return repo
 
 
@@ -73,17 +85,8 @@ def test_get_git_user_info_no_config_set():
 
 def test_get_git_user_info_config_set():
     repo_path = tmpdir / "test_repo"
-    create_new_repo(repo_path)
-    try:
-        # Set config that is local to temporary test repository only
-        subprocess.run('git config user.name "TestUserName"',
-                       check=True,
-                       shell=True,
-                       cwd=repo_path)
-        print("User name set successfully.")
-    except subprocess.CalledProcessError as e:
-        print(f"Error setting user name: {e}")
-
+    create_new_repo(repo_path, set_user = True)
+    
     repo = GitRepository(repo_path)
     value = repo.get_user_info('name')
 

--- a/test/test_git_utils.py
+++ b/test/test_git_utils.py
@@ -27,23 +27,11 @@ def setup_and_teardown():
         print(e)
 
 
-def create_new_repo(repo_path, set_user=False):
-    """Helper function to initialise a repo and create first commit
-    Set the git username if required"""
+def create_new_repo(repo_path):
+    """Helper function to initialise a repo and create first commit"""
     repo = git.Repo.init(repo_path)
     init_file = repo_path / "init.txt"
     add_file_and_commit(repo, init_file)
-
-    if set_user :
-        try:
-            # Set config that is local to temporary test repository only
-            subprocess.run('git config user.name "TestUserName"',
-                        check=True,
-                        shell=True,
-                        cwd=repo_path)
-            print("User name set successfully.")
-        except subprocess.CalledProcessError as e:
-            print(f"Error setting user name: {e}")
     return repo
 
 
@@ -85,8 +73,17 @@ def test_get_git_user_info_no_config_set():
 
 def test_get_git_user_info_config_set():
     repo_path = tmpdir / "test_repo"
-    create_new_repo(repo_path, set_user = True)
-    
+    create_new_repo(repo_path)
+    try:
+        # Set config that is local to temporary test repository only
+        subprocess.run('git config user.name "TestUserName"',
+                       check=True,
+                       shell=True,
+                       cwd=repo_path)
+        print("User name set successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error setting user name: {e}")
+
     repo = GitRepository(repo_path)
     value = repo.get_user_info('name')
 

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -257,3 +257,36 @@ def test_check_payu_version_configured_invalid_version(minimum_version):
 
             with pytest.raises(ValueError):
                 expt.check_payu_version()
+
+
+
+# model.expt.runlog.enabled is used in code for writing runlog
+# it can be set as runlog:true or runlog:enable:true in config.yaml
+@pytest.mark.parametrize(
+        "runlog, enabled", 
+        [   
+            (None, True),
+            (True, True), 
+            (False, False), 
+            ({"enable":True}, True),
+            ({"enable":False}, False)
+         ]
+)
+@pytest.mark.filterwarnings("error")
+def test_runlog_enable(runlog, enabled):
+    config = copy.deepcopy(config_orig)
+    if runlog == None:
+        config.pop('runlog')
+    else:
+        config['runlog'] = runlog
+
+    write_config(config)
+
+    make_inputs()
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+    assert model.expt.runlog.enabled == enabled

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -265,7 +265,7 @@ def test_check_payu_version_configured_invalid_version(minimum_version):
 @pytest.mark.parametrize(
         "runlog, enabled", 
         [   
-            (None, True),
+            (None, True), #default is True
             (True, True), 
             (False, False), 
             ({"enable":True}, True),
@@ -276,7 +276,7 @@ def test_check_payu_version_configured_invalid_version(minimum_version):
 def test_runlog_enable(runlog, enabled):
     config = copy.deepcopy(config_orig)
     if runlog == None:
-        config.pop('runlog')
+        config.pop('runlog') #remove from config for default case
     else:
         config['runlog'] = runlog
 


### PR DESCRIPTION
Closes #565 

When using the access-om3 driver, the commits the MOM output documentation (`MOM_parameter_doc.*`) into the `docs` folder of the config being run.

If `runlog: False` it adds the docs folder it without committing

If `runlog: True` it commits it, with the message "payu archive: documentation of MOM6 run-time configuration" 

@dougiesquire - do you have a MOM6 standalone config i can test this with ?

@chrisb13 - if you'd like, we could try and do an "online/in zoom" review for training purposes. We probably need @jo-basevi because i'm a hack