### PR TITLE
Only copy cice_in to restart when using CICE4

### DIFF
--- a/payu/models/access_esm1p6.py
+++ b/payu/models/access_esm1p6.py
@@ -260,6 +260,7 @@ class AccessEsm1p6(Model):
                     if os.path.exists(f_src):
                         shutil.move(f_src, f_dst)
 
+            if model.model_type == 'cice':
                 # Copy "cice_in.nml" from work path to restart.
                 work_ice_nml_path = os.path.join(
                                         model.work_path,
@@ -273,7 +274,6 @@ class AccessEsm1p6(Model):
                 if os.path.exists(work_ice_nml_path):
                     shutil.copy2(work_ice_nml_path, restart_ice_nml_path)
 
-            if model.model_type == 'cice':
                 # Write the simulation end date to the restart date
                 # namelist.
 


### PR DESCRIPTION
Closes #643

This PR modifies the `access_esm1p6` driver so that it does not copy the `cice_in.nml` file to the restart directory when using CICE5. Behaviour with CICE4 is unchanged.


To test that there aren't any unintended effects, I've run 12 consecutive 1 month segments with and without the changes. Model outputs are identical according to the following:
```
(dev-payu-env) [sw6175@gadi-login-01 payu_cice_in]$ nccmp -dgf base/archive/output011/ice/iceh-1monthly-mean_2145-12.nc no_cice_in/archive/output011/ice/iceh-1monthly-mean_2145-12.nc 
(dev-payu-env) [sw6175@gadi-login-01 payu_cice_in]$ nccmp -dgf base/archive/output011/ice/iceh-1daily-mean_2145-12.nc no_cice_in/archive/output011/ice/iceh-1daily-mean_2145-12.nc
```