### PR TITLE
payu sync: Default exclude_uncollated to false

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -463,7 +463,7 @@ User Processing
             - 'iceh.????-??-??.nc'
             - '*-IN-PROGRESS'
 
-   ``exclude_uncollated`` (*Default:* ``True`` if collation is enabled)
+   ``exclude_uncollated`` (*Default:* ``False``)
       Flag to exclude uncollated files from being synced. This is equivalent 
       to adding ``--exclude *.nc.*``.
 

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -159,20 +159,12 @@ class SyncToRemoteArchive():
 
         excludes = ' '.join(['--exclude ' + pattern for pattern in exclude])
 
-        # Default to exclude uncollated files if collation is enabled
-        # This can be over-riden using exclude_uncollated config flag
-        exclude_uncollated = self.config.get('exclude_uncollated', None)
-
-        if exclude_uncollated is None:
-            collate_config = self.expt.config.get('collate', {})
-            collating = collate_config.get('enable', True)
-            if collating:
-                exclude_uncollated = True
-
+        # Default to not exclude uncollated files
+        exclude_uncollated = self.config.get('exclude_uncollated', False)
         exclude_flag = "--exclude *.nc.*"
         if (exclude_uncollated and exclude_flag not in excludes
                 and exclude_flag not in self.config.get('rsync_flags', [])):
-            excludes += " --exclude *.nc.*"
+            excludes += f" {exclude_flag}" if excludes != "" else exclude_flag
 
         self.excludes = excludes
 

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -217,31 +217,45 @@ def test_set_destination_path():
                 "sync": {
                     "exclude": ["iceh.????-??-??.nc", "*-DEPRECATED"]
                 },
-                "collate": {
-                    "enable": True
-                }
-            }, ("--exclude iceh.????-??-??.nc --exclude *-DEPRECATED"
-                " --exclude *.nc.*")
+            }, ("--exclude iceh.????-??-??.nc --exclude *-DEPRECATED")
         ),
         (
             {
                 "sync": {
                     "exclude_uncollated": False
                 },
-                "collate": {
-                    "enable": True
-                }
             }, ""
         ),
         (
             {
                 "sync": {
-                    "exclude": "*-DEPRECATED"
+                    "exclude_uncollated": True,
                 },
-                "collate": {
-                    "enable": False
-                }
-            }, "--exclude *-DEPRECATED"
+            }, "--exclude *.nc.*"
+        ),
+        (
+            {
+                "sync": {
+                    "exclude_uncollated": True,
+                    "exclude": ["iceh.????-??-??.nc"]
+                },
+            }, "--exclude iceh.????-??-??.nc --exclude *.nc.*"
+        ),
+        (
+            {
+                "sync": {
+                    "exclude_uncollated": True,
+                    "exclude": ["iceh.????-??-??.nc", "*.nc.*"]
+                },
+            }, "--exclude iceh.????-??-??.nc --exclude *.nc.*"
+        ),
+        (
+            {
+                "sync": {
+                    "rsync_flags": ["--exclude *.nc.*"],
+                    "exclude_uncollated": True,
+                },
+            }, ""
         )
     ])
 def test_set_excludes_flags(add_config, expected_excludes):
@@ -307,8 +321,8 @@ def test_sync():
     # Check nested output dirs are synced
     assert os.path.exists(os.path.join(remote_archive, nested_output_dirs))
 
-    # Check that uncollated files are not synced by default
-    assert not os.path.exists(os.path.join(remote_archive, uncollated_file))
+    # Check that uncollated files are also synced by default
+    assert os.path.exists(os.path.join(remote_archive, uncollated_file))
     assert os.path.exists(os.path.join(remote_archive, collated_file))
 
     # Check synced file still exist locally


### PR DESCRIPTION
This PR changes the default setting of sync to `exclude_uncollated` files to always False. 

See related issue #648