### PR TITLE
Ensure status file are group-readable

### DIFF
--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -6,6 +6,7 @@ this data to telemetry services at the end of a run, if configured.
 import datetime
 import json
 import os
+import stat
 from pathlib import Path
 import requests
 import shutil
@@ -313,8 +314,8 @@ def atomic_write_file(
         temp_name = temp_file.name
     os.replace(temp_name, file_path)
 
-    # Ensure group has read permissions
-    os.chmod(file_path, 0o640)
+    # Ensure status file has same permissions as parent directory
+    os.chmod(file_path, stat.S_IMODE(file_path.parent.stat().st_mode))
 
 
 def get_job_file_path_with_id(


### PR DESCRIPTION
Closes #652 by adding a small patch to `atomic_write_file` in telemetry.py. This ensures files are consistently created with `-rw-r-----` permissions.