### PR TITLE
Allow starting from user-restart when empty archive and non-zero counter

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -381,7 +381,7 @@ class Experiment(object):
             else:
                 self.prior_restart_path = None
                 if self.counter > 0 and not self.repeat_run:
-                    raise RuntimeError(
+                    warnings.warn(
                         "No prior restart directory found in archive "
                         "or specified in config.yaml"
                     )

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -19,6 +19,8 @@ CONFIG_FILES = ['data', 'diag', 'input.nml']
 OPTIONAL_CONFIG_FILES = ['opt_data']
 INPUT_NML_FILENAME = 'input.nml'
 
+config_orig = copy.deepcopy(config_orig)
+
 
 @pytest.fixture(autouse=True)
 def setup_and_teardown():
@@ -315,10 +317,10 @@ def test_set_prior_restart_path_with_restart_in_archive(tmp_path):
     assert expt.prior_restart_path == os.path.join(expt.archive_path, 'restart009')
 
 
-def test_set_prior_restart_path_with_non_zero_counter_and_no_restarts():
+def test_set_prior_restart_with_non_zero_counter_and_no_restarts(monkeypatch):
     """Test set prior restart path raises an error if the prior restart
     is not found"""
-    os.environ['PAYU_CURRENT_RUN'] = '10'
+    monkeypatch.setenv('PAYU_CURRENT_RUN', '10')
     error_msg = (
         "No prior restart directory found in archive or "
         "specified in config.yaml"
@@ -327,9 +329,11 @@ def test_set_prior_restart_path_with_non_zero_counter_and_no_restarts():
         expt = init_experiment(config_orig)
 
 
-def test_set_prior_restart_path_with_non_zero_counter_and_restart(tmp_path):
+def test_set_prior_restart_with_non_zero_counter_and_restart(tmp_path,
+                                                             monkeypatch):
     """Test prior restart path is set to restart directory in config.yaml
     when PAYU_CURRENT_RUN is set to non-zero"""
+    monkeypatch.setenv("PAYU_CURRENT_RUN", "10")
     os.environ['PAYU_CURRENT_RUN'] = '10'
 
     # Create an external restart directory

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -318,15 +318,16 @@ def test_set_prior_restart_path_with_restart_in_archive(tmp_path):
 
 
 def test_set_prior_restart_with_non_zero_counter_and_no_restarts(monkeypatch):
-    """Test set prior restart path raises an error if the prior restart
-    is not found"""
+    """Test set prior restart path warns if the prior restart
+    is not found with a non-zero run counter"""
     monkeypatch.setenv('PAYU_CURRENT_RUN', '10')
-    error_msg = (
+    msg = (
         "No prior restart directory found in archive or "
         "specified in config.yaml"
     )
-    with pytest.raises(RuntimeError, match=error_msg):
+    with pytest.warns(UserWarning, match=msg):
         expt = init_experiment(config_orig)
+    assert expt.prior_restart_path is None
 
 
 def test_set_prior_restart_with_non_zero_counter_and_restart(tmp_path,
@@ -334,7 +335,6 @@ def test_set_prior_restart_with_non_zero_counter_and_restart(tmp_path,
     """Test prior restart path is set to restart directory in config.yaml
     when PAYU_CURRENT_RUN is set to non-zero"""
     monkeypatch.setenv("PAYU_CURRENT_RUN", "10")
-    os.environ['PAYU_CURRENT_RUN'] = '10'
 
     # Create an external restart directory
     user_restart = tmp_path / 'restart009'


### PR DESCRIPTION
This PR checks if there are any pre-existing restarts in archive when setting `prior_restart_path` to allow the case of a non-zero counter (i.e. run number which is used for output naming) and using a user defined restart directory in `config.yaml`. (This means for continuing a run from a new empty archive, it is possible to set `restart: path/to/last/restart9` in `config.yaml` and start new run using `payu run -i 10` which result in output directories `output010` and `restart011` )

I've also changed an assert, and printed warning to exceptions. I'm still raising a warning when using a restart from `config.yaml` with a non-zero counter so there's some visibility on what payu is doing. 

I'm still trying to think of a case where using a restart in `config.yaml` and a non-zero counter would be unexpected. One case could be if restarts somehow got accidentally deleted but there were still pre-existing outputs, so the user might not be aware at the point that payu is restarting from the beginning again? This could happen if the `repeat` option was used. 

Closes #603 