### PR TITLE
Specify postscript PBS job as payu_postscript.

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -416,8 +416,10 @@ User Processing
 ``postscript``
    This is an older, less user-friendly, method to submit a script after ``payu`` 
    has completed all steps that might alter the output directory. e.g. collation.
-   Unlike the ``userscripts``, it does not support user commands. These scripts 
-   are always re-submitted via ``qsub``.
+   Unlike the ``userscripts``, it does not support user commands. 
+   These scripts are always re-submitted via ``qsub``. 
+   Payu sets the job name to ``payu_postscript`` using the ``-N`` option in the command line, 
+   which overrides any job name specified in the PBS script.
 
 ``sync`` 
    Sync archive to a remote directory using rsync. Make sure that the 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -980,7 +980,8 @@ class Experiment(object):
             envmod.setup()
             envmod.module('load', 'pbs')
 
-            cmd = 'qsub {script}'.format(script=self.postscript)
+            # Name of this PBS job is set to "payu_postscript"
+            cmd = 'qsub -N payu_postscript {script}'.format(script=self.postscript)
 
             if needs_subprocess_shell(cmd):
                 sp.check_call(cmd, shell=True)
@@ -1063,6 +1064,9 @@ class Experiment(object):
         log_filenames = [short_job_name + '.o', short_job_name + '.e']
         for postfix in ['_c.o', '_c.e', '_p.o', '_p.e', '_s.o', '_s.e']:
             log_filenames.append(short_job_name[:13] + postfix)
+            
+        if self.postscript:
+            log_filenames.extend(['payu_postscript.o', 'payu_postscript.e'])
 
         logs = [
             f for f in os.listdir(os.curdir) if os.path.isfile(f) and (


### PR DESCRIPTION
**Summary**
This PR standardises the PBS job name for user's `postscript` to `payu_postscript`, ensuring that `payu sweep` clean up postscript log files.

**Background**
Previously, payu submitted a separate PBS job for the user’s `postscript` using the name of the `.sh` file. For example, when using `test_postscript.sh`, the generated logs were:
```
double_gyre.e16xxxx073  double_gyre.o16xxxx073  
test_postscript.sh.e16xxxx174  test_postscript.sh.o16xxxx174
```
In this case, `payu sweep` only clean up the main job logs:
```
Moving log double_gyre.o16xxxx073
Moving log double_gyre.e16xxxx073
```
Postscript logs (`test_postscript.sh.*16xxxx174`) remained in the control directory.

**Changes**
Payu now submits postscript jobs with the fixed name `payu_postscript`, generating log files as:
```
double_gyre.e16xxxx073  double_gyre.o16xxxx073 
payu_postscript.o16xxxx174  payu_postscript.e16xxxx174 
```
`payu sweep` clean up postscript logs, along with the main job logs.
```
Moving log double_gyre.o16xxxx073
Moving log double_gyre.e16xxxx073
Moving log payu_postscript.o16xxxx174
Moving log payu_postscript.e16xxxx174 
```

**Testing**
A user-defined postscript (`test_postscript.sh`) was ran with `payu run`.
`test_postscript.sh` ran successfully.
Log files named as `payu_postscript.e*` and `payu_postscript.o*` were found.
`payu sweep` removes both main job and postscript log files.

Closes #628 