### PR TITLE
Add netCDF4 as a explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "cftime",
     "GitPython >=3.1.40",
     "ruamel.yaml >=0.18.5",
-    "packaging"
+    "packaging",
+    "netCDF4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`netCDF4` is imported in CICE5 model driver, but was previously available in the environment due to an older version of `yamanifest` dependency. This PR adds `netCDF4` explicitly to the project dependencies.

Closes #613