### PR TITLE
Increase pbsnode timeout limit for _run_pbsnodes_json

### DIFF
--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -22,7 +22,8 @@ import payu.envmod as envmod
 from payu.fsops import check_exe_path
 from payu.manifest import Manifest
 from payu.schedulers.scheduler import Scheduler
-from payu.telemetry import REQUEST_TIMEOUT
+
+PBSNODE_TIMEOUT = 60
 
 
 def _run_pbsnodes_json(timeout: int) -> Dict[str, Any]:
@@ -180,7 +181,7 @@ class PBS(Scheduler):
         """
         tag = cls.QUEUE_MAPS.get(queue)
         # collect all node information from pbsnodes
-        data = _run_pbsnodes_json(timeout=REQUEST_TIMEOUT)
+        data = _run_pbsnodes_json(timeout=PBSNODE_TIMEOUT)
 
         ncpus, mem = [], []
         for node in data["nodes"].values():


### PR DESCRIPTION
Ref: https://github.com/payu-org/payu/issues/688#issuecomment-3894747587

Increase the timeout as an initial fix for repro errors: 

`Unable to collect pbs node info: command timed out after 10 seconds`