### PR TITLE
Removed build_path and build_exec_path.

### DIFF
--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -61,8 +61,6 @@ class Cice(Model):
     def set_model_pathnames(self):
         super(Cice, self).set_model_pathnames()
 
-        self.build_exec_path = os.path.join(self.codebase_path,
-                                            'build_access-om_360x300_6p')
 
         ice_nml_path = os.path.join(self.control_path, self.ice_nml_fname)
         self.ice_in = f90nml.read(ice_nml_path)

--- a/payu/models/mom.py
+++ b/payu/models/mom.py
@@ -43,9 +43,6 @@ class Mom(MomMixin, Fms):
     def set_model_pathnames(self):
         super(Mom, self).set_model_pathnames()
 
-        self.build_exec_path = os.path.join(self.codebase_path, 'exec', 'nci',
-                                            'MOM_SIS')
-        self.build_path = os.path.join(self.codebase_path, 'exp')
 
 
     def setup(self):


### PR DESCRIPTION
Removed `build_path` and `build_exec_path` from `cice.py` and `mom.py`.