### PR TITLE
Add exe_prefix option to documentation

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -172,6 +172,10 @@ configuration.
    modules).
    Various model drivers typically define their own default executable names.
 
+``exe_prefix``
+   Optional string to add in front of the model executable in the MPI run
+   command. This can be useful for configuring profilers or valgrind.
+
 ``submodels``
    If one is running a coupled model containing several submodels, then each
    model is configured individually within a ``submodel`` namespace, such as in

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -173,8 +173,10 @@ configuration.
    Various model drivers typically define their own default executable names.
 
 ``exe_prefix``
-   Optional string to add in front of the model executable in the MPI run
-   command. This can be useful for configuring profilers or valgrind.
+   Optional string that is added immediately before the model executable in the
+   MPI run command. It appears after `mpirun` and any MPI related flags, for
+    example, `mpirun <mpi-flags> <exe_prefix> <model-exe>`.
+   This can be useful for configuring profilers or valgrind.
 
 ``submodels``
    If one is running a coupled model containing several submodels, then each


### PR DESCRIPTION
Add a brief description of  `exe_prefix` to the Model configuration section.
Closes #578 

