### PR TITLE
Revert um calendar format change

### DIFF
--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -26,7 +26,6 @@ from payu.fsops import mkdir_p, make_symlink
 from payu.models.model import Model
 import payu.calendar as cal
 
-UM_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 # UM in access always uses proleptic gregorian calendar
 UM_CFTIME_CALENDAR = "proleptic_gregorian"
 

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -223,11 +223,16 @@ class UnifiedModel(Model):
         with open(restart_calendar_path, 'r') as calendar_file:
             date_info = yaml.safe_load(calendar_file)
 
-        restart_date = cftime.datetime.strptime(date_info['end_date'],
-                                                UM_DATE_FORMAT,
-                                                calendar=UM_CFTIME_CALENDAR)
+        restart_date = date_info['end_date']
+        if not isinstance(restart_date, datetime.date):
+            raise TypeError(
+                "Failed to parse restart calendar file contents into "
+                "datetime object. "
+                f"Calendar file: {restart_calendar_path}"
+            )
 
-        return restart_date
+        # Convert to cftime.datetime
+        return cal.date_to_cftime(restart_date, UM_CFTIME_CALENDAR)
 
     def get_restart_datetime(self, restart_path):
         """

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -231,8 +231,7 @@ class UnifiedModel(Model):
                 f"Calendar file: {restart_calendar_path}"
             )
 
-        # Convert to cftime.datetime
-        return cal.date_to_cftime(restart_date, UM_CFTIME_CALENDAR)
+        return restart_date
 
     def get_restart_datetime(self, restart_path):
         """
@@ -251,7 +250,10 @@ class UnifiedModel(Model):
                                      self.restart_calendar_file)
 
         restart_date = self.read_calendar_file(calendar_path)
-        return restart_date
+
+        # Date-based restart pruning requires cftime.datetime object and
+        # Payu UM always uses proleptic Gregorian calendar
+        return cal.date_to_cftime(restart_date, UM_CFTIME_CALENDAR)
 
 
 def date_to_um_dump_date(date):

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -17,7 +17,6 @@ import shutil
 import string
 
 # Extensions
-import cftime
 import f90nml
 import yaml
 
@@ -212,7 +211,7 @@ class UnifiedModel(Model):
 
         Returns
         -------
-        cftime.datetime
+        datetime.datetime or datetime.date
         """
         if not os.path.exists(restart_calendar_path):
             raise FileNotFoundError(

--- a/test/models/test_um.py
+++ b/test/models/test_um.py
@@ -90,8 +90,14 @@ def make_atmosphere_restart_dir(date,
     calendar_file_path = os.path.join(restart_path, UM_RES_FILE)
 
     with open(calendar_file_path, 'w') as um_cal_file:
-        date_str = date.strftime(UM_DATE_FORMAT)
-        um_cal_file.write(yaml.dump({'end_date': date_str},
+        # yaml parser expects datetime.datetime object
+        date_out = datetime.datetime(date.year,
+                                     date.month,
+                                     date.day,
+                                     date.hour,
+                                     date.minute,
+                                     date.second)
+        um_cal_file.write(yaml.dump({'end_date': date_out},
                                     default_flow_style=False))
 
 

--- a/test/models/test_um.py
+++ b/test/models/test_um.py
@@ -9,8 +9,6 @@ import yaml
 
 import payu
 
-from payu.models.um import UM_DATE_FORMAT
-
 from test.common import cd
 from test.common import tmpdir, ctrldir, labdir
 from test.common import config as config_orig


### PR DESCRIPTION
Closes #609.

Consistently read and write the `um_res.yaml` file using `datetime.datetime` objects. This maintains compatibility with the files that the driver writes, and maintains compatibility with other date manipulations within the UM driver which expect datetime.datetime objects (e.g. [here](https://github.com/payu-org/payu/blob/3f79a0d0a57f1e9bb86b20fe2a11ef4f5991a5a1/payu/models/um.py#L192-L198)). Convert to `cftime.datetime` after reading.