### PR TITLE
Don't write start date to CICE5 namelist

### DIFF
--- a/payu/models/access_esm1p6.py
+++ b/payu/models/access_esm1p6.py
@@ -200,7 +200,7 @@ class AccessEsm1p6(Model):
                 else:
                     raise RuntimeError("runtime missing from config.yaml")
 
-                # CICE5 start date read directly from restart
+                # Namelist dates only required for CICE4
                 if model.model_type == "cice":
                     # Now write out new run start date and total runtime into the
                     # work directory namelist.

--- a/payu/models/access_esm1p6.py
+++ b/payu/models/access_esm1p6.py
@@ -200,11 +200,14 @@ class AccessEsm1p6(Model):
                 else:
                     raise RuntimeError("runtime missing from config.yaml")
 
-                # Now write out new run start date and total runtime into the
-                # work directory namelist.
-                cpl_group[model.init_date_key] = cal.date_to_int(init_date)
-                cpl_group[model.inidate_key] = cal.date_to_int(run_start_date)
-                cpl_group[model.runtime0_key] = previous_runtime
+                # CICE5 start date read directly from restart
+                if model.model_type == "cice":
+                    # Now write out new run start date and total runtime into the
+                    # work directory namelist.
+                    cpl_group[model.init_date_key] = cal.date_to_int(init_date)
+                    cpl_group[model.inidate_key] = cal.date_to_int(run_start_date)
+                    cpl_group[model.runtime0_key] = previous_runtime
+
                 cpl_group[model.runtime_key] = int(run_runtime)
 
                 # write coupler namelist


### PR DESCRIPTION
Closes #595. 

Updates the `access-esm1.6` driver so that start date information is written to the CICE `input_ice.nml` namelist only for CICE4, and not CICE5. ~Should be merged around the same time as https://github.com/ACCESS-NRI/cice5/pull/48 to maintain compatibility.~ actually timing doesn't matter too much, as long as we add this in when swapping to an updated cice5 build