### PR TITLE
CICE5: Ignore missing prior restart files

### DIFF
--- a/payu/models/cice5.py
+++ b/payu/models/cice5.py
@@ -73,6 +73,16 @@ class Cice5(Cice):
         # Make log dir
         mkdir_p(os.path.join(self.work_path, 'log'))
 
+    def get_prior_restart_files(self):
+        """
+        Overrides the super method to avoid printing an error if there are no
+        prior restart files found
+        """
+        if self.prior_restart_path is not None:
+            return sorted(os.listdir(self.prior_restart_path))
+        else:
+            return []
+
     def get_latest_restart_file(self, restart_path):
         """
         Given a restart path, parse the restart files and return the latest in


### PR DESCRIPTION
This PR adds back in an override method for `get_prior_restart_files` in CICE5 driver that doesn't print out an error if there's no prior restart files.

Closes #611 

I've tested that adding the method back in removes the error message `No prior restart files found: expected str, bytes or os.PathLike object, not NoneType` when running an OM2 configuration