### PR TITLE
Autodetect nuopc.runconfig for restart-only collate

### DIFF
--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -334,18 +334,14 @@ class CesmCmeps(Model):
             os.rmdir(self.work_restart_path)
 
     def collate(self):
-        
         self.output_path = os.path.realpath(os.path.abspath(self.output_path))
-        runconfig_path = os.path.join(self.output_path, NUOPC_CONFIG)
+        runconfig_path = os.path.join(self.expt.control_path, NUOPC_CONFIG)
+
         if not os.path.exists(runconfig_path):
-            # guess its sibling output
-            sib_output = re.sub(r"restart(\d+)", r"output\1", self.output_path)
-            sib_output_path = os.path.join(sib_output, NUOPC_CONFIG)
-            if os.path.exists(sib_output_path):
-                runconfig_path = sib_output_path
-            else:
-                # use the control directory path
-                runconfig_path = os.path.join(self.expt.control_path, NUOPC_CONFIG)
+            raise FileNotFoundError(
+                f"{NUOPC_CONFIG} is not found in control directory: {runconfig_path}!"
+            )
+
         # .setup is not run when collate is called so need to get components
         self.get_runconfig(os.path.dirname(runconfig_path))
         self.get_components()

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -335,6 +335,17 @@ class CesmCmeps(Model):
 
     def collate(self):
         
+        self.output_path = os.path.realpath(os.path.abspath(self.output_path))
+        runconfig_path = os.path.join(self.output_path, NUOPC_CONFIG)
+        if not os.path.exists(runconfig_path):
+            # guess its sibling output
+            sib_output = re.sub(r"restart(\d+)", r"output\1", self.output_path)
+            sib_output_path = os.path.join(sib_output, NUOPC_CONFIG)
+            if os.path.exists(sib_output_path):
+                runconfig_path = sib_output_path
+            else:
+                # use the control directory path
+                runconfig_path = os.path.join(self.expt.control_path, NUOPC_CONFIG)
         # .setup is not run when collate is called so need to get components
         self.get_runconfig(self.output_path)
         self.get_components()

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -347,7 +347,7 @@ class CesmCmeps(Model):
                 # use the control directory path
                 runconfig_path = os.path.join(self.expt.control_path, NUOPC_CONFIG)
         # .setup is not run when collate is called so need to get components
-        self.get_runconfig(self.output_path)
+        self.get_runconfig(os.path.dirname(runconfig_path))
         self.get_components()
         
         if "mom" in self.components.values():

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -334,18 +334,11 @@ class CesmCmeps(Model):
             os.rmdir(self.work_restart_path)
 
     def collate(self):
-        self.output_path = os.path.realpath(os.path.abspath(self.output_path))
-        runconfig_path = os.path.join(self.expt.control_path, NUOPC_CONFIG)
-
-        if not os.path.exists(runconfig_path):
-            raise FileNotFoundError(
-                f"{NUOPC_CONFIG} is not found in control directory: {runconfig_path}!"
-            )
 
         # .setup is not run when collate is called so need to get components
-        self.get_runconfig(os.path.dirname(runconfig_path))
+        self.get_runconfig(self.control_path)
         self.get_components()
-        
+
         if "mom" in self.components.values():
             fms_collate(self)
         else:


### PR DESCRIPTION
closes https://github.com/payu-org/payu/issues/620

This PR patches collate method in CesmCmeps to automatically locate `nuopc.runconfig` when the user collates a bare restart directory with `payu collate -d archive/restartxxx` or `payu collate -d restartxxx`,

1. lookinig for sibling `outputxxx` directory obtained by `restartxxx -> outputxxx`
2. If absent, fall back to the copy in `control/`.