### PR TITLE
Remove .coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-relative_files = True

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -175,7 +175,7 @@ configuration.
 ``exe_prefix``
    Optional string that is added immediately before the model executable in the
    MPI run command. It appears after `mpirun` and any MPI related flags, for
-    example, `mpirun <mpi-flags> <exe_prefix> <model-exe>`.
+   example, `mpirun <mpi-flags> <exe_prefix> <model-exe>`.
    This can be useful for configuring profilers or valgrind.
 
 ``submodels``


### PR DESCRIPTION
Remove `.coveragerc` file since it gets priority over the `pyproject.toml`. 
The ultimate goal is to make CodeCov ignore `_version.py`.