### PR TITLE
Fix links on Payu Installation page

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -14,7 +14,7 @@ NCI Users
 Payu is made available for users of NCI HPC systems in `conda` environments.
 
 The ACCESS-Hive `ACCESS-OM models`_ documentation contains instructions for
-using ACCESS-NRI supported conda environments.
+using ACCESS-NRI supported Payu environments.
 
 Local installation
 ------------------
@@ -66,5 +66,5 @@ you are interested in porting payu to your machine.
 .. _`MPI`: http://en.wikipedia.org/wiki/Message_Passing_Interface
 .. _`GitHub Issue`: https://github.com/payu-org/payu/issues
 .. _`pip`: https://pip.pypa.io/en/stable/cli/pip_install
-.. _`ACCESS-OM models`: https://access-hive.org.au/models/run-a-model/run-access-om/#model-specific-prerequisites
+.. _`ACCESS-OM models`: https://docs.access-hive.org.au/models/run_a_model/run_access-om2/#prerequisites
 .. _`conda environments`: https://github.com/coecms/access-esm#quickstart-guide


### PR DESCRIPTION
Fixes #674. 

- [x] Fix broken ACCESS-OM Models link on the installation page.
- [x] Remove CLEX links from installation page.
- [x] Change the text from `supported conda environments` to `supported payu environments`.
