### PR TITLE
Prepend container launcher script to pbs command, if it exists

### DIFF
--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -132,7 +132,11 @@ class PBS(Scheduler):
 
         # Check for custom container launcher script environment variable
         launcher_script = os.environ.get('ENV_LAUNCHER_SCRIPT_PATH')
-        if launcher_script and Path(launcher_script).is_file():
+        if (
+            launcher_script
+            and Path(launcher_script).is_file()
+            and os.access(launcher_script, os.X_OK)
+        ):
             # Prepend the container launcher script to the python command
             # so the python executable is accessible in the container
             python_exe = f'{launcher_script} {python_exe}'

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -6,6 +6,7 @@
 
 # Standard library
 import os
+from pathlib import Path
 import re
 import sys
 import shlex
@@ -128,6 +129,13 @@ class PBS(Scheduler):
         # Set up environment modules here for PBS.
         envmod.setup()
         envmod.module('load', 'pbs')
+
+        # Check for custom container launcher script environment variable
+        launcher_script = os.environ.get('ENV_LAUNCHER_SCRIPT_PATH')
+        if launcher_script and Path(launcher_script).is_file():
+            # Prepend the container launcher script to the python command
+            # so the python executable is accessible in the container
+            python_exe = f'{launcher_script} {python_exe}'
 
         # Construct job submission command
         cmd = 'qsub {flags} -- {python} {script}'.format(


### PR DESCRIPTION
Related to https://github.com/ACCESS-NRI/model-release-condaenv/issues/17 which requires running payu from an environment within a singularity container. 
This allows a custom launcher script to run at the start of the PBS job which launches a singularity container with a SquashFS overlay for the environment, and then runs the python and payu executable within that environment.

Could use a shorter or other name than `ENV_LAUNCHER_SCRIPT_PATH`? Now would be the time to change it if so..

I've manually tested that this does not add `ENV_LAUNCHER_SCRIPT_PATH` if it isn't set in the environment, and if it is, it then works with an launcher script implementation in the https://github.com/ACCESS-NRI/model-release-condaenv/pull/19 PR. 

Note: qsub call looks like `qsub <qsub_flags> -- /path/to/env-launcher-scripts/bin/launcher.sh /path/to/envs/payu/bin/python3.10 /path/to/envs/payu/bin/payu-run` where `/path/to/envs/payu/bin` directory is only accessible when running within the singularity container.
