### PR TITLE
Update pypa/gh-action-pypi-publish to v1.12.4

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -64,11 +64,10 @@ jobs:
           auto-activate-base: false
           show-channel-urls: true
 
-      - name: Build and upload the conda package
-        uses: uibcdf/action-build-and-upload-conda-packages@c6e7a90ad5e599d6cde76e130db4ee52ad733ecf # v1.2.0
+      - name: Build and upload conda package
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v2.0.1
         with:
           meta_yaml_dir: conda
-          python-version: ${{ env.PY_VERSION }}
           user: accessnri
           label: main
           token: ${{ secrets.anaconda_token }}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -43,7 +43,7 @@ jobs:
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
 
   conda:
     name: Build with conda and upload

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,9 +47,12 @@ jobs:
           auto-activate-base: false
           show-channel-urls: true
 
-      - name: Run conda build
-        shell: bash -el {0}
-        run: conda build . --no-anaconda-upload
+      - name: Build conda package
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v2.0.1
+        with:
+          meta_yaml_dir: conda
+          label: main
+          upload: false
 
   tests:
     name: Tests


### PR DESCRIPTION
This PR updates the [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) action used in the CD workflow to `v1.12.4` so it can support newer versions of `twine`.

Closes #615 