### PR TITLE
Handle null error when userscripts is empty

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -135,7 +135,8 @@ class Experiment(object):
 
         # Miscellaneous configurations
         # TODO: Move this stuff somewhere else
-        self.userscripts = self.config.get('userscripts', {})
+        userscript_val = self.config.get('userscripts', {})
+        self.userscripts = userscript_val if isinstance(userscript_val, dict) else {}
 
         self.profilers = []
 

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -421,3 +421,10 @@ def test_setup_telemetry_file(tmp_path):
         data = json.load(f)
     assert data['stage'] == 'setup'
     assert data['payu_current_run'] == 0
+
+def test_null_userscripts():
+    '''Test when userscripts is set to null in config.yaml'''
+    config_orig_null = copy.deepcopy(config_orig)
+    config_orig_null['userscripts'] = None
+    expt = init_experiment(config_orig_null)
+    assert expt.userscripts == {}


### PR DESCRIPTION
When `userscripts` in `config.yml` is empty, `payu` will assign an empty dictionary `{}` to `userscripts`.
***Closes #602 ***

We tested the updated code by setting 
```
config[userscripts] = None
```
, and pytest assert
```
expt.userscripts = {}
```
.