### PR TITLE
Clean up and test atomic_write_file function.

### DIFF
--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -19,6 +19,7 @@ import cftime
 
 from payu.metadata import Metadata
 from payu.schedulers.scheduler import Scheduler
+from payu.fsops import atomic_write_file
 
 # Environment variable for external telemetry configuration file
 TELEMETRY_CONFIG = "PAYU_TELEMETRY_CONFIG"
@@ -298,24 +299,6 @@ def record_telemetry(run_info: dict[str, Any],
         },
     )
     thread.start()
-
-
-def atomic_write_file(
-            file_path: Path,
-            data: dict[str, Any],
-        ) -> None:
-    """Write the job information to a temporary file and
-    replace the existing if it exists so the update is atomic"""
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode='w', dir=file_path.parent, delete=False
-    ) as temp_file:
-        json.dump(data, temp_file, ensure_ascii=False, indent=4)
-        temp_name = temp_file.name
-    os.replace(temp_name, file_path)
-
-    # Ensure status file has same permissions as parent directory
-    os.chmod(file_path, stat.S_IMODE(file_path.parent.stat().st_mode))
 
 
 def get_job_file_path_with_id(

--- a/test/test_fsops.py
+++ b/test/test_fsops.py
@@ -1,0 +1,82 @@
+import json
+import pytest
+import os
+from unittest.mock import patch
+
+# import payu packages
+from payu.fsops import atomic_write_file
+
+# import some common variables for testing
+from .common import tmpdir
+
+def test_atomic_write_file_new_content():
+    """Test that atomic_write_file write expected content into designated file
+    and delete the temp file."""
+    write_dir = tmpdir / "test_write_dir"
+    orig_file = write_dir / "origin.json"
+    content = {"key1": "value1", "key2": 123}
+    # write original file
+    write_dir.mkdir(parents=True, exist_ok=True)
+    with orig_file.open("w") as f:
+        json.dump(content, f)
+
+    new_content = {"key1": "new_value", "key2": 456}
+    atomic_write_file(orig_file, new_content)
+
+    # assert correct content
+    assert json.loads(orig_file.read_text()) == new_content
+
+    # assert no other files exist in this directory (e.g. temp files)
+    files_in_dir = list(write_dir.iterdir())
+    assert len(files_in_dir) == 1
+    assert files_in_dir[0] == orig_file
+
+def sim_disrupt(*args, **kwargs):
+        raise RuntimeError("Simulated disruption")
+
+def test_atomic_write_file_disrupt_replace(monkeypatch):
+    """Test that when atomic_write_file is disrupted during replace operation,
+    the original file will not be corrupted/changed."""
+    write_dir = tmpdir / "test_disrupt_replace_dir"
+    orig_file = write_dir / "origin.json"
+    content = {"key1": "value1", "key2": 123}
+
+    # write original file
+    write_dir.mkdir(parents=True, exist_ok=True)
+    with orig_file.open("w") as f:
+        json.dump(content, f)
+
+    # simulate disruption by raising an exception during replacing
+    new_content = {"key1": "new_value", "key2": 456}
+    monkeypatch.setattr("payu.fsops.os.replace", sim_disrupt)
+    with pytest.raises(RuntimeError):
+        atomic_write_file(orig_file, new_content)
+
+    # assert the original file is unchanged and not corrupted
+    with open(orig_file, 'r') as f:
+        content_after_error = json.load(f)
+    assert content_after_error == content
+
+
+def test_atomic_write_file_disrupt_dump(monkeypatch):
+    """Test that when atomic_write_file is disrupted during writing tmp file,
+    the original file will not be corrupted/changed."""
+    write_dir = tmpdir / "test_disrupt_dump_dir"
+    orig_file = write_dir / "origin.json"
+    content = {"key1": "value1", "key2": 123}
+
+    # write original file
+    write_dir.mkdir(parents=True, exist_ok=True)
+    with orig_file.open("w") as f:
+        json.dump(content, f)
+
+    # simulate disruption in writing tmp file
+    new_content = {"key1": "new_value", "key2": 456}
+    monkeypatch.setattr("payu.fsops.json.dump", sim_disrupt)
+    with pytest.raises(RuntimeError):
+        atomic_write_file(orig_file, new_content)
+
+    # assert the original file is unchanged and not corrupted
+    with open(orig_file, 'r') as f:
+        content_after_error = json.load(f)
+    assert content_after_error == content

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -14,7 +14,7 @@ import yaml
 
 import payu
 
-from payu.fsops import read_config
+from payu.fsops import read_config, atomic_write_file
 from payu.laboratory import Laboratory
 from payu.schedulers import pbs
 from payu.schedulers import index as scheduler_index
@@ -36,6 +36,22 @@ config = copy.deepcopy(original_config)
 def _fake_pbsnodes_dict(nodes):
     """Build a pbsnodes -F json compatible payload."""
     return {"nodes": {name: {"resources_available": ra} for name, ra in nodes.items()}}
+
+def test_atomic_write_file():
+    """Test that atomic_write_file write expected content into designated file
+    and delete the temp file."""
+    write_dir = tmpdir / "atomic_write_dir"
+    test_file = write_dir / "test.txt"
+    content = {"key1": "value1", "key2": 123}
+    atomic_write_file(test_file, content)
+
+    # assert correct content
+    assert json.loads(test_file.read_text()) == content
+
+    # assert no other files exist in this directory (e.g. temp files)
+    files_in_dir = list(write_dir.iterdir())
+    assert len(files_in_dir) == 1
+    assert files_in_dir[0] == test_file
 
 
 def test_get_queue_node_shape_picks_node_shape(monkeypatch):

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -14,7 +14,7 @@ import yaml
 
 import payu
 
-from payu.fsops import read_config, atomic_write_file
+from payu.fsops import read_config
 from payu.laboratory import Laboratory
 from payu.schedulers import pbs
 from payu.schedulers import index as scheduler_index
@@ -36,23 +36,6 @@ config = copy.deepcopy(original_config)
 def _fake_pbsnodes_dict(nodes):
     """Build a pbsnodes -F json compatible payload."""
     return {"nodes": {name: {"resources_available": ra} for name, ra in nodes.items()}}
-
-def test_atomic_write_file():
-    """Test that atomic_write_file write expected content into designated file
-    and delete the temp file."""
-    write_dir = tmpdir / "atomic_write_dir"
-    test_file = write_dir / "test.txt"
-    content = {"key1": "value1", "key2": 123}
-    atomic_write_file(test_file, content)
-
-    # assert correct content
-    assert json.loads(test_file.read_text()) == content
-
-    # assert no other files exist in this directory (e.g. temp files)
-    files_in_dir = list(write_dir.iterdir())
-    assert len(files_in_dir) == 1
-    assert files_in_dir[0] == test_file
-
 
 def test_get_queue_node_shape_picks_node_shape(monkeypatch):
 


### PR DESCRIPTION
This PR 
1. keeps `atomic_write_file` only in `fsops.py` and remove the duplication in `telemetry.py`
2. add a unit test of `atomic_write_file` to ensure it 
    - write correct content
    - remove the created temporary file

Closes #695 