### PR TITLE
fix: properly handle provision of optional configuration files

### DIFF
--- a/payu/models/roms.py
+++ b/payu/models/roms.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from payu.models.model import Model
 from payu.fsops import mkdir_p
 
-config_files = ['varinfo_seacofs.yaml']
+config_files = []
 optional_config_files = []
 
 class Roms(Model):
@@ -29,7 +29,7 @@ class Roms(Model):
         self.optional_config_files = optional_config_files
 
     def setup(self):
-        # Add the model config file to the list of config files
+        ## handle mandatory config files
         if 'model_config' not in self.config:
             raise ValueError(
                 "'model_config' field must be specified in config.yaml for "
@@ -45,6 +45,20 @@ class Roms(Model):
             )
 
         self.config_files.append(model_config)
+
+        ## handle optional config files
+        optional_config_files = self.expt.config['optional_config_files']
+        if optional_config_files and isinstance(optional_config_files, str):
+            optional_config_files = [optional_config_files]
+
+        for optional_file in optional_config_files:
+            if not (Path(self.control_path) / optional_file).is_file():
+                raise FileNotFoundError(
+                    f"Optional configuration file '{optional_file}' not found in the "
+                    f"control directory: {self.control_path}"
+                )
+
+        self.optional_config_files.extend(optional_config_files)
 
         super(Roms, self).setup()
 

--- a/payu/models/roms.py
+++ b/payu/models/roms.py
@@ -12,9 +12,6 @@ from pathlib import Path
 from payu.models.model import Model
 from payu.fsops import mkdir_p
 
-config_files = []
-optional_config_files = []
-
 class Roms(Model):
 
     def __init__(self, expt, name, config):
@@ -24,9 +21,9 @@ class Roms(Model):
 
         # Model-specific configuration
         self.model_type = 'roms'
-
-        self.config_files = config_files
-        self.optional_config_files = optional_config_files
+        
+        self.config_files = []
+        self.optional_config_files = []
 
     def setup(self):
         ## handle mandatory config files


### PR DESCRIPTION
Enabled `optional_config_files` provision through `config.yaml`. Prior to this change, ROMS `varinfo` file was being considered a mandatory model config file and mistakenly hard coded into `config_files` list, leading to model initialisation failure when file name differed from `varinfo_seacofs.yaml`.