### PR TITLE
Add error messaging when cloning from tag/commit

### DIFF
--- a/payu/branch.py
+++ b/payu/branch.py
@@ -12,6 +12,7 @@ import warnings
 from pathlib import Path
 from typing import Optional
 import shutil
+import sys
 
 from ruamel.yaml import YAML, CommentedMap, constructor
 import git
@@ -42,6 +43,17 @@ To find a branch that has a config file, you can:
 To checkout an existing branch, run:
     payu checkout BRANCH_NAME
 Where BRANCH_NAME is the name of the branch"""
+
+
+def remove_traceback_hook(kind, message, traceback):
+    """Remove traceback for only PayuBranchError"""
+    if kind is PayuBranchError:
+        print(f'{kind.__name__}: {message}', file=sys.stderr)
+    else:
+        sys.__excepthook__(kind, message, traceback)
+
+# Override the default exception hook to remove traceback
+sys.excepthook = remove_traceback_hook
 
 
 def check_restart(restart_path: Path,

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -292,6 +292,14 @@ def clone(repository: str,
             "and use `payu checkout` if it is the same git repository"
         )
 
+    # Check -b is set when -s/--start-point is set
+    if start_point is not None and new_branch_name is None:
+        raise PayuBranchError(
+            "Starting from a specific commit or tag requires a new branch "
+            "name to be specified. Use the --new-branch/-b flag in payu clone "
+            "to create a new git branch."
+        )
+
     # git clone the repository
     repo = git_clone(repository, control_path, branch)
 

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -297,7 +297,8 @@ def clone(repository: str,
         raise PayuBranchError(
             "Starting from a specific commit or tag requires a new branch "
             "name to be specified. Use the --new-branch/-b flag in payu clone "
-            "to create a new git branch."
+            "to create a new git branch.\n"
+            "For more infomation on payu clone, run `payu clone --help`"
         )
 
     # git clone the repository
@@ -343,10 +344,11 @@ def clone(repository: str,
         # Remove directory if incomplete checkout
         shutil.rmtree(control_path)
         msg = (
-            "Incomplete checkout. To run payu clone again, modify/remove " +
-            "the checkout new branch flag: --new-branch/-b, or " +
-            "checkout existing branch flag: --branch/-B " +
-            f"\n  Checkout error: {e}"
+            "Incomplete checkout. To run payu clone again, modify/remove "
+            "the checkout new branch flag: --new-branch/-b, or "
+            "checkout existing branch flag: --branch/-B "
+            f"\n  Checkout error: {e}\n"
+            "For more infomation on payu clone, run `payu clone --help`"
         )
         raise PayuBranchError(msg)
     finally:

--- a/payu/subcommands/checkout_cmd.py
+++ b/payu/subcommands/checkout_cmd.py
@@ -3,16 +3,32 @@
 :copyright: Copyright 2018 Marshall Ward, see AUTHORS for details.
 :license: Apache License, Version 2.0, see LICENSE for details.
 """
+from argparse import RawDescriptionHelpFormatter
 from pathlib import Path
 
 from payu.branch import checkout_branch
 import payu.subcommands.args as args
 
 title = 'checkout'
-parameters = {'description': ('A wrapper around git checkout. '
-                              'Create a new branch (if specified), '
-                              'checkout branch, setup experiment metadata '
-                              'and create/switch archive/work symlinks')}
+parameters = {
+    "description": (
+        "A wrapper around git checkout. Create a new branch (if specified), "
+        "checkout branch, setup experiment metadata and "
+        "create/switch archive/work symlinks"
+    ),
+    "epilog": (
+        "Example usage:\n"
+        "\n  To checkout an existing git branch:\n"
+        "    payu checkout <branch_name>\n"
+        "\n  To create a new branch from an existing branch:\n"
+        "    payu checkout -b <new_branch_name> <existing_branch_name>\n"
+        "\n  To create a new branch from an existing commit or tag:\n"
+        "    payu checkout -b <new_branch_name> <commit_or_tag>\n"
+        "\n  To checkout a new branch, and specify a restart path to start from:\n"
+        "    payu checkout -r <path_to_restart_dir> -b <new_branch_name>"
+    ),
+    "formatter_class": RawDescriptionHelpFormatter,
+}
 
 arguments = [args.model, args.config, args.laboratory, args.new_branch,
              args.branch_name, args.start_point, args.restart_path,

--- a/payu/subcommands/clone_cmd.py
+++ b/payu/subcommands/clone_cmd.py
@@ -4,15 +4,31 @@
 :license: Apache License, Version 2.0, see LICENSE for details.
 """
 
+from argparse import RawDescriptionHelpFormatter
 from pathlib import Path
 
 from payu.branch import clone
 import payu.subcommands.args as args
 
 title = 'clone'
-parameters = {'description': ('A wrapper around git clone. Clones a '
-                              'control repository and setup new experiment '
-                              'metadata')}
+parameters = {
+    'description': (
+        'A wrapper around git clone. Clones a control repository and setup '
+        'new experiment metadata'
+    ),
+    'epilog': (
+        'Example usage:\n'
+        '\n  To clone repository and checkout an existing git branch:\n'
+        '    payu clone -B <branch_name> <repository> <local_directory>\n'
+        '\n  To clone and create a new branch from an existing branch:\n'
+        '    payu clone -B <branch_name> -b <new_branch_name> <repository> <local_directory>\n'
+        '\n  To clone and create a new branch from an existing commit or tag:\n'
+        '    payu clone -s <commit_or_tag> -b <new_branch_name> <repository> <local_directory>\n'
+        '\n  To clone and checkout a new branch, and specify a restart path to start from:\n'
+        '    payu clone -b <new_branch_name> -r <path_to_restart_dir> <repository> <local_directory>\n'
+    ),
+    'formatter_class': RawDescriptionHelpFormatter,
+}
 
 arguments = [args.model, args.config, args.laboratory,
              args.keep_uuid, args.clone_branch,


### PR DESCRIPTION
Add a check to `payu clone` for when `-s/--start-point` to start from a commit/tag is defined but a new branch name with `-b` is not set. Closes #574  

The now error becomes: 
```
$ payu clone -s dev-MC_025deg_jra_ryf-0.4 https://github.com/access-nri/access-om3-configs my_folder
Traceback (most recent call last):
  File "/scratch/project/user/payu-telemetry-venv/bin/payu", line 8, in <module>
    sys.exit(parse())
             ^^^^^^^
  File "/home/189/user/payu_fork/payu/cli.py", line 49, in parse
    run_cmd(**args)
  File "/home/189/user/payu_fork/payu/subcommands/clone_cmd.py", line 37, in runcmd
    clone(repository=repository,
  File "/home/189/user/payu_fork/payu/branch.py", line 297, in clone
    raise PayuBranchError(
payu.git_utils.PayuBranchError: Starting from a specific commit or tag requires a new branch name to be specified. Use the --new-branch/-b flag in payu clone to create a new git branch.
```

I had looked into adding couple small examples to `payu clone --help` (displayed below). I can add it in to this PR if it'll be useful - though I wonder if it'll be more descriptive with concrete values. Might be worth extending `https://github.com/payu-org/mom-example` with an example branch and tag so that can be used in various payu documentation?
```
payu clone --help
usage: payu clone [-h] [--model MODEL_TYPE] [--config CONFIG_PATH] [--laboratory LAB_PATH] [-k] [--branch BRANCH] [--new-branch NEW_BRANCH_NAME]
                  [--restart RESTART_PATH] [--parent-experiment PARENT_EXPERIMENT] [--start-point START_POINT]
                  repository local_directory

A wrapper around git clone. Clones a control repository and setup new experiment metadata

positional arguments:
  repository            The repository to clone from. This can be either a local path or git url
  local_directory       The directory to clone into

options:
  -h, --help            show this help message and exit
  --model MODEL_TYPE, -m MODEL_TYPE
                        Model type
  --config CONFIG_PATH, -c CONFIG_PATH
                        Configuration file path
  --laboratory LAB_PATH, --lab LAB_PATH, -l LAB_PATH
                        The laboratory, this will over-ride the value given in config.yaml
  -k, --keep-uuid       If an experiment uuid exists, leave it unchanged
  --branch BRANCH, -B BRANCH
                        Clone and checkout this branch
  --new-branch NEW_BRANCH_NAME, -b NEW_BRANCH_NAME
                        The name of the git branch to create and checkout
  --restart RESTART_PATH, -r RESTART_PATH
                        The restart path from which to start the model run
  --parent-experiment PARENT_EXPERIMENT, -p PARENT_EXPERIMENT
                        The parent experiment UUID to add to generated metadata
  --start-point START_POINT, -s START_POINT
                        New branch will start from this commit or tag

Example usage:

  To clone and checkout an existing git branch:
    payu clone -B <branch_name> <repository> <local_directory>

  To clone and create a new branch starting from an existing branch:
    payu clone -B <branch_name> -b <new_branch_name> <repository> <local_directory>

  To clone and create a new branch starting from an existing commit or tag:
    payu clone -s <commit_or_tag> -b <new_branch_name> <repository> <local_directory>
```