### PR TITLE
allow repeat_run from a restart defined in config.yaml

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -508,6 +508,7 @@ Experiment Tracking
 Miscellaneous
 =============
 
+.. _restart:
 ``restart``
    Specify the full path to a restart directory from which to start the run.
    This is known as a "warm start". This option has no effect if there is an
@@ -570,8 +571,10 @@ Miscellaneous
    command-line flag. 
 
 ``repeat``
-   Ignore any restart files and repeat the initial run upon resubmission. This
-   is generally only used for testing purposes, such as bit reproducibility.
+   Remove any archived restart files and repeat the initial run upon resubmission. 
+   The repeated runs start from the same :ref:`user-defined restart <restart>` or 
+   initial condition. This is generally only used for testing purposes, such as bit 
+   reproducibility.
 
 .. _configuring-modules:
 ``modules``

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -112,7 +112,7 @@ class Access(Model):
                 caltype = cpl_group['caltype']
 
                 # Get timing information for the new run.
-                if model.prior_restart_path and not self.expt.repeat_run:
+                if model.prior_restart_path:
                     # Read the start date from the restart date namelist.
                     start_date_fpath = os.path.join(
                         model.prior_restart_path,
@@ -202,7 +202,7 @@ class Access(Model):
                 f90nml.write(cpl_nml, nml_work_path + '~')
                 shutil.move(nml_work_path + '~', nml_work_path)
 
-                if  model.prior_restart_path and not self.expt.repeat_run:
+                if  model.prior_restart_path:
                     # Set up and check the cice restart files.
                     model.overwrite_restart_ptr(run_start_date,
                                                 previous_runtime,

--- a/payu/models/access_esm1p6.py
+++ b/payu/models/access_esm1p6.py
@@ -121,7 +121,7 @@ class AccessEsm1p6(Model):
                 caltype = cpl_group['caltype']
 
                 # Get timing information for the new run.
-                if model.prior_restart_path and not self.expt.repeat_run:
+                if model.prior_restart_path:
                     # Read the start date from the restart date namelist.
                     start_date_fpath = os.path.join(
                         model.prior_restart_path,
@@ -211,7 +211,7 @@ class AccessEsm1p6(Model):
                 f90nml.write(cpl_nml, nml_work_path + '~')
                 shutil.move(nml_work_path + '~', nml_work_path)
 
-                if  model.prior_restart_path and not self.expt.repeat_run:
+                if  model.prior_restart_path:
                     # Set up and check the cice restart files.
                     model.overwrite_restart_ptr(run_start_date,
                                                 previous_runtime,

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -148,7 +148,7 @@ class CesmCmeps(Model):
         # Copy configuration files from control path to work path
         self.setup_configuration_files()
 
-        if self.prior_restart_path and not self.expt.repeat_run:
+        if self.prior_restart_path:
             start_type = 'continue'
 
             # Overwrite restart pointer symlinks with copies

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -75,7 +75,7 @@ class Mitgcm(Model):
         # Generic model setup
         super(Mitgcm, self).setup()
 
-        if self.prior_restart_path and not self.expt.repeat_run:
+        if self.prior_restart_path:
             # Determine total number of timesteps since initialisation
             core_restarts = [f for f in os.listdir(self.prior_restart_path)
                              if f.startswith('pickup.')]
@@ -128,8 +128,7 @@ class Mitgcm(Model):
                 # Assume n_timesteps and dt set correctly
                 pass
 
-        if t_start is None or (self.prior_restart_path
-           and not self.expt.repeat_run):
+        if t_start is None or self.prior_restart_path:
             # Look for a restart file from a previous run
             if os.path.exists(restart_calendar_path):
                 with open(restart_calendar_path, 'r') as restart_file:

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -114,7 +114,7 @@ class Mom6(MomMixin, Fms):
 
         input_nml = f90nml.read(input_fpath)
 
-        if ((self.expt.counter == 0 or self.expt.repeat_run) and
+        if ((self.expt.counter == 0) and
                 self.prior_restart_path is None):
             input_type = 'n'
         else:

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -114,8 +114,7 @@ class Mom6(MomMixin, Fms):
 
         input_nml = f90nml.read(input_fpath)
 
-        if ((self.expt.counter == 0) and
-                self.prior_restart_path is None):
+        if (self.prior_restart_path is None):
             input_type = 'n'
         else:
             input_type = 'r'

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -133,7 +133,7 @@ class UnifiedModel(Model):
 
 
         # Stage the UM restart file.
-        if self.prior_restart_path and not self.expt.repeat_run:
+        if self.prior_restart_path :
             f_src = os.path.join(self.prior_restart_path, self.restart)
             f_dst = os.path.join(self.work_input_path, self.restart)
 
@@ -170,8 +170,7 @@ class UnifiedModel(Model):
                                              self.restart_calendar_file)
 
         # Modify namelists for a continuation run.
-        if self.prior_restart_path and not self.expt.repeat_run \
-           and os.path.exists(restart_calendar_path):
+        if self.prior_restart_path and os.path.exists(restart_calendar_path):
 
             run_start_date = self.read_calendar_file(restart_calendar_path)
 


### PR DESCRIPTION
Contributes to #576 

This enables the repeat option to be used with previous restart files to start (rather than always assuming they are starting from an initial condition).

Ad-hoc testing only. This works with the access-esm1.6 driver now. I've assumed that users specify the restart in `config.yaml` and do not already have restart's in their archive directory.