### PR TITLE
Disable InsecureRequestWarnings for telemetry requests 

### DIFF
--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -12,6 +12,7 @@ import shutil
 import tempfile
 import threading
 from typing import Any, Optional
+import urllib3
 import warnings
 
 import cftime
@@ -36,6 +37,8 @@ REQUEST_TIMEOUT = 10
 
 TELEMETRY_VERSION = "1.0.0"
 
+# Disable warnings about unverified HTTPS requests
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 def get_metadata(metadata: Metadata) -> Optional[dict[str, Any]]:
     """Returns a dictionary of the experiment metadata to record"""


### PR DESCRIPTION
For telemetry we are using a persistent session on Gadi to forward post requests to the ACCESS-NRI services django instance. With the current setup, it requires `verify=False` to be set in `request.post()` to the persistent session, however this raises a warning:

```
</path/to/env>/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host '<persistent-session-name>.ps.gadi.nci.org.au'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
```

A fix to this with persistent session sending the correct host might be complicated, or not quite possible on NCI (see https://unix.stackexchange.com/questions/426542/how-to-make-ssh-port-fowarding-for-https)



