### PR TITLE
Fix pbsnodes timeout by introducing cached pbsnodes.json file

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -116,11 +116,7 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     if 'PAYU_PBSNODES_CACHE' in os.environ:
         payu_env_vars['PAYU_PBSNODES_CACHE'] = os.environ['PAYU_PBSNODES_CACHE']
     elif 'XDG_CACHE_HOME' in os.environ:
-        payu_env_vars['PAYU_PBSNODES_CACHE'] = os.path.join(os.environ["XDG_CACHE_HOME"], "pbs", "pbsnodes.json")
-    else:
-        home_dir = os.path.join(os.environ["HOME"])
-        payu_env_vars['PAYU_PBSNODES_CACHE'] = os.path.join(home_dir, "pbs", "pbsnodes.json")
-
+        payu_env_vars['XDG_CACHE_HOME'] = os.environ["XDG_CACHE_HOME"]
 
     # Set (or import) the path to the PAYU scripts (PAYU_PATH)
     # NOTE: We may be able to use sys.path[0] here.

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -111,6 +111,16 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
 
     if 'PYTHONPATH' in os.environ:
         payu_env_vars['PYTHONPATH'] = os.environ['PYTHONPATH']
+    
+    # Pass through the PBS nodes cache path if it exists
+    if 'PAYU_PBSNODES_CACHE' in os.environ:
+        payu_env_vars['PAYU_PBSNODES_CACHE'] = os.environ['PAYU_PBSNODES_CACHE']
+    elif 'XDG_CACHE_HOME' in os.environ:
+        payu_env_vars['PAYU_PBSNODES_CACHE'] = os.path.join(os.environ["XDG_CACHE_HOME"], "pbs", "pbsnodes.json")
+    else:
+        home_dir = os.path.join(os.environ["HOME"])
+        payu_env_vars['PAYU_PBSNODES_CACHE'] = os.path.join(home_dir, "pbs", "pbsnodes.json")
+
 
     # Set (or import) the path to the PAYU scripts (PAYU_PATH)
     # NOTE: We may be able to use sys.path[0] here.

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -16,7 +16,10 @@ import shutil
 import sys
 import shlex
 import subprocess
-from typing import Union, List
+from typing import Union, List, Any
+import tempfile
+import json
+import stat
 import warnings
 
 # Extensions
@@ -262,6 +265,24 @@ def list_archive_dirs(archive_path: Union[Path, str],
 
     dirs.sort(key=lambda d: int(d.lstrip(dir_type)))
     return dirs
+
+
+def atomic_write_file(
+            file_path: Path,
+            data: dict[str, Any],
+        ) -> None:
+    """Write the job information to a temporary file and
+    replace the existing if it exists so the update is atomic"""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode='w', dir=file_path.parent, delete=False
+    ) as temp_file:
+        json.dump(data, temp_file, ensure_ascii=False, indent=4)
+        temp_name = temp_file.name
+    os.replace(temp_name, file_path)
+
+    # Ensure status file has same permissions as parent directory
+    os.chmod(file_path, stat.S_IMODE(file_path.parent.stat().st_mode))
 
 
 def run_script_command(script_cmd: str, control_path: Path) -> None:

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -26,6 +26,21 @@ from payu.schedulers.scheduler import Scheduler
 
 PBSNODE_TIMEOUT = 60
 
+def get_pbsnodes_cache_path() -> Path:
+    """Get the path of pbsnodes.json cache file, 
+    If not set, then use default cache path."""
+
+    env_path = os.environ.get("PAYU_PBSNODES_CACHE")
+    if env_path:
+        return Path(env_path)
+    else:
+        xdg_cache = os.environ.get('XDG_CACHE_HOME')
+        if xdg_cache:
+            return Path(xdg_cache) / "pbs" / "pbsnodes.json"
+        else:
+            home_dir = os.environ.get("HOME")
+            return Path(home_dir) / ".cache" / "pbs" / "pbsnodes.json"
+
 def check_pbsnode_file(pbsnodes_json_path):
     """ Check if pbsnodes.json file is recent (< 7 days) and rerun pbsnodes if not. """
     expire_day = 7
@@ -48,13 +63,17 @@ def check_pbsnode_file(pbsnodes_json_path):
     # If the file is not recent, rerun pbsnodes and update the file
     if not is_recent:
         new_pbsnodes_json = _run_pbsnodes_json(timeout=PBSNODE_TIMEOUT)
-        new_pbsnodes_json["timestamp"] = time.time()
-        with pbsnodes_json_path.open("w") as f:
-            json.dump(new_pbsnodes_json, f, indent=2)
+        try:
+            with pbsnodes_json_path.open("w") as f:
+                json.dump(new_pbsnodes_json, f, indent=2)
+        except IOError as e:
+            raise RuntimeError(f"Failed to write pbsnodes JSON to {pbsnodes_json_path}") from e
 
-def read_pbsnode_file(archive_path) -> Dict[str, Any]:
+def read_pbsnode_file() -> Dict[str, Any]:
     """ Read pbsnodes.json file and return the parsed JSON data. """ 
-    pbsnodes_json_path = Path(archive_path) / "payu_jobs" / "pbsnodes.json"
+    pbsnodes_json_path = get_pbsnodes_cache_path()
+    pbsnodes_json_path.parent.mkdir(parents=True, exist_ok=True)
+
     check_pbsnode_file(pbsnodes_json_path)
     try:
         with pbsnodes_json_path.open() as f:
@@ -214,13 +233,13 @@ class PBS(Scheduler):
         return int(s.replace("kb", "")) // (1024 * 1024)
 
     @classmethod
-    def get_queue_node_shape(cls, queue: str, archive_path: str) -> tuple[int, int]:
+    def get_queue_node_shape(cls, queue: str) -> tuple[int, int]:
         """
         Get the node shape (cpu count and memory) for a given queue.
         """
         tag = cls.QUEUE_MAPS.get(queue)
         # collect all node information from pbsnodes
-        data = read_pbsnode_file(archive_path)
+        data = read_pbsnode_file()
 
         ncpus, mem = [], []
         for node in data["nodes"].values():

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -17,6 +17,7 @@ from collections import Counter
 
 import json
 from tenacity import retry, stop_after_delay
+import time
 
 import payu.envmod as envmod
 from payu.fsops import check_exe_path
@@ -25,6 +26,44 @@ from payu.schedulers.scheduler import Scheduler
 
 PBSNODE_TIMEOUT = 60
 
+def check_pbsnode_file(pbsnodes_json_path):
+    """ Check if pbsnodes.json file is recent (< 7 days) and rerun pbsnodes if not. """
+    expire_day = 7
+    is_recent = False
+    
+    # Check if pbsnodes.json exists
+    if pbsnodes_json_path.exists():
+        try:
+            # Check if the file is recent (modified within the last 7 days)
+            with pbsnodes_json_path.open() as f:
+                pbsnodes_json = json.load(f)
+            timestamp = pbsnodes_json.get("timestamp", 0)
+
+            if timestamp > time.time() - expire_day*24*60*60:           
+                is_recent = True
+
+        except json.JSONDecodeError:
+            is_recent = False
+
+    # If the file is not recent, rerun pbsnodes and update the file
+    if not is_recent:
+        new_pbsnodes_json = _run_pbsnodes_json(timeout=PBSNODE_TIMEOUT)
+        new_pbsnodes_json["timestamp"] = time.time()
+        with pbsnodes_json_path.open("w") as f:
+            json.dump(new_pbsnodes_json, f, indent=2)
+
+def read_pbsnode_file(archive_path) -> Dict[str, Any]:
+    """ Read pbsnodes.json file and return the parsed JSON data. """ 
+    pbsnodes_json_path = Path(archive_path) / "payu_jobs" / "pbsnodes.json"
+    check_pbsnode_file(pbsnodes_json_path)
+    try:
+        with pbsnodes_json_path.open() as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"Failed to decode JSON from {pbsnodes_json_path} after timestamp checking."
+        ) from e
+        
 
 def _run_pbsnodes_json(timeout: int) -> Dict[str, Any]:
     """Run pbsnodes -a -F json and return parsed Json output."""
@@ -175,13 +214,13 @@ class PBS(Scheduler):
         return int(s.replace("kb", "")) // (1024 * 1024)
 
     @classmethod
-    def get_queue_node_shape(cls, queue: str) -> tuple[int, int]:
+    def get_queue_node_shape(cls, queue: str, archive_path: str) -> tuple[int, int]:
         """
         Get the node shape (cpu count and memory) for a given queue.
         """
         tag = cls.QUEUE_MAPS.get(queue)
         # collect all node information from pbsnodes
-        data = _run_pbsnodes_json(timeout=PBSNODE_TIMEOUT)
+        data = read_pbsnode_file(archive_path)
 
         ncpus, mem = [], []
         for node in data["nodes"].values():

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -17,14 +17,17 @@ from collections import Counter
 
 import json
 from tenacity import retry, stop_after_delay
-import time
+from datetime import datetime, timedelta
+from filelock import SoftFileLock, Timeout
 
 import payu.envmod as envmod
-from payu.fsops import check_exe_path
+from payu.fsops import check_exe_path, atomic_write_file
 from payu.manifest import Manifest
 from payu.schedulers.scheduler import Scheduler
 
 PBSNODE_TIMEOUT = 60
+LOCK_TIMEOUT = 5
+LOCK_LIFETIME = 8
 
 def get_pbsnodes_cache_path() -> Path:
     """Get the path of pbsnodes.json cache file, 
@@ -34,17 +37,13 @@ def get_pbsnodes_cache_path() -> Path:
     if env_path:
         return Path(env_path)
     else:
-        xdg_cache = os.environ.get('XDG_CACHE_HOME')
-        if xdg_cache:
-            return Path(xdg_cache) / "pbs" / "pbsnodes.json"
-        else:
-            home_dir = os.environ.get("HOME")
-            return Path(home_dir) / ".cache" / "pbs" / "pbsnodes.json"
+        cache_dir = os.environ.get('XDG_CACHE_HOME', Path.home() / ".cache")
+        return Path(cache_dir) / "pbs" / "pbsnodes.json"
 
 def check_pbsnode_file(pbsnodes_json_path):
     """ Check if pbsnodes.json file is recent (< 7 days) and rerun pbsnodes if not. """
     expire_day = 7
-    is_recent = False
+    refresh_cache_file = True
     
     # Check if pbsnodes.json exists
     if pbsnodes_json_path.exists():
@@ -52,28 +51,33 @@ def check_pbsnode_file(pbsnodes_json_path):
             # Check if the file is recent (modified within the last 7 days)
             with pbsnodes_json_path.open() as f:
                 pbsnodes_json = json.load(f)
-            timestamp = pbsnodes_json.get("timestamp", 0)
+            timestamp = datetime.fromtimestamp(pbsnodes_json.get("timestamp", 0))
 
-            if timestamp > time.time() - expire_day*24*60*60:           
-                is_recent = True
+            if (datetime.now() - timestamp) < timedelta(days=expire_day):
+                refresh_cache_file = False
 
         except json.JSONDecodeError:
-            is_recent = False
+            # Cache file is invalid, pass as it will be refreshed below
+            pass
 
-    # If the file is not recent, rerun pbsnodes and update the file
-    if not is_recent:
+    # If the cached file is not recent or doesn't exist, rerun pbsnodes and cache the result
+    if refresh_cache_file:   
         new_pbsnodes_json = _run_pbsnodes_json(timeout=PBSNODE_TIMEOUT)
+
+        pbsnodes_json_path.parent.mkdir(parents=True, exist_ok=True)
+        lock = SoftFileLock(str(pbsnodes_json_path) + ".lock", lifetime=LOCK_LIFETIME, timeout=LOCK_TIMEOUT)
         try:
-            with pbsnodes_json_path.open("w") as f:
-                json.dump(new_pbsnodes_json, f, indent=2)
-        except IOError as e:
-            raise RuntimeError(f"Failed to write pbsnodes JSON to {pbsnodes_json_path}") from e
+            with lock:
+                atomic_write_file(pbsnodes_json_path, new_pbsnodes_json)
+        except Timeout:
+            warnings.warn(f"Could not acquire lock to write pbsnodes cache file {pbsnodes_json_path}.\n"
+             f"Cache into {pbsnodes_json_path}.tmp instead.")
+            atomic_write_file(pbsnodes_json_path.with_suffix(".tmp"), new_pbsnodes_json)
+        
 
 def read_pbsnode_file() -> Dict[str, Any]:
     """ Read pbsnodes.json file and return the parsed JSON data. """ 
     pbsnodes_json_path = get_pbsnodes_cache_path()
-    pbsnodes_json_path.parent.mkdir(parents=True, exist_ok=True)
-
     check_pbsnode_file(pbsnodes_json_path)
     try:
         with pbsnodes_json_path.open() as f:

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -26,14 +26,14 @@ arguments = [args.model, args.config, args.initial, args.nruns,
 logger = logging.getLogger(__name__)
 
 
-def validate_platform_node(platform, queue, get_queue_node_shape, archive_path):
+def validate_platform_node(platform, queue, get_queue_node_shape):
     """
     Validate platform node setting against the queue node shape for the active scheduler.
     """
     if not platform:
         return
 
-    cpu, mem = get_queue_node_shape(queue, archive_path)
+    cpu, mem = get_queue_node_shape(queue)
 
     if platform.get("nodesize") != cpu:
         raise ValueError(
@@ -70,10 +70,10 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
     platform = pbs_config.get("platform", {})
 
     if expt.scheduler_name == 'pbs':
-        cpu_q, mem_q = PBS.get_queue_node_shape(queue, expt.archive_path)
+        cpu_q, mem_q = PBS.get_queue_node_shape(queue)
 
         if platform:
-            validate_platform_node(platform, queue, PBS.get_queue_node_shape, expt.archive_path)
+            validate_platform_node(platform, queue, PBS.get_queue_node_shape)
 
         max_cpus_per_node = platform.get("nodesize", cpu_q)
         max_ram_per_node = platform.get("nodemem", mem_q)

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -26,14 +26,14 @@ arguments = [args.model, args.config, args.initial, args.nruns,
 logger = logging.getLogger(__name__)
 
 
-def validate_platform_node(platform, queue, get_queue_node_shape):
+def validate_platform_node(platform, queue, get_queue_node_shape, archive_path):
     """
     Validate platform node setting against the queue node shape for the active scheduler.
     """
     if not platform:
         return
 
-    cpu, mem = get_queue_node_shape(queue)
+    cpu, mem = get_queue_node_shape(queue, archive_path)
 
     if platform.get("nodesize") != cpu:
         raise ValueError(
@@ -70,10 +70,10 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
     platform = pbs_config.get("platform", {})
 
     if expt.scheduler_name == 'pbs':
-        cpu_q, mem_q = PBS.get_queue_node_shape(queue)
+        cpu_q, mem_q = PBS.get_queue_node_shape(queue, expt.archive_path)
 
         if platform:
-            validate_platform_node(platform, queue, PBS.get_queue_node_shape)
+            validate_platform_node(platform, queue, PBS.get_queue_node_shape, expt.archive_path)
 
         max_cpus_per_node = platform.get("nodesize", cpu_q)
         max_ram_per_node = platform.get("nodemem", mem_q)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "packaging",
     "netCDF4",
     "jsonschema", 
-    "colorama"
+    "colorama",
+    "filelock"
 ]
 
 [project.optional-dependencies]

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -21,7 +21,7 @@ from payu.schedulers import index as scheduler_index
 from payu.schedulers.pbs import PBS
 
 from .common import cd, make_random_file, get_manifests
-from .common import tmpdir, ctrldir, labdir, workdir, payudir
+from .common import tmpdir, ctrldir, labdir, workdir, payudir, archive_dir
 from .common import sweep_work, payu_init, payu_setup
 from .common import config as original_config
 from .common import write_config
@@ -51,10 +51,10 @@ def test_get_queue_node_shape_picks_node_shape(monkeypatch):
         # Non-matching topology - should be ignored
         "node005": {"topology": "cpu-xyz", "ncpus": 12, "mem": "12582912KB"},  # 12GB
     })
+    
+    monkeypatch.setattr(pbs, "read_pbsnode_file", lambda timeout: payload)
 
-    monkeypatch.setattr(pbs, "_run_pbsnodes_json", lambda timeout: payload)
-
-    ncpus, mem = pbs.PBS.get_queue_node_shape("normal")
+    ncpus, mem = pbs.PBS.get_queue_node_shape("normal", str(archive_dir))
 
     assert ncpus == 48
     assert mem == 192
@@ -68,10 +68,52 @@ def test_get_queue_node_shape_no_matching_topology(monkeypatch):
         "node002": {"topology": "cpu-clx", "ncpus": 48, "mem": "201326592KB"},  # 192GB
     })
 
-    monkeypatch.setattr(pbs, "_run_pbsnodes_json", lambda timeout: payload)
+    monkeypatch.setattr(pbs, "read_pbsnode_file", lambda timeout: payload)
 
     with pytest.raises(ValueError, match=r"No nodes matched"):
-        pbs.PBS.get_queue_node_shape("normalsr")
+        pbs.PBS.get_queue_node_shape("normalsr", str(archive_dir))
+
+@pytest.mark.parametrize("file_exist, timestamp, expected_rerun",
+    [
+        (True, 0, 1),  # No timestamp
+        (True, 100, 1),  # Old timestamp
+        (True, 9999999999, 0),  # Recent timestamp
+        (False, 0, 1),  # File doesn't exist
+    ]
+)
+def test_read_pbsnode_file_different_age(monkeypatch, file_exist, timestamp, expected_rerun):
+    """ Test if read_pbsnodes_file will rerun given different aged `pbsnodes.json`. """
+    payload = _fake_pbsnodes_dict({
+        # Non-matching topology - should be ignored
+        "node001": {"topology": "cpu-clx", "ncpus": 48, "mem": "201326592KB"},  # 192GB
+        "node002": {"topology": "cpu-clx", "ncpus": 48, "mem": "201326592KB"},  # 192GB
+    })
+
+    # Create a fake pbsnodes.json file
+    payu_job_path = archive_dir / "payu_jobs"
+    payu_job_path.mkdir(parents=True, exist_ok=True)
+    pbsnodes_json_path = payu_job_path / "pbsnodes.json"
+    if file_exist:
+        data = {
+            "timestamp": timestamp,
+            "nodes": payload["nodes"]
+        }
+        with open(pbsnodes_json_path, "w") as f:
+            json.dump(data, f)
+    else:
+        pbsnodes_json_path.unlink(missing_ok=True)
+
+    # Set up a run counter
+    run_counter = 0
+    def fake_run(*args, **kwargs):
+        nonlocal run_counter
+        run_counter += 1
+        return payload
+
+    monkeypatch.setattr(pbs, "_run_pbsnodes_json", fake_run)
+    pbs.PBS.get_queue_node_shape("normal", str(archive_dir))
+
+    assert run_counter == expected_rerun
 
 
 def test_mem_convert_requires_kb_suffix():

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -52,9 +52,9 @@ def test_get_queue_node_shape_picks_node_shape(monkeypatch):
         "node005": {"topology": "cpu-xyz", "ncpus": 12, "mem": "12582912KB"},  # 12GB
     })
     
-    monkeypatch.setattr(pbs, "read_pbsnode_file", lambda timeout: payload)
+    monkeypatch.setattr(pbs, "read_pbsnode_file", lambda: payload)
 
-    ncpus, mem = pbs.PBS.get_queue_node_shape("normal", str(archive_dir))
+    ncpus, mem = pbs.PBS.get_queue_node_shape("normal")
 
     assert ncpus == 48
     assert mem == 192
@@ -68,10 +68,10 @@ def test_get_queue_node_shape_no_matching_topology(monkeypatch):
         "node002": {"topology": "cpu-clx", "ncpus": 48, "mem": "201326592KB"},  # 192GB
     })
 
-    monkeypatch.setattr(pbs, "read_pbsnode_file", lambda timeout: payload)
+    monkeypatch.setattr(pbs, "read_pbsnode_file", lambda: payload)
 
     with pytest.raises(ValueError, match=r"No nodes matched"):
-        pbs.PBS.get_queue_node_shape("normalsr", str(archive_dir))
+        pbs.PBS.get_queue_node_shape("normalsr")
 
 @pytest.mark.parametrize("file_exist, timestamp, expected_rerun",
     [
@@ -90,9 +90,9 @@ def test_read_pbsnode_file_different_age(monkeypatch, file_exist, timestamp, exp
     })
 
     # Create a fake pbsnodes.json file
-    payu_job_path = archive_dir / "payu_jobs"
-    payu_job_path.mkdir(parents=True, exist_ok=True)
-    pbsnodes_json_path = payu_job_path / "pbsnodes.json"
+    pbsnodes_json_path = archive_dir / "pbs" / "pbsnodes.json"
+    pbsnodes_json_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv('PAYU_PBSNODES_CACHE', str(pbsnodes_json_path))
     if file_exist:
         data = {
             "timestamp": timestamp,
@@ -111,9 +111,52 @@ def test_read_pbsnode_file_different_age(monkeypatch, file_exist, timestamp, exp
         return payload
 
     monkeypatch.setattr(pbs, "_run_pbsnodes_json", fake_run)
-    pbs.PBS.get_queue_node_shape("normal", str(archive_dir))
+    pbs.PBS.get_queue_node_shape("normal")
 
     assert run_counter == expected_rerun
+
+@pytest.mark.parametrize("pbsnode_cache, xdg_cache, home_dir, expected_path", 
+    [
+        # Test with only PAYU_PBSNODES_CACHE set
+        (str(tmpdir / "pbs_cache" / "pbsnodes.json"), 
+        None, 
+        None, 
+        tmpdir / "pbs_cache" / "pbsnodes.json"),
+
+        # Test with only XDG_CACHE_HOME set
+        (None, 
+        str(tmpdir / "xdg_cache"), 
+        None, 
+        tmpdir / "xdg_cache" / "pbs" / "pbsnodes.json"),
+
+        # Test with PAYU_PBSNODES_CACHE and XDG_CACHE_HOME set
+        (str(tmpdir / "pbs_cache" / "pbsnodes.json"), 
+        str(tmpdir / "xdg_cache"), 
+        None, 
+        tmpdir / "pbs_cache" / "pbsnodes.json"),
+
+        # Test with neither set (should default to $HOME/.cache directory)
+        (None, 
+        None, 
+        str(tmpdir), 
+        tmpdir / ".cache" / "pbs" / "pbsnodes.json"),
+    ]
+)
+def test_get_pbsnodes_cache_path(monkeypatch, pbsnode_cache, xdg_cache, home_dir, expected_path):
+    """ Test if get_pbsnodes_cache_path returns the correct pbsnodes.json path """
+    if pbsnode_cache:
+        monkeypatch.setenv('PAYU_PBSNODES_CACHE', pbsnode_cache)
+    else:
+        monkeypatch.delenv('PAYU_PBSNODES_CACHE', raising=False)
+    if xdg_cache:
+        monkeypatch.setenv('XDG_CACHE_HOME', xdg_cache)
+    else:
+        monkeypatch.delenv('XDG_CACHE_HOME', raising=False)
+
+    monkeypatch.setenv('HOME', home_dir)
+    path = pbs.get_pbsnodes_cache_path()
+    assert path == expected_path
+
 
 
 def test_mem_convert_requires_kb_suffix():


### PR DESCRIPTION
We introduce a caching mechanism for `pbsnodes -a -F json` to prevent timeout errors when the scheduler is busy.

Instead of running the command every time, the output is now saved to a cached `pbsnodes.json` file along with a timestamp. 
If the timestamp is found older than 7 days, `pbsnodes -a -F json` is re-run and the cache file is refreshed.

Fixes #688.