### PR TITLE
Add description of post-processing PBS jobs.

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -369,6 +369,8 @@ FMS based model only options:
    is then ``ncpus / nthreads``
 
 
+.. _User_processing:
+
 User Processing
 --------------
 

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -85,8 +85,9 @@ postscript
 sync
    When enabled, payu syncs the archive directory with a specificed remote directory.
    Payu sync job is submitted after the collate job is completed successfully, if collate is enabled.
-   Currently, payu sync does not sync the latest output if postscript is configured, 
-   because postscript and sync jobs are submitted at the same time.
+   Currently, ``postscript`` and ``sync`` jobs are submitted at the same time.
+   As a result, ``payu sync`` does not wait for the postscript job to complete, 
+   and does not sync the most recent ``output`` directory (see :ref:`Postprocessing` and :ref:`User_processing`).
 
 Style Guide
 ===========

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -352,6 +352,7 @@ use it with caution.
 Hard sweeps will only delete the run output for your particular experiment.
 Other experiment runs will not be harmed by this command.
 
+.. _Postprocessing:
 
 Postprocessing
 ==============


### PR DESCRIPTION
After [`Experiment Steps`](https://github.com/payu-org/payu/blob/master/docs/source/design.rst#experiment-steps) in docs, add descriptions of `Post-processing PBS Jobs`, including `collate` and `sync` steps.
Swap `error` and `archive` paragraph in [`userscripts`](https://payu.readthedocs.io/en/stable/config.html#user-processing) .
Closes #653 