### PR TITLE
Improve handling hidden files and directories in manifests.

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -275,7 +275,7 @@ section for details.
       ``restart`` (*Default: global reproduce flag*)
             Enforce restart file reproducibility.
 
-``ignore`` (*Default: [.\*]*):
+``ignore`` (*Default:* ``[.*]``):
       List of ``glob`` patterns which match files to ignore when scanning input directories.
       A file will be ignored if any part of its full path matches one of the patterns.
       This is an array, so multiple patterns can be specified on multiple lines. 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -275,17 +275,18 @@ section for details.
       ``restart`` (*Default: global reproduce flag*)
             Enforce restart file reproducibility.
 
-``ignore`` (*Default: .*):
+``ignore`` (*Default: [.\*]*):
       List of ``glob`` patterns which match files to ignore when scanning input
       directories. This is an array, so multiple patterns can be specified on
-      multiple lines. The default is .** which ignores all hidden files on a
-      POSIX filesystem. To include hidden files, set this option to an empty.
-``ignore_path`` (*Default: */.*):
+      multiple lines. 
+      The default is .** which ignores all hidden files on a POSIX filesystem. 
+      To include hidden files, set this option to an empty list ``[]``.
+``ignore_path`` (*Default: [*/.\*]*):
       List of ``glob`` patterns which match directories to ignore when
       scanning input. This is an array, so multiple patterns can be
-      specified on multiple lines. The default is ***/.** which ignores all
-      hidden directories on a POSIX filesystem. To include hidden directories,
-      set this option to an empty.
+      specified on multiple lines. 
+      The default is ***/.** which ignores all hidden directories on a POSIX filesystem. 
+      To include hidden directories, set this option to an empty list ``[]``.
 
 
 Archiving

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -276,18 +276,11 @@ section for details.
             Enforce restart file reproducibility.
 
 ``ignore`` (*Default: [.\*]*):
-      List of ``glob`` patterns which match files to ignore when scanning input
-      directories. This is an array, so multiple patterns can be specified on
-      multiple lines. 
-      The default is .** which ignores all hidden files on a POSIX filesystem. 
-      To include hidden files, set this option to an empty list ``[]``.
-``ignore_path`` (*Default: [*/.\*]*):
-      List of ``glob`` patterns which match directories to ignore when
-      scanning input. This is an array, so multiple patterns can be
-      specified on multiple lines. 
-      The default is ***/.** which ignores all hidden directories on a POSIX filesystem. 
-      To include hidden directories, set this option to an empty list ``[]``.
-
+      List of ``glob`` patterns which match files to ignore when scanning input directories.
+      A file will be ignored if any part of its full path matches one of the patterns.
+      This is an array, so multiple patterns can be specified on multiple lines. 
+      The default is .** which ignores all hidden files and directories on a POSIX filesystem. 
+      To include hidden files and directories, set this option to an empty list ``[]``.
 
 Archiving
 ---------

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -275,11 +275,17 @@ section for details.
       ``restart`` (*Default: global reproduce flag*)
             Enforce restart file reproducibility.
 
-``ignore`` (*Default: .\**):
+``ignore`` (*Default: .*):
       List of ``glob`` patterns which match files to ignore when scanning input
       directories. This is an array, so multiple patterns can be specified on
-      multiple lines. The default is *.\** which ignores all hidden files on a
-      POSIX filesystem.
+      multiple lines. The default is .** which ignores all hidden files on a
+      POSIX filesystem. To include hidden files, set this option to an empty.
+``ignore_path`` (*Default: */.*):
+      List of ``glob`` patterns which match directories to ignore when
+      scanning input. This is an array, so multiple patterns can be
+      specified on multiple lines. The default is ***/.** which ignores all
+      hidden directories on a POSIX filesystem. To include hidden directories,
+      set this option to an empty.
 
 
 Archiving

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -135,15 +135,15 @@ class PayuManifest(YaManifest):
         if os.path.isdir(fullpath):
             return False
 
-        # If ignore config is not set to None, apply ignore patterns
-        if self.ignore is not None:
+        # If ignore config is not set to [], apply ignore patterns
+        if len(self.ignore) > 0:
             # Ignore anything matching the ignore patterns
             for pattern in self.ignore:
                 if fnmatch.fnmatch(os.path.basename(fullpath), pattern):
                     return False
         
-        # If ignore_path config is not set to None, apply ignore_path patterns
-        if self.ignore_path is not None:
+        # If ignore_path config is not set to [], apply ignore_path patterns
+        if len(self.ignore_path) > 0:
             for pattern in self.ignore_path:
                 if fnmatch.fnmatch(os.path.dirname(fullpath), pattern):
                     return False
@@ -260,17 +260,24 @@ class Manifest(object):
         if isinstance(self.ignore_path, str):
             self.ignore_path = [self.ignore_path]
 
-        # warn if ignore patterns are set to None
+        # Warn if ignore patterns are set to None
+        # And set to default patterns
         if self.ignore is None:
-            print("Warning: Manifest `ignore` pattern is left empty. \n"
-                  "All files (including hidden files) will be included!!!\n"
-                  "If you intended to ignore hidden files (default), \n"
-                  "please delete the `ignore` config entry.")
+            self.ignore = ['.*']
+            print("Warning: Manifest `ignore` pattern is set to NULL. \n"
+                  "Using default ignore pattern to ignore hidden files.\n")
         if self.ignore_path is None:
-            print("Warning: Manifest `ignore_path` pattern is left empty. \n"
-                  "All directories (including hidden directories) will be included!!!\n"
-                  "If you intended to ignore hidden directories (default), \n"
-                  "please delete the `ignore_path` config entry.")
+            self.ignore_path = ['*/.*']
+            print("Warning: Manifest `ignore_path` pattern is set to NULL. \n"
+                  "Using default ignore_path pattern to ignore hidden directories.\n")
+        
+        # Warn if ignore patterns are empty lists
+        if len(self.ignore) == 0:
+            print("Warning: Manifest `ignore` pattern is set to an empty list. \n"
+                  "All files (including hidden files) will be included!!!\n")
+        if len(self.ignore_path) == 0:
+            print("Warning: Manifest `ignore_path` pattern is set to an empty list. \n"
+                  "All directories (including hidden directories) will be included!!!\n")
 
         # Initialise manifests and reproduce flags
         self.manifests = {}

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -27,6 +27,16 @@ fast_hashes = ['binhash']
 full_hashes = ['md5']
 all_hashes = fast_hashes + full_hashes
 
+def path_full_match(fullpath, ignore_patterns):
+    """
+    Iteratively check if ignore patterns match filepath. If any pattern matches, return True.
+    """
+    for pattern in ignore_patterns:
+        # Check each part of the filepath against the pattern
+        for p in Path(fullpath).parts:  
+            if Path(p).match(pattern):
+                return True
+    return False
 
 class PayuManifest(YaManifest):
     """
@@ -121,16 +131,6 @@ class PayuManifest(YaManifest):
 
             sys.exit(1)
 
-    def path_full_match(self, fullpath, ignore_patterns):
-        """
-        Recursively check if ignore patterns match filepath. If any pattern matches, return True.
-        """
-        for pattern in ignore_patterns:
-            # Check each part of the filepath against the pattern
-            for p in Path(fullpath).parts:  
-                if Path(p).match(pattern):
-                    return True
-        return False
 
     def add_filepath(self, filepath, fullpath, hashes, copy=False):
         """
@@ -144,8 +144,8 @@ class PayuManifest(YaManifest):
         if os.path.isdir(fullpath):
             return False
 
-        # Recursively check if ignore patterns match any part in fullpath
-        if self.path_full_match(fullpath, self.ignore):
+        # Iteratively check if ignore patterns match any part in fullpath
+        if path_full_match(fullpath, self.ignore):
             return False
 
         if filepath not in self.data:

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -15,6 +15,7 @@ import os
 import sys
 import shutil
 import stat
+from pathlib import Path
 
 from yamanifest.manifest import Manifest as YaManifest
 
@@ -34,7 +35,6 @@ class PayuManifest(YaManifest):
     """
     def __init__(self, path,
                  ignore=None,
-                 ignore_path=None,
                  fast_hashes=fast_hashes,
                  full_hashes=full_hashes,
                  **kwargs):
@@ -46,7 +46,6 @@ class PayuManifest(YaManifest):
         self.full_hashes = full_hashes
 
         self.ignore = ignore
-        self.ignore_path = ignore_path
 
     def calculate_fast(self, previous_manifest):
         """
@@ -122,6 +121,16 @@ class PayuManifest(YaManifest):
 
             sys.exit(1)
 
+    def path_full_match(self, fullpath, ignore_patterns):
+        """
+        Recursively check if ignore patterns match filepath. If any pattern matches, return True.
+        """
+        for pattern in ignore_patterns:
+            # Check each part of the filepath against the pattern
+            for p in Path(fullpath).parts:  
+                if Path(p).match(pattern):
+                    return True
+        return False
 
     def add_filepath(self, filepath, fullpath, hashes, copy=False):
         """
@@ -135,18 +144,9 @@ class PayuManifest(YaManifest):
         if os.path.isdir(fullpath):
             return False
 
-        # If ignore config is not set to [], apply ignore patterns
-        if len(self.ignore) > 0:
-            # Ignore anything matching the ignore patterns
-            for pattern in self.ignore:
-                if fnmatch.fnmatch(os.path.basename(fullpath), pattern):
-                    return False
-        
-        # If ignore_path config is not set to [], apply ignore_path patterns
-        if len(self.ignore_path) > 0:
-            for pattern in self.ignore_path:
-                if fnmatch.fnmatch(os.path.dirname(fullpath), pattern):
-                    return False
+        # Recursively check if ignore patterns match any part in fullpath
+        if self.path_full_match(fullpath, self.ignore):
+            return False
 
         if filepath not in self.data:
             self.data[filepath] = {}
@@ -254,11 +254,8 @@ class Manifest(object):
             self.full_hashes = [self.full_hashes, ]
 
         self.ignore = self.manifest_config.get('ignore', ['.*'])
-        self.ignore_path = self.manifest_config.get('ignore_path', ['*/.*'])
         if isinstance(self.ignore, str):
             self.ignore = [self.ignore]
-        if isinstance(self.ignore_path, str):
-            self.ignore_path = [self.ignore_path]
 
         # Warn if ignore patterns are set to None
         # And set to default patterns
@@ -266,18 +263,11 @@ class Manifest(object):
             self.ignore = ['.*']
             print("Warning: Manifest `ignore` pattern is set to NULL. \n"
                   "Using default ignore pattern to ignore hidden files.\n")
-        if self.ignore_path is None:
-            self.ignore_path = ['*/.*']
-            print("Warning: Manifest `ignore_path` pattern is set to NULL. \n"
-                  "Using default ignore_path pattern to ignore hidden directories.\n")
         
         # Warn if ignore patterns are empty lists
         if len(self.ignore) == 0:
             print("Warning: Manifest `ignore` pattern is set to an empty list. \n"
                   "All files (including hidden files) will be included!!!\n")
-        if len(self.ignore_path) == 0:
-            print("Warning: Manifest `ignore_path` pattern is set to an empty list. \n"
-                  "All directories (including hidden directories) will be included!!!\n")
 
         # Initialise manifests and reproduce flags
         self.manifests = {}
@@ -296,7 +286,6 @@ class Manifest(object):
         self.manifests[mf] = PayuManifest(
             os.path.join('manifests', '{}.yaml'.format(mf)),
             ignore=self.ignore,
-            ignore_path=self.ignore_path,
             fast_hashes=self.fast_hashes,
             full_hashes=self.full_hashes
         )
@@ -305,7 +294,6 @@ class Manifest(object):
         self.previous_manifests[mf] = PayuManifest(
             os.path.join('manifests', '{}.yaml'.format(mf)),
             ignore=self.ignore,
-            ignore_path=self.ignore_path,
             fast_hashes=self.fast_hashes,
             full_hashes=self.full_hashes
         )

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from payu.fsops import mkdir_p, list_archive_dirs
 from payu.metadata import METADATA_FILENAME, UUID_FIELD
 
-DEST_NOT_CONFIGURED_MSG = DEST_NOT_CONFIGURED_MSG = """
+DEST_NOT_CONFIGURED_MSG ="""
 There's is no configured `base_path` or `path` to sync output to.
 In config.yaml, set either the `base_path` or `path`:
     sync:

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -547,9 +547,17 @@ def test_path_full_match():
     assert(path_full_match(tmpdir/'.hidden_file', ['.*']) == True)
     assert(path_full_match(tmpdir/'visible_file', ['.*']) == False)
     assert(path_full_match(tmpdir/'.hidden_dir/visible_file', ['.*']) == True)
+    assert(path_full_match(tmpdir/'test.nc', ['.*']) == False)
     
     # Test with custom pattern, should match files and directories with pattern but not those without
     assert(path_full_match(tmpdir/'pattern_test_004', ['pattern_*']) == True)
     assert(path_full_match(tmpdir/'test_002', ['pattern_*']) == False)
     assert(path_full_match(tmpdir/'pattern_dir/test_005', ['pattern_*']) == True)
+    
+    #Test with multiple patterns
+    assert(path_full_match(tmpdir/'pattern_test_004', ['pattern_*', '.*']) == True)
+    assert(path_full_match(tmpdir/'pattern_dir/test_005', ['pattern_*', '.*']) == True)
+    assert(path_full_match(tmpdir/'.hidden_file', ['pattern_*', '.*']) == True)
+    assert(path_full_match(tmpdir/'visible_file', ['pattern_*', '.*']) == False)
+    assert(path_full_match(tmpdir/'pattern_dir/.hidden_file', ['pattern_*', '.*']) == True)
     


### PR DESCRIPTION
Hidden files and directories are in default set to be ignored. 
Users **do not need to include** `ignore` or `ignore_path` entry in `manifest` of `config.yaml`.

If users would like to include the hidden files (directories), users can add
```
ignore:
ignore_path:
```
and leave them empty in `manifest` section of `config.yaml`.

Users can also customize their ignore pattern through 
```
ignore: 
    - <custom1>
    - <custom2>
ignore_path:
    - <custom_path1>
    - <custom_path2>
```
Closes #377 