### PR TITLE
Don't copy cice5 inputs for esm1p6

### DIFF
--- a/payu/models/access_esm1p6.py
+++ b/payu/models/access_esm1p6.py
@@ -67,7 +67,8 @@ class AccessEsm1p6(Model):
                 model.start_date_nml_name = "restart_date.nml"
 
             if model.model_type == 'cice5':
-                # OM2 copies rather than symlinks cice5 inputs for parallel reading.
+                # OM2 copies rather than symlinks cice5 inputs to support parallel reading. 
+                # See https://github.com/open-mpi/ompi/issues/12141
                 # This is not required for esm1.6
                 model.copy_inputs = False
 


### PR DESCRIPTION
Closes #634 

The cice5 driver copies input files to the `work` directory rather than making symlinks: https://github.com/payu-org/payu/blob/d026d1ed9229e3a6f24db09d4b45940678c78539/payu/models/cice5.py#L41

This may be necessary for OM2's parallel reading, but isn't required for ESM1.6. A side effect is that for ESM1.6, the input files get archived to the output directory for each run:

```
> ls archive/output000/ice
cice_in.nml    ice_diag.d    iceh.1843-01.nc  iceout086  iceout088  iceout090  iceout092  iceout094  iceout096  input_ice.nml
debug.root.03  ice_diag_out  iceout085        iceout087  iceout089  iceout091  iceout093  iceout095  INPUT
```

This PR switches off the `copy_inputs` flag for CICE5 in ESM1.6. With the changes, the driver symlinks to the CICE5 inputs when making the work directory, and the inputs are no longer archived to the output directory:

```
> ls archive/output000/ice
cice_in.nml    ice_diag.d    iceh.1843-01.nc  iceout086  iceout088  iceout090  iceout092  iceout094  iceout096
debug.root.03  ice_diag_out  iceout085        iceout087  iceout089  iceout091  iceout093  iceout095  input_ice.nml
```

Answers don't change with this update:
```
>  nccmp -dgf cice-copy-control/archive/output000/ice/iceh.1843-01.nc cice-nocopy/archive/output000/ice/iceh.1843-01.nc 


```
