### PR TITLE
List loaded modules after openmpi has been updated

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -273,8 +273,6 @@ class Experiment(object):
         for mod in self.modules:
             envmod.module('load', mod)
 
-        envmod.module('list')
-
         for prof in self.profilers:
             prof.load_modules()
 
@@ -625,6 +623,9 @@ class Experiment(object):
             model_prog.append(os.path.join(model.work_path, model.exec_name))
 
             mpi_progs.append(' '.join(model_prog))
+
+        # List all loaded environment modules
+        envmod.module("list")
 
         cmd = '{runcmd} {flags} {exes}'.format(
             runcmd=mpi_runcmd,

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -109,6 +109,8 @@ def fms_collate(model):
         # the output
         collate_flags = " ".join([collate_flags, '-o'])
         envmod.lib_update(required_libs(mppnc_path), 'libmpi.so')
+        # List all loaded environment modules
+        envmod.module("list")
 
     # Import list of collated files to ignore
     collate_ignore = collate_config.get('ignore')


### PR DESCRIPTION
Move listing loaded modules until after openmpi has been potentially been updated. This should make it more clear what modules are loaded by the time the model runs

Closes #605
