### PR TITLE
Tidy up handling history_dir and restart_dir

### DIFF
--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -73,7 +73,12 @@ class Cice(Model):
         # Assume local paths are relative to the work path
         setup_nml = self.ice_in['setup_nml']
 
-        res_path = os.path.normpath(setup_nml['restart_dir'])
+        try:
+            res_path = os.path.normpath(setup_nml['restart_dir'])
+        except KeyError:
+            raise RuntimeError(
+                f"`restart_dir` must be set in {self.ice_nml_fname} for payu to run"
+            )
         input_dir = setup_nml.get('input_dir', None)
 
         if input_dir is None:
@@ -129,7 +134,7 @@ class Cice(Model):
             res_path = os.path.join(self.work_path, res_path)
         self.work_restart_path = res_path
 
-        work_out_path = os.path.normpath(setup_nml['history_dir'])
+        work_out_path = os.path.normpath(setup_nml.get('history_dir', None))
 
         if not os.path.isabs(work_out_path):
             work_out_path = os.path.join(self.work_path, work_out_path)

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -134,7 +134,7 @@ class Cice(Model):
             res_path = os.path.join(self.work_path, res_path)
         self.work_restart_path = res_path
 
-        work_out_path = os.path.normpath(setup_nml.get('history_dir', None))
+        work_out_path = os.path.normpath(setup_nml.get('history_dir', ''))
 
         if not os.path.isabs(work_out_path):
             work_out_path = os.path.join(self.work_path, work_out_path)

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -172,7 +172,7 @@ del NOCAL_CICE_NML["setup_nml"]["use_leap_years"]
                          indirect=True)
 def test_setup_fails(config, cice_config_files):
     """
-    # Confirm that payu setup fails with an invalid calendar
+    Confirm that payu setup fails with an invalid calendar 
     """
     with cd(ctrldir):
 
@@ -184,15 +184,40 @@ def test_setup_fails(config, cice_config_files):
         with pytest.raises(Exception):
             model.setup()
 
+# with no restart_dir, payu should fail as payu just move the restart_dir wholesale for setup/archve
+NORES_CICE_NML = deepcopy(DEFAULT_CICE_NML)
+del NORES_CICE_NML["setup_nml"]["restart_dir"]
+
+@pytest.mark.parametrize("config", 
+                        [DEFAULT_CONFIG],
+                         indirect=True)
+@pytest.mark.parametrize("cice_config_files", 
+                        [NORES_CICE_NML],
+                         indirect=True)
+def test_Experiment_fails(config, cice_config_files):
+    """
+    Confirm that payu fails with a missing restart dir
+    """
+    with cd(ctrldir):
+
+        with pytest.raises(Exception):
+            lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+            expt = payu.experiment.Experiment(lab, reproduce=False)
+
 
 LEAP_CICE_NML = deepcopy(DEFAULT_CICE_NML)
 LEAP_CICE_NML["setup_nml"].update(use_leap_years=True)
+
+# with no history_dir, payu should use the default (which is the same as the exe directory)
+NOHIST_CICE_NML = deepcopy(DEFAULT_CICE_NML)
+del NORES_CICE_NML["setup_nml"]["history_dir"]
 
 @pytest.mark.parametrize("config", 
                         [DEFAULT_CONFIG],
                          indirect=True)
 @pytest.mark.parametrize("cice_config_files,expected_cal", 
                         [(DEFAULT_CICE_NML,"noleap"),
+                         (NOHIST_CICE_NML,"noleap"),
                          (LEAP_CICE_NML,"proleptic_gregorian")],
                          indirect=["cice_config_files"])
 def test_setup(config, cice_config_files, expected_cal):

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -200,10 +200,9 @@ def test_Experiment_fails(config, cice_config_files):
     """
     with cd(ctrldir):
 
-        with pytest.raises(Exception):
-            lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        with pytest.raises(RuntimeError, match='`restart_dir`'):
             expt = payu.experiment.Experiment(lab, reproduce=False)
-
 
 LEAP_CICE_NML = deepcopy(DEFAULT_CICE_NML)
 LEAP_CICE_NML["setup_nml"].update(use_leap_years=True)

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -210,7 +210,7 @@ LEAP_CICE_NML["setup_nml"].update(use_leap_years=True)
 
 # with no history_dir, payu should use the default (which is the same as the exe directory)
 NOHIST_CICE_NML = deepcopy(DEFAULT_CICE_NML)
-del NORES_CICE_NML["setup_nml"]["history_dir"]
+del NOHIST_CICE_NML["setup_nml"]["history_dir"]
 
 @pytest.mark.parametrize("config", 
                         [DEFAULT_CONFIG],


### PR DESCRIPTION
Closes #617 

- Allow for `history_dir` to not be set and use a default value
- Error if `restar_dir` is not set, as payu relies on it for tracking restarting files.