### PR TITLE
Fix missing walltime limit for 4160-core normalsr run

### DIFF
--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -70,6 +70,7 @@ class PBS(Scheduler):
         "normalsr": [
             (1040, 48),
             (2080, 24),
+            (4160, 10),
             (10400, 5),
         ],
         "expresssr": [


### PR DESCRIPTION
In #675, the 4160 core normalsr case is missing a 10-hour walltime limit.

This patch corrects that config.