### PR TITLE
Add copy restarts flag to ROMS driver

### DIFF
--- a/payu/models/roms.py
+++ b/payu/models/roms.py
@@ -25,6 +25,8 @@ class Roms(Model):
         self.config_files = []
         self.optional_config_files = []
 
+        self.copy_restarts = True
+
     def setup(self):
         ## handle mandatory config files
         if 'model_config' not in self.config:


### PR DESCRIPTION
Closes #629 

ROMS reads from and writes to the same restart file, so added a copy restarts flag as the simplest and easiest solution.