### PR TITLE
Add in HPCpy

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -167,7 +167,6 @@ def submit_job(script, config, vars=None):
     sched_name = config.get('scheduler', DEFAULT_SCHEDULER_CONFIG)
     sched_type = scheduler_index[sched_name]
     sched = sched_type()
-    cmd = sched.submit(script, config, vars)
-    print(cmd)
-
-    subprocess.check_call(shlex.split(cmd))
+    job = sched.submit(script, config, vars)
+    print(job.id)
+    return job

--- a/payu/schedulers/payu-submit.sh
+++ b/payu/schedulers/payu-submit.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Script to run payu command on a scheduled job, e.g. path/to/python path/to/payu-run
+{{python_exe}} {{payu_exe}}

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -13,36 +13,36 @@ import shlex
 import subprocess
 from typing import Any, Dict, Optional
 
+from tenacity import retry, stop_after_delay
+from hpcpy import PBSClient
+
 import payu.envmod as envmod
 from payu.fsops import check_exe_path
 from payu.manifest import Manifest
 from payu.schedulers.scheduler import Scheduler
 
-from tenacity import retry, stop_after_delay
 
+JOB_SCRIPT_TEMPLATE =  Path(__file__).parent / 'payu-submit.sh'
 
 # TODO: This is a stub acting as a minimal port to a Scheduler class.
 class PBS(Scheduler):
     # TODO: __init__
 
-    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None):
-        """Prepare a correct PBS command string"""
+    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None,
+               dry_run=False):
+        """Submit a job using HPCpy PBS client"""
 
-        pbs_env_init()
+        # TODO: Is pbs_env_init() still required?
+        # pbs_env_init()
 
         # Initialisation
         if pbs_vars is None:
             pbs_vars = {}
 
-        # Necessary for testing
         if python_exe is None:
             python_exe = sys.executable
 
         pbs_flags = []
-
-        pbs_queue = pbs_config.get('queue', 'normal')
-        pbs_flags.append('-q {queue}'.format(queue=pbs_queue))
-
         pbs_project = pbs_config.get('project', os.environ['PROJECT'])
         pbs_flags.append('-P {project}'.format(project=pbs_project))
 
@@ -76,12 +76,6 @@ class PBS(Scheduler):
             sys.exit(-1)
         else:
             pbs_flags.append('-j {join}'.format(join=pbs_join))
-
-        # Append environment variables to qsub command
-        # TODO: Support full export of environment variables: `qsub -V`
-        pbs_vstring = ','.join('{0}={1}'.format(k, v)
-                               for k, v in pbs_vars.items())
-        pbs_flags.append('-v ' + pbs_vstring)
 
         storages = set()
         storage_config = pbs_config.get('storage', {})
@@ -120,15 +114,13 @@ class PBS(Scheduler):
         storages.update(find_mounts(extra_search_paths, mounts))
         storages.update(find_mounts(get_manifest_paths(), mounts))
 
-        # Add storage flags. Note that these are sorted to get predictable
-        # behaviour for testing
-        pbs_flags_extend = '+'.join(sorted(storages))
-        if pbs_flags_extend:
-            pbs_flags.append("-l storage={}".format(pbs_flags_extend))
+        # Sort the storages for testing
+        storages = sorted(list(storages))
 
+        # TODO: Is this still needed?
         # Set up environment modules here for PBS.
-        envmod.setup()
-        envmod.module('load', 'pbs')
+        # envmod.setup()
+        # envmod.module('load', 'pbs')
 
         # Check for custom container launcher script environment variable
         launcher_script = os.environ.get('ENV_LAUNCHER_SCRIPT_PATH')
@@ -141,14 +133,20 @@ class PBS(Scheduler):
             # so the python executable is accessible in the container
             python_exe = f'{launcher_script} {python_exe}'
 
-        # Construct job submission command
-        cmd = 'qsub {flags} -- {python} {script}'.format(
-            flags=' '.join(pbs_flags),
-            python=python_exe,
-            script=pbs_script
+        client = PBSClient()
+        job = client.submit(
+            dry_run=dry_run,
+            directives=pbs_flags,
+            queue=pbs_config.get("queue", "normal"),
+            variables=pbs_vars,
+            storage=storages,
+            job_script=JOB_SCRIPT_TEMPLATE,
+            render=True,
+            python_exe=python_exe,
+            payu_exe=pbs_script,
         )
+        return job
 
-        return cmd
 
     def get_job_id(self, short: bool = True) -> Optional[str]:
         """Get PBS job ID

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -19,10 +19,7 @@ from hpcpy import PBSClient
 import payu.envmod as envmod
 from payu.fsops import check_exe_path
 from payu.manifest import Manifest
-from payu.schedulers.scheduler import Scheduler
-
-
-JOB_SCRIPT_TEMPLATE =  Path(__file__).parent / 'payu-submit.sh'
+from payu.schedulers.scheduler import Scheduler, JOB_SCRIPT_TEMPLATE
 
 # TODO: This is a stub acting as a minimal port to a Scheduler class.
 class PBS(Scheduler):

--- a/payu/schedulers/scheduler.py
+++ b/payu/schedulers/scheduler.py
@@ -7,9 +7,11 @@
 # TODO: This class is currently just a stub.  I would hope that it will be
 # expanded to provide greater functionality in the future.
 
-
+from pathlib import Path
 from typing import Any, Dict, Optional
 
+
+JOB_SCRIPT_TEMPLATE = Path(__file__).parent / "payu-submit.sh"
 
 class Scheduler(object):
     """Abstract scheduler class."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "ruamel.yaml >=0.18.5",
     "packaging",
     "netCDF4",
+    "hpcpy"
 ]
 
 [project.optional-dependencies]

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -227,7 +227,6 @@ def test_run():
 
         env = {}
         for env_var in args.v:
-            print("Environment variable:", env_var)
             if '=' in env_var:
                 k, v = env_var.split('=')
                 env[k] = v


### PR DESCRIPTION
Storing some initial changes of adding in hpcpy. Installed hpcpy from the github repository into a python virtual environment as hpcpy is currently not available on PyPI (so I imagine the CI tests will fail...)

TODO:
- Test slurm client
- Use HPCpy for submitting post-scripts - add in job dependency for sync scripts?
- Add hpcpy to PyPI?
- Disable hpcpy debug logs but print job submission command (available when using `dry_run=True`)

A number of PBS specific directives are still required so can't use a generic client currently. 

Closes #568