### PR TITLE
Current expt time for running jobs in payu status

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -69,7 +69,7 @@ def timeit(time_name):
 
 
 class Experiment(object):
-    def __init__(self, lab, reproduce=False, force=False, metadata_off=False):
+    def __init__(self, lab, reproduce=False, force=False, metadata_off=False, config_path=None):
         self.init_timings()
         self.lab = lab
         # Check laboratory directories are writable
@@ -82,14 +82,14 @@ class Experiment(object):
             self.force = force
 
         # Initialise experiment metadata - uuid and experiment name
-        self.metadata = Metadata(Path(lab.archive_path), disabled=metadata_off)
+        self.metadata = Metadata(Path(lab.archive_path), disabled=metadata_off, config_path=config_path)
         self.metadata.setup()
 
         # TODO: replace with dict, check versions via key-value pairs
         self.modules = set()
 
         # TODO: __init__ should not be a config dumping ground!
-        self.config = read_config()
+        self.config = read_config(config_path)
 
         # Payu experiment type
         self.debug = self.config.get('debug', False)
@@ -856,6 +856,9 @@ class Experiment(object):
             # or if there was error during file parsing
             pass
         return datetimes
+
+    def get_model_cur_expt_time(self):
+        return self.model.get_cur_expt_time()
 
     def archiving(self):
         """

--- a/payu/models/access.py
+++ b/payu/models/access.py
@@ -283,6 +283,11 @@ class Access(Model):
         return self.get_restart_datetime_using_submodel(restart_path,
                                                         model_types)
 
+    def get_cur_expt_time(self):
+        """ Use UM submodel to get the current experiment time."""
+        model_types = ['um']
+        return self.get_cur_expt_time_using_submodel(model_types)
+
     def set_model_pathnames(self):
         pass
 

--- a/payu/models/access_esm1p6.py
+++ b/payu/models/access_esm1p6.py
@@ -15,7 +15,6 @@ import os
 import re
 import shutil
 import sys
-import warnings
 
 # Extensions
 import f90nml
@@ -320,6 +319,11 @@ class AccessEsm1p6(Model):
         return self.get_restart_datetime_using_submodel(restart_path,
                                                         model_types)
 
+    def get_cur_expt_time(self):
+        """ Use UM submodel to get the current experiment time."""
+        model_types = ['um']
+        return self.get_cur_expt_time_using_submodel(model_types)
+
     def set_model_pathnames(self):
         pass
 
@@ -335,69 +339,6 @@ class AccessEsm1p6(Model):
     def collate(self):
         pass
 
-    def read_start_date(self, nl_path):
-        """Read the start date from the namelist file"""
-        try:
-            namelist = f90nml.read(nl_path)
-            model_basis_time = namelist.get('nlstcall', {}).get('model_basis_time', None)
-            if model_basis_time is None:
-                warnings.warn(f"model_basis_time not found in {nl_path}")
-                return None
-            return datetime(*model_basis_time)
-        except Exception as e:
-            warnings.warn(f"Could not read file {nl_path}: {e}")
-            return None
-
-    def convert_timestep(self, log_path):
-        """ Convert the timestep to experiment runtime 
-        based on the information in log file"""
-        timestep = None
-        step_per_period = 0
-        secs_per_period = 0
-
-        with open(log_path, 'r') as f:
-            for line in f:
-                try:
-                    if 'STEPS_PER_PERIODim' in line:
-                        step_per_period = int(line.split('=')[-1].strip())
-                    if 'SECS_PER_PERIODim' in line:
-                        secs_per_period = int(line.split('=')[-1].strip())
-                        print(f"Found secs_per_period: {secs_per_period}")
-                    if 'Atm_Step: Timestep' in line:
-                        timestep = int(line.split()[-1])
-                except ValueError:
-                    continue
-
-        if timestep is not None and secs_per_period > 0 and step_per_period > 0:
-            secs_per_step = secs_per_period / step_per_period 
-            runtime_sec = timestep * secs_per_step
-            return runtime_sec
-        
-        warnings.warn(
-                f"""Could not find all required entries in file {log_path}
-                to calculate run time"""
-            )
-        return None
-
-
-    def get_cur_expt_time(self):
-        """Get the current experiment time from file"""
-        nl_path = os.path.join(self.expt.work_path, 'atmosphere', 'namelists')
-        log_path = os.path.join(self.expt.work_path, 'atmosphere', 'atm.fort6.pe0')
-
-        if not os.path.exists(nl_path) or not os.path.exists(log_path):
-            warnings.warn(f"Could not find required files: {nl_path} or {log_path}")
-            return None
-        
-        start_date = self.read_start_date(nl_path)
-        runtime_sec = self.convert_timestep(log_path)
-        if start_date is None or runtime_sec is None:
-            return None
-            
-        # Both ESM1.6 and datetime package use Gregorian calendar, 
-        # so we can use datetime here for date calculations.
-        cur_expt_time = start_date + timedelta(seconds=runtime_sec)
-        return cur_expt_time.isoformat()
         
         
         

--- a/payu/models/access_esm1p6.py
+++ b/payu/models/access_esm1p6.py
@@ -338,8 +338,3 @@ class AccessEsm1p6(Model):
 
     def collate(self):
         pass
-
-        
-        
-        
-

--- a/payu/models/access_esm1p6.py
+++ b/payu/models/access_esm1p6.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import sys
+import warnings
 
 # Extensions
 import f90nml
@@ -333,3 +334,71 @@ class AccessEsm1p6(Model):
 
     def collate(self):
         pass
+
+    def read_start_date(self, nl_path):
+        """Read the start date from the namelist file"""
+        try:
+            namelist = f90nml.read(nl_path)
+            model_basis_time = namelist.get('nlstcall', {}).get('model_basis_time', None)
+            if model_basis_time is None:
+                warnings.warn(f"model_basis_time not found in {nl_path}")
+                return None
+            return datetime(*model_basis_time)
+        except Exception as e:
+            warnings.warn(f"Could not read file {nl_path}: {e}")
+            return None
+
+    def convert_timestep(self, log_path):
+        """ Convert the timestep to experiment runtime 
+        based on the information in log file"""
+        timestep = None
+        step_per_period = 0
+        secs_per_period = 0
+
+        with open(log_path, 'r') as f:
+            for line in f:
+                try:
+                    if 'STEPS_PER_PERIODim' in line:
+                        step_per_period = int(line.split('=')[-1].strip())
+                    if 'SECS_PER_PERIODim' in line:
+                        secs_per_period = int(line.split('=')[-1].strip())
+                        print(f"Found secs_per_period: {secs_per_period}")
+                    if 'Atm_Step: Timestep' in line:
+                        timestep = int(line.split()[-1])
+                except ValueError:
+                    continue
+
+        if timestep is not None and secs_per_period > 0 and step_per_period > 0:
+            secs_per_step = secs_per_period / step_per_period 
+            runtime_sec = timestep * secs_per_step
+            return runtime_sec
+        
+        warnings.warn(
+                f"""Could not find all required entries in file {log_path}
+                to calculate run time"""
+            )
+        return None
+
+
+    def get_cur_expt_time(self):
+        """Get the current experiment time from file"""
+        nl_path = os.path.join(self.expt.work_path, 'atmosphere', 'namelists')
+        log_path = os.path.join(self.expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+
+        if not os.path.exists(nl_path) or not os.path.exists(log_path):
+            warnings.warn(f"Could not find required files: {nl_path} or {log_path}")
+            return None
+        
+        start_date = self.read_start_date(nl_path)
+        runtime_sec = self.convert_timestep(log_path)
+        if start_date is None or runtime_sec is None:
+            return None
+            
+        # Both ESM1.6 and datetime package use Gregorian calendar, 
+        # so we can use datetime here for date calculations.
+        cur_expt_time = start_date + timedelta(seconds=runtime_sec)
+        return cur_expt_time.isoformat()
+        
+        
+        
+

--- a/payu/models/accessom2.py
+++ b/payu/models/accessom2.py
@@ -12,6 +12,8 @@ from __future__ import print_function
 
 import os
 import shutil
+import json
+import warnings
 
 from payu.models.model import Model
 
@@ -94,3 +96,25 @@ class AccessOm2(Model):
 
         return self.get_restart_datetime_using_submodel(restart_path,
                                                         model_types)
+
+    def get_cur_expt_time(self):
+        """Get the current experiment time from file work/atmosphere/log/matmxx.pe00000.log."""
+        try:
+            log_path = os.path.join(self.expt.work_path, 'atmosphere', 'log', 
+                                    'matmxx.pe00000.log')
+            
+            # Read out the latest `cur_exp-datetime` from the log file
+            if os.path.exists(log_path):
+                with open(log_path, 'r') as f:
+                    for line in reversed(f.readlines()):
+                        if 'cur_exp-datetime' in line:
+                            cur_expt_time = json.loads(line)['cur_exp-datetime']
+                            return cur_expt_time
+                    
+            warnings.warn(f"Log file {log_path} does not exist or does not contain current model time.")
+            return None
+
+        except KeyError as e:
+            warnings.warn('Error getting current experiment time: {}'.format(e))
+            return None
+

--- a/payu/models/accessom2.py
+++ b/payu/models/accessom2.py
@@ -13,13 +13,9 @@ from __future__ import print_function
 import os
 import shutil
 import json
-import warnings
 import cftime
-import logging
 
 from payu.models.model import Model
-
-logger = logging.getLogger(__name__)
 
 class AccessOm2(Model):
 
@@ -104,7 +100,9 @@ class AccessOm2(Model):
         """Get the current experiment time from file work/atmosphere/log/matmxx.pe00000.log.
         ---
         output:
-            cftime.datetime or None if it cannot be determined.
+            cftime.datetime
+        raises:
+            ValueError if the key 'cur_exp-datetime' is not found in the log file
         """
         log_path = os.path.join(self.expt.work_path, 'atmosphere', 'log', 
                                     'matmxx.pe00000.log')

--- a/payu/models/accessom2.py
+++ b/payu/models/accessom2.py
@@ -14,6 +14,9 @@ import os
 import shutil
 import json
 import warnings
+import cftime
+import logging
+logger = logging.getLogger(__name__)
 
 from payu.models.model import Model
 
@@ -98,23 +101,22 @@ class AccessOm2(Model):
                                                         model_types)
 
     def get_cur_expt_time(self):
-        """Get the current experiment time from file work/atmosphere/log/matmxx.pe00000.log."""
-        try:
-            log_path = os.path.join(self.expt.work_path, 'atmosphere', 'log', 
+        """Get the current experiment time from file work/atmosphere/log/matmxx.pe00000.log.
+        ---
+        output:
+            cftime.datetime or None if it cannot be determined.
+        """
+        log_path = os.path.join(self.expt.work_path, 'atmosphere', 'log', 
                                     'matmxx.pe00000.log')
             
-            # Read out the latest `cur_exp-datetime` from the log file
-            if os.path.exists(log_path):
-                with open(log_path, 'r') as f:
-                    for line in reversed(f.readlines()):
-                        if 'cur_exp-datetime' in line:
-                            cur_expt_time = json.loads(line)['cur_exp-datetime']
-                            return cur_expt_time
-                    
-            warnings.warn(f"Log file {log_path} does not exist or does not contain current model time.")
-            return None
+        with open(log_path, 'r') as f:
+            for line in reversed(f.readlines()):
+                if 'cur_exp-datetime' in line:
+                    line_json = json.loads(line)
+                    time_str = line_json.get('cur_exp-datetime', None)
+                    if time_str is not None:
+                        return cftime.datetime.strptime(time_str, '%Y-%m-%dT%H:%M:%S')
 
-        except KeyError as e:
-            warnings.warn('Error getting current experiment time: {}'.format(e))
-            return None
+        logger.debug(f"cur_exp-datetime not found in {log_path}")
+        return None
 

--- a/payu/models/accessom2.py
+++ b/payu/models/accessom2.py
@@ -16,10 +16,10 @@ import json
 import warnings
 import cftime
 import logging
-logger = logging.getLogger(__name__)
 
 from payu.models.model import Model
 
+logger = logging.getLogger(__name__)
 
 class AccessOm2(Model):
 
@@ -117,6 +117,5 @@ class AccessOm2(Model):
                     if time_str is not None:
                         return cftime.datetime.strptime(time_str, '%Y-%m-%dT%H:%M:%S')
 
-        logger.debug(f"cur_exp-datetime not found in {log_path}")
-        return None
+        raise ValueError(f"Key 'cur_exp-datetime' not found in {log_path}")
 

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -16,6 +16,8 @@ import glob
 import shutil
 import cftime
 from warnings import warn
+import logging
+logger = logging.getLogger(__name__)
 
 from payu.fsops import make_symlink
 from payu.models.model import Model
@@ -432,26 +434,20 @@ class AccessOm3(CesmCmeps):
             )
         
     def get_cur_expt_time(self):
-        """Get the current experiment time from file work/log/med.log."""
-        try:
-            log_path = os.path.join(self.expt.work_path, 'log', 'med.log')
+        """Get the current experiment time from file work/log/med.log.
+        ---
+        output:
+            cftime.datetime or None if it cannot be determined.
+        """
+        log_path = os.path.join(self.expt.work_path, 'log', 'med.log')
             
-            # Read out the latest `cur_exp-datetime` from the log file
-            if os.path.exists(log_path):
-                with open(log_path, 'r') as f:
-                    for line in reversed(f.readlines()):
-                        if line.startswith(" memory_write: model date"):
-                            cur_expt_time = line.split()[4]
-                            return cur_expt_time
-            
-            warn(f"Log file {log_path} does not exist or does not contain current model time.")
-            return None
-
-        except KeyError as e:
-            warn('Error getting current experiment time: {}'.format(e))
-            return None
-     
-
+        with open(log_path, 'r') as f:
+            for line in reversed(f.readlines()):
+                if line.startswith(" memory_write: model date"):
+                    time_str = line.split()[4]
+                    return cftime.datetime.strptime(time_str, '%Y-%m-%dT%H:%M:%S')
+        
+        return None
 
 class Runconfig:
     """ Simple class for parsing and editing nuopc.runconfig """

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -448,7 +448,7 @@ class AccessOm3(CesmCmeps):
                     time_str = line.split()[4]
                     return cftime.datetime.strptime(time_str, '%Y-%m-%dT%H:%M:%S')
         
-        return None
+        raise ValueError(f"Key string 'memory_write: model date' not found in {log_path}, cannot determine current experiment time")
 
 class Runconfig:
     """ Simple class for parsing and editing nuopc.runconfig """

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -430,6 +430,27 @@ class AccessOm3(CesmCmeps):
                 "Access-OM3 comprises a data runoff model, but the runoff model in nuopc.runconfig is set "
                 f"to {self.components['rof']}."
             )
+        
+    def get_cur_expt_time(self):
+        """Get the current experiment time from file work/log/med.log."""
+        try:
+            log_path = os.path.join(self.expt.work_path, 'log', 'med.log')
+            
+            # Read out the latest `cur_exp-datetime` from the log file
+            if os.path.exists(log_path):
+                with open(log_path, 'r') as f:
+                    for line in reversed(f.readlines()):
+                        if line.startswith(" memory_write: model date"):
+                            cur_expt_time = line.split()[4]
+                            return cur_expt_time
+            
+            warn(f"Log file {log_path} does not exist or does not contain current model time.")
+            return None
+
+        except KeyError as e:
+            warn('Error getting current experiment time: {}'.format(e))
+            return None
+     
 
 
 class Runconfig:

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -17,12 +17,13 @@ import shutil
 import cftime
 from warnings import warn
 import logging
-logger = logging.getLogger(__name__)
 
 from payu.fsops import make_symlink
 from payu.models.model import Model
 from payu.models.fms import fms_collate
 from payu.models.mom6 import mom6_add_parameter_files, mom6_save_docs_files
+
+logger = logging.getLogger(__name__)
 
 NUOPC_CONFIG = "nuopc.runconfig"
 NUOPC_RUNSEQ = "nuopc.runseq"

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -16,14 +16,11 @@ import glob
 import shutil
 import cftime
 from warnings import warn
-import logging
 
 from payu.fsops import make_symlink
 from payu.models.model import Model
 from payu.models.fms import fms_collate
 from payu.models.mom6 import mom6_add_parameter_files, mom6_save_docs_files
-
-logger = logging.getLogger(__name__)
 
 NUOPC_CONFIG = "nuopc.runconfig"
 NUOPC_RUNSEQ = "nuopc.runseq"
@@ -438,7 +435,9 @@ class AccessOm3(CesmCmeps):
         """Get the current experiment time from file work/log/med.log.
         ---
         output:
-            cftime.datetime or None if it cannot be determined.
+            cftime.datetime
+        raises:
+            ValueError if the key string 'memory_write: model date' is not found in the log file
         """
         log_path = os.path.join(self.expt.work_path, 'log', 'med.log')
             

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -9,6 +9,8 @@ import shutil
 import shlex
 import sys
 import subprocess as sp
+import logging
+logger = logging.getLogger(__name__)
 
 from payu import envmod
 from payu.fsops import required_libs
@@ -453,7 +455,7 @@ class Model(object):
     def get_cur_expt_time(self):
         """For model not implemented experiment time calculate/read-out,
         leaves a warning and returns None."""
-        print("Getting current experiment time is not yet implemented.")
+        logger.debug("Current experiment time not implemented for this model.")
         return None
 
     def get_cur_expt_time_using_submodel(self, model_types):
@@ -471,9 +473,7 @@ class Model(object):
         """
         for model_type in model_types:
             for model in self.expt.models:
-                if model.model_type == model_type and hasattr(model, 'get_cur_expt_time'):
+                if model.model_type == model_type:
                     cur_expt_time = model.get_cur_expt_time()
                     if cur_expt_time is not None:
                         return cur_expt_time
-
-        return None

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -451,9 +451,8 @@ class Model(object):
 
     def get_cur_expt_time(self):
         """For model not implemented experiment time calculate/read-out,
-        leaves a warning and returns None."""
-        print("Current experiment time not implemented for this model.")
-        return None
+        raise error."""
+        raise NotImplementedError("Current experiment time not implemented for this model.")
 
     def get_cur_expt_time_using_submodel(self, model_types):
         """
@@ -474,3 +473,9 @@ class Model(object):
                     cur_expt_time = model.get_cur_expt_time()
                     if cur_expt_time is not None:
                         return cur_expt_time
+        
+        raise NotImplementedError(
+            f'Cannot find any of the specified sub-models: '
+            f'{", ".join(model_types)}. '
+            'to determine current experiment time.'
+        )

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -449,3 +449,31 @@ class Model(object):
             f'{self.model_type} date-based restart pruning requires one of '
             'these sub-models to determine restart dates.'
         )
+
+    def get_cur_expt_time(self):
+        """For model not implemented experiment time calculate/read-out,
+        leaves a warning and returns None."""
+        print("Getting current experiment time is not yet implemented.")
+        return None
+
+    def get_cur_expt_time_using_submodel(self, model_types):
+        """
+        Use a specified submodel's get_cur_expt_time method
+
+        Parameters
+        ----------
+        model_types: List of submodels in order of priority. Use first
+        submodel in model_types that is present in the experiment.
+
+        Returns:
+        --------
+        Current experiment time in string (e.g., 1900-01-01T01:00:00)
+        """
+        for model_type in model_types:
+            for model in self.expt.models:
+                if model.model_type == model_type and hasattr(model, 'get_cur_expt_time'):
+                    cur_expt_time = model.get_cur_expt_time()
+                    if cur_expt_time is not None:
+                        return cur_expt_time
+
+        return None

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -9,12 +9,9 @@ import shutil
 import shlex
 import sys
 import subprocess as sp
-import logging
-logger = logging.getLogger(__name__)
 
 from payu import envmod
 from payu.fsops import required_libs
-
 
 class Model(object):
     """Abstract model class."""
@@ -455,7 +452,7 @@ class Model(object):
     def get_cur_expt_time(self):
         """For model not implemented experiment time calculate/read-out,
         leaves a warning and returns None."""
-        logger.debug("Current experiment time not implemented for this model.")
+        print("Current experiment time not implemented for this model.")
         return None
 
     def get_cur_expt_time_using_submodel(self, model_types):
@@ -469,7 +466,7 @@ class Model(object):
 
         Returns:
         --------
-        Current experiment time in string (e.g., 1900-01-01T01:00:00)
+        Current experiment time in cftime.datetime
         """
         for model_type in model_types:
             for model in self.expt.models:

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -153,7 +153,7 @@ class Mom6(MomMixin, Fms):
         """Get the current experiment time from log file.
         --- 
         output:
-            cftime.datetime or None if it cannot be determined.
+            cftime.datetime
         """
         ocean_solo_path = os.path.join(self.expt.work_path, 'INPUT', 'ocean_solo.res')
         calendar = self.get_calendar(ocean_solo_path)

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -12,8 +12,7 @@
 import os
 from datetime import datetime, timedelta
 import cftime
-import logging
-logger = logging.getLogger(__name__)
+from collections import deque
 
 # Extensions
 import f90nml
@@ -27,13 +26,6 @@ from payu.models.mom_mixin import MomMixin
 from payu.git_utils import GitRepository
 
 MOM6_DOCS = ["MOM_parameter_doc.*","available_diags.*"]
-
-cftime_calendars = {
-            1: "360_day",
-            2: "julian",
-            3: "proleptic_gregorian",
-            4: "noleap"
-        }
 
 def mom6_add_parameter_files(model):
     """Add parameter files defined in input.nml to model configuration files.
@@ -142,6 +134,21 @@ class Mom6(MomMixin, Fms):
 
         super().archive()
 
+    def read_start_date(self, input_path, calendar):
+        """Read the start date from input.nml."""
+        input_nml = f90nml.read(input_path)
+        start_date_list = input_nml.get('ocean_solo_nml', {}).get('date_init', None)
+        if start_date_list is None:
+            raise ValueError(f"Key 'date_init' not found in {input_path}")
+        return cftime.datetime(*start_date_list, calendar=calendar)
+
+    def read_timestep(self, stats_path):
+        """ Read the current timestep from ocean.stats."""
+        with open(stats_path, 'r') as f:
+            line = deque(f, maxlen=1)[0]
+            timestep = float(line.split(',')[1])
+            return timestep
+
     def get_cur_expt_time(self):
         """Get the current experiment time from log file.
         --- 
@@ -149,10 +156,16 @@ class Mom6(MomMixin, Fms):
             cftime.datetime or None if it cannot be determined.
         """
         ocean_solo_path = os.path.join(self.expt.work_path, 'INPUT', 'ocean_solo.res')
-        with open(ocean_solo_path, 'r') as ocean_solo:
-            lines = ocean_solo.readlines()
-            calendar_int = int(lines[0].split()[0])
-            time_values = [int(x) for x in lines[2].split()[0:6]]
+        calendar = self.get_calendar(ocean_solo_path)
 
-        cur_expt_time = cftime.datetime(*time_values, calendar = cftime_calendars[calendar_int])
+        input_path = os.path.join(self.expt.work_path, 'input.nml')
+        start_date = self.read_start_date(input_path, calendar)
+
+        stats_path = os.path.join(self.expt.work_path, 'ocean.stats')
+        timestep = self.read_timestep(stats_path)
+
+        if start_date is None or timestep is None:
+            return None
+
+        cur_expt_time = start_date + timedelta(days=timestep)
         return cur_expt_time

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -164,8 +164,5 @@ class Mom6(MomMixin, Fms):
         stats_path = os.path.join(self.expt.work_path, 'ocean.stats')
         timestep = self.read_timestep(stats_path)
 
-        if start_date is None or timestep is None:
-            return None
-
         cur_expt_time = start_date + timedelta(days=timestep)
         return cur_expt_time

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -10,6 +10,7 @@
 
 # Standard library
 import os
+from datetime import datetime, timedelta
 
 # Extensions
 import f90nml
@@ -130,3 +131,44 @@ class Mom6(MomMixin, Fms):
         mom6_save_docs_files(self)
 
         super().archive()
+
+    def read_start_date(self, input_path):
+        """Read the start date from input.nml."""
+        try:
+            input_nml = f90nml.read(input_path)
+            start_date = input_nml.get('ocean_solo_nml', {}).get('date_init', None)
+            if start_date is None:
+                warn(f"date_init not found in {input_path}")
+                return None
+            return datetime(*start_date)
+        except Exception as e:
+            warn(f"Could not read file {input_path}: {e}")
+            return None
+
+    def read_timestep(self, stats_path):
+        """ Read the current timestep from ocean.stats."""
+        try:
+            with open(stats_path, 'r') as f:
+                for line in reversed(f.readlines()):
+                    timestep = float(line.split(',')[1])
+                    return timestep
+        except Exception as e:
+            warn(f"Could not read timestep from {stats_path}: {e}")
+            return None
+
+    def get_cur_expt_time(self):
+        """Get the current experiment time from log file."""
+        input_path = os.path.join(self.expt.work_path, 'input.nml')
+        stats_path = os.path.join(self.expt.work_path, 'ocean.stats')
+        if not os.path.exists(input_path) or not os.path.exists(stats_path):
+            warn(f"Could not find required files: {input_path} or {stats_path}")
+            return None
+
+        start_date = self.read_start_date(input_path)
+        timestep = self.read_timestep(stats_path)
+
+        if start_date is None or timestep is None:
+            return None
+
+        cur_expt_time = start_date + timedelta(days=timestep)
+        return cur_expt_time.isoformat()

--- a/payu/models/mom6.py
+++ b/payu/models/mom6.py
@@ -11,6 +11,9 @@
 # Standard library
 import os
 from datetime import datetime, timedelta
+import cftime
+import logging
+logger = logging.getLogger(__name__)
 
 # Extensions
 import f90nml
@@ -24,6 +27,13 @@ from payu.models.mom_mixin import MomMixin
 from payu.git_utils import GitRepository
 
 MOM6_DOCS = ["MOM_parameter_doc.*","available_diags.*"]
+
+cftime_calendars = {
+            1: "360_day",
+            2: "julian",
+            3: "proleptic_gregorian",
+            4: "noleap"
+        }
 
 def mom6_add_parameter_files(model):
     """Add parameter files defined in input.nml to model configuration files.
@@ -132,43 +142,17 @@ class Mom6(MomMixin, Fms):
 
         super().archive()
 
-    def read_start_date(self, input_path):
-        """Read the start date from input.nml."""
-        try:
-            input_nml = f90nml.read(input_path)
-            start_date = input_nml.get('ocean_solo_nml', {}).get('date_init', None)
-            if start_date is None:
-                warn(f"date_init not found in {input_path}")
-                return None
-            return datetime(*start_date)
-        except Exception as e:
-            warn(f"Could not read file {input_path}: {e}")
-            return None
-
-    def read_timestep(self, stats_path):
-        """ Read the current timestep from ocean.stats."""
-        try:
-            with open(stats_path, 'r') as f:
-                for line in reversed(f.readlines()):
-                    timestep = float(line.split(',')[1])
-                    return timestep
-        except Exception as e:
-            warn(f"Could not read timestep from {stats_path}: {e}")
-            return None
-
     def get_cur_expt_time(self):
-        """Get the current experiment time from log file."""
-        input_path = os.path.join(self.expt.work_path, 'input.nml')
-        stats_path = os.path.join(self.expt.work_path, 'ocean.stats')
-        if not os.path.exists(input_path) or not os.path.exists(stats_path):
-            warn(f"Could not find required files: {input_path} or {stats_path}")
-            return None
+        """Get the current experiment time from log file.
+        --- 
+        output:
+            cftime.datetime or None if it cannot be determined.
+        """
+        ocean_solo_path = os.path.join(self.expt.work_path, 'INPUT', 'ocean_solo.res')
+        with open(ocean_solo_path, 'r') as ocean_solo:
+            lines = ocean_solo.readlines()
+            calendar_int = int(lines[0].split()[0])
+            time_values = [int(x) for x in lines[2].split()[0:6]]
 
-        start_date = self.read_start_date(input_path)
-        timestep = self.read_timestep(stats_path)
-
-        if start_date is None or timestep is None:
-            return None
-
-        cur_expt_time = start_date + timedelta(days=timestep)
-        return cur_expt_time.isoformat()
+        cur_expt_time = cftime.datetime(*time_values, calendar = cftime_calendars[calendar_int])
+        return cur_expt_time

--- a/payu/models/mom_mixin.py
+++ b/payu/models/mom_mixin.py
@@ -10,6 +10,19 @@ import cftime
 
 
 class MomMixin:
+    def get_calendar(self, ocean_solo_path):
+        """Get the calendar type from the ocean_solo.res file."""
+        with open(ocean_solo_path, 'r') as ocean_solo:
+            line = ocean_solo.readlines()[0]
+            calendar_int = int(line.split()[0])
+
+        cftime_calendars = {
+            1: "360_day",
+            2: "julian",
+            3: "proleptic_gregorian",
+            4: "noleap"
+        }
+        return cftime_calendars[calendar_int]
 
     def get_restart_datetime(self, restart_path):
         """Given a restart path, parse the restart files and
@@ -21,19 +34,11 @@ class MomMixin:
                 'Cannot find ocean_solo.res file, which is required for '
                 'date-based restart pruning')
 
+        calendar = self.get_calendar(ocean_solo_path)
+
         with open(ocean_solo_path, 'r') as ocean_solo:
-            lines = ocean_solo.readlines()
-
-        calendar_int = int(lines[0].split()[0])
-        cftime_calendars = {
-            1: "360_day",
-            2: "julian",
-            3: "proleptic_gregorian",
-            4: "noleap"
-        }
-        calendar = cftime_calendars[calendar_int]
-
-        last_date_line = lines[-1].split()
+            lines = ocean_solo.readlines()[-1]
+            last_date_line = lines.split()
         date_values = [int(i) for i in last_date_line[:6]]
         year, month, day, hour, minute, second = date_values
         return cftime.datetime(year, month, day, hour, minute, second,

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -15,6 +15,9 @@ import glob
 import os
 import shutil
 import string
+import cftime
+import logging
+logger = logging.getLogger(__name__)
 
 # Extensions
 import f90nml
@@ -252,6 +255,45 @@ class UnifiedModel(Model):
         # Date-based restart pruning requires cftime.datetime object and
         # Payu UM always uses proleptic Gregorian calendar
         return cal.date_to_cftime(restart_date, UM_CFTIME_CALENDAR)
+
+    def convert_timestep(self, log_path):
+        """ Convert the timestep to experiment runtime 
+        based on the information in log file"""
+        timestep = None
+        step_per_period = 0
+        secs_per_period = 0
+
+        with open(log_path, 'r') as f:
+            for line in f:
+                if 'STEPS_PER_PERIODim' in line:
+                    step_per_period = int(line.split('=')[-1].strip())
+                if 'SECS_PER_PERIODim' in line:
+                    secs_per_period = int(line.split('=')[-1].strip())
+                if 'Atm_Step: Timestep' in line:
+                    timestep = int(line.split()[-1])
+
+        if timestep is not None and secs_per_period > 0 and step_per_period > 0:
+            secs_per_step = secs_per_period / step_per_period 
+            runtime_sec = timestep * secs_per_step
+            return runtime_sec
+        
+        logger.debug(
+            f"Could not find all required entries in file {log_path}"
+            f" to calculate run time"
+        )
+        return None
+
+    def get_cur_expt_time(self):
+        """Get the current experiment time from file"""
+        log_path = os.path.join(self.expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+        
+        start_date = self.get_restart_datetime(self.expt.work_path + '/atmosphere')
+        runtime_sec = self.convert_timestep(log_path)
+        if start_date is None or runtime_sec is None:
+            return None
+            
+        cur_expt_time = start_date + datetime.timedelta(seconds=runtime_sec)
+        return cur_expt_time
 
 
 def date_to_um_dump_date(date):

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -287,7 +287,7 @@ class UnifiedModel(Model):
         start_date = self.get_restart_datetime(start_date_dir)
         runtime_sec = self.convert_timestep(log_path)
         if start_date is None or runtime_sec is None:
-            raise ValueError("Could not determine current experiment time.")
+            raise ValueError("Could not determine current experiment time due to missing start date or timestep.")
         cur_expt_time = start_date + datetime.timedelta(seconds=runtime_sec)
         return cur_expt_time
 

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -15,9 +15,6 @@ import glob
 import os
 import shutil
 import string
-import cftime
-import logging
-logger = logging.getLogger(__name__)
 
 # Extensions
 import f90nml
@@ -277,21 +274,20 @@ class UnifiedModel(Model):
             runtime_sec = timestep * secs_per_step
             return runtime_sec
         
-        logger.debug(
+        raise ValueError(
             f"Could not find all required entries in file {log_path}"
             f" to calculate run time"
         )
-        return None
 
     def get_cur_expt_time(self):
         """Get the current experiment time from file"""
         log_path = os.path.join(self.expt.work_path, 'atmosphere', 'atm.fort6.pe0')
         
-        start_date = self.get_restart_datetime(self.expt.work_path + '/atmosphere')
+        start_date_dir = os.path.join(self.expt.work_path, 'atmosphere')
+        start_date = self.get_restart_datetime(start_date_dir)
         runtime_sec = self.convert_timestep(log_path)
         if start_date is None or runtime_sec is None:
-            return None
-            
+            raise ValueError("Could not determine current experiment time.")
         cur_expt_time = start_date + datetime.timedelta(seconds=runtime_sec)
         return cur_expt_time
 

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -286,8 +286,6 @@ class UnifiedModel(Model):
         start_date_dir = os.path.join(self.expt.work_path, 'atmosphere')
         start_date = self.get_restart_datetime(start_date_dir)
         runtime_sec = self.convert_timestep(log_path)
-        if start_date is None or runtime_sec is None:
-            raise ValueError("Could not determine current experiment time due to missing start date or timestep.")
         cur_expt_time = start_date + datetime.timedelta(seconds=runtime_sec)
         return cur_expt_time
 

--- a/payu/status.py
+++ b/payu/status.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from typing import Any, Optional
 import warnings
 from datetime import datetime
+import json
+import logging
+logger = logging.getLogger(__name__)
 
 from payu.schedulers import Scheduler
 from payu.telemetry import (
@@ -279,7 +282,7 @@ def print_line(label: str, key: Any, data: dict[str, Any]) -> None:
         print(f"  {f'{label}:':<{label_width}} {value}")
 
 
-def display_job_info(data: dict[str, Any], cur_expt_time) -> None:
+def display_job_info(data: dict[str, Any], expt) -> None:
     """
     Display the job information in a human-readable way
     """
@@ -303,8 +306,17 @@ def display_job_info(data: dict[str, Any], cur_expt_time) -> None:
             job_info = all_job_info.get("scheduler_job_info", {}).get("Jobs", {}).get(job_id, {})
             display_wait_time(job_info.get("qtime", None), job_info.get("stime", None))
 
-            if run_info.get("stage") == "model-run" and cur_expt_time is not None:
-                print(f"  {'Current Expt Time:':<18} {cur_expt_time}")
+            if run_info.get("stage") == "model-run":
+                cur_expt_time = None
+                try:
+                    cur_expt_time = expt.get_model_cur_expt_time()
+                except (FileNotFoundError, IndexError, OSError, json.JSONDecodeError, UnboundLocalError) as e:
+                    logger.debug(f"Cannot parse current experiment time: {e}")
+                except Exception as e:
+                    logger.warning(f"Unexpected error getting current experiment time: {e}")
+
+                if cur_expt_time is not None:
+                    print(f"  {'Current Expt Time:':<18} {cur_expt_time.isoformat()}")
             if run_info.get("stage") == "archive":
                 model_finish_time = all_job_info.get("model_finish_time", None)
                 print(f"  {'Model Finish Time:':<18} {model_finish_time}")

--- a/payu/status.py
+++ b/payu/status.py
@@ -10,7 +10,6 @@ import warnings
 from datetime import datetime
 import json
 import logging
-logger = logging.getLogger(__name__)
 
 from payu.schedulers import Scheduler
 from payu.telemetry import (
@@ -19,6 +18,7 @@ from payu.telemetry import (
     remove_job_file
 )
 
+logger = logging.getLogger(__name__)
 
 def find_file_match(pattern: str, path: Path) -> Optional[Path]:
     """Find a file matching the pattern in the given path"""
@@ -135,7 +135,8 @@ def build_job_info(
             archive_path: Path,
             control_path: Path,
             run_number: Optional[int] = None,
-            all_runs: Optional[bool] = False
+            all_runs: Optional[bool] = False,
+            expt=None
         ) -> Optional[dict[str, Any]]:
     """
     Generate a dictionary of jobs information (exit status, stage),
@@ -179,6 +180,10 @@ def build_job_info(
             "start_time": data.get("timings", {}).get("payu_start_time"),
         }
 
+        if data.get("stage") == "archive":
+            # For archive stage, add the model finish time if available
+            run_info["model_finish_time"] = data.get("model_finish_time", None)
+
         run_num = data["payu_current_run"]
         runs.setdefault(run_num, {"run": []})["run"].append(run_info)
 
@@ -199,6 +204,16 @@ def build_job_info(
         # Use latest run job
         for run_num, run_jobs in status_data["runs"].items():
             run_jobs["run"] = [run_jobs["run"][-1]]
+
+    if run_info.get("stage") == "model-run" and expt is not None:
+        try:
+            cur_expt_time = expt.get_model_cur_expt_time()
+            if cur_expt_time is not None:
+                run_info["cur_expt_time"] = cur_expt_time.isoformat()
+        except (FileNotFoundError, IndexError, OSError, json.JSONDecodeError, ValueError, NotImplementedError) as e:
+            logger.debug(f"Cannot parse current experiment time: {e}")
+        except Exception as e:
+            logger.warning(f"Unexpected error while parsing current experiment time: {e}")
 
     return status_data
 
@@ -282,7 +297,7 @@ def print_line(label: str, key: Any, data: dict[str, Any]) -> None:
         print(f"  {f'{label}:':<{label_width}} {value}")
 
 
-def display_job_info(data: dict[str, Any], expt) -> None:
+def display_job_info(data: dict[str, Any]) -> None:
     """
     Display the job information in a human-readable way
     """
@@ -307,16 +322,7 @@ def display_job_info(data: dict[str, Any], expt) -> None:
             display_wait_time(job_info.get("qtime", None), job_info.get("stime", None))
 
             if run_info.get("stage") == "model-run":
-                cur_expt_time = None
-                try:
-                    cur_expt_time = expt.get_model_cur_expt_time()
-                except (FileNotFoundError, IndexError, OSError, json.JSONDecodeError, UnboundLocalError) as e:
-                    logger.debug(f"Cannot parse current experiment time: {e}")
-                except Exception as e:
-                    logger.warning(f"Unexpected error getting current experiment time: {e}")
-
-                if cur_expt_time is not None:
-                    print(f"  {'Current Expt Time:':<18} {cur_expt_time.isoformat()}")
+                print_line("Current Expt Time", "cur_expt_time", run_info)
             if run_info.get("stage") == "archive":
                 model_finish_time = all_job_info.get("model_finish_time", None)
                 print(f"  {'Model Finish Time:':<18} {model_finish_time}")

--- a/payu/status.py
+++ b/payu/status.py
@@ -279,7 +279,7 @@ def print_line(label: str, key: Any, data: dict[str, Any]) -> None:
         print(f"  {f'{label}:':<{label_width}} {value}")
 
 
-def display_job_info(data: dict[str, Any]) -> None:
+def display_job_info(data: dict[str, Any], cur_expt_time) -> None:
     """
     Display the job information in a human-readable way
     """
@@ -299,10 +299,15 @@ def display_job_info(data: dict[str, Any]) -> None:
             #read out qtime and stime from the job file
             job_file = run_info.get("job_file")
             job_id = run_info.get("job_id")
-            all_job_info = read_job_file(Path(job_file)).get("scheduler_job_info", {})
-            job_info = all_job_info.get("Jobs", {}).get(job_id, {})
+            all_job_info = read_job_file(Path(job_file))
+            job_info = all_job_info.get("scheduler_job_info", {}).get("Jobs", {}).get(job_id, {})
             display_wait_time(job_info.get("qtime", None), job_info.get("stime", None))
 
+            if run_info.get("stage") == "model-run" and cur_expt_time is not None:
+                print(f"  {'Current Expt Time:':<18} {cur_expt_time}")
+            if run_info.get("stage") == "archive":
+                model_finish_time = all_job_info.get("model_finish_time", None)
+                print(f"  {'Model Finish Time:':<18} {model_finish_time}")
             exit_status = run_info.get("exit_status")
             if exit_status is not None:
                 status_str = "Success" if exit_status == 0 else "Failed"

--- a/payu/status.py
+++ b/payu/status.py
@@ -174,15 +174,12 @@ def build_job_info(
             "stage": data.get("stage"),
             "exit_status": data.get("payu_run_status"),
             "model_exit_status": data.get("payu_model_run_status"),
+            "model_finish_time": data.get("model_finish_time", None),
             "stdout_file": str(stdout) if stdout else None,
             "stderr_file": str(stderr) if stderr else None,
             "job_file": str(job_file),
             "start_time": data.get("timings", {}).get("payu_start_time"),
         }
-
-        if data.get("stage") == "archive":
-            # For archive stage, add the model finish time if available
-            run_info["model_finish_time"] = data.get("model_finish_time", None)
 
         run_num = data["payu_current_run"]
         runs.setdefault(run_num, {"run": []})["run"].append(run_info)
@@ -205,7 +202,7 @@ def build_job_info(
         for run_num, run_jobs in status_data["runs"].items():
             run_jobs["run"] = [run_jobs["run"][-1]]
 
-    if run_info.get("stage") == "model-run" and expt is not None:
+    if run_info.get("stage") == "model-run":
         try:
             cur_expt_time = expt.get_model_cur_expt_time()
             if cur_expt_time is not None:
@@ -321,11 +318,8 @@ def display_job_info(data: dict[str, Any]) -> None:
             job_info = all_job_info.get("scheduler_job_info", {}).get("Jobs", {}).get(job_id, {})
             display_wait_time(job_info.get("qtime", None), job_info.get("stime", None))
 
-            if run_info.get("stage") == "model-run":
-                print_line("Current Expt Time", "cur_expt_time", run_info)
-            if run_info.get("stage") == "archive":
-                model_finish_time = all_job_info.get("model_finish_time", None)
-                print(f"  {'Model Finish Time:':<18} {model_finish_time}")
+            print_line("Current Expt Time", "cur_expt_time", run_info)
+            print_line("Model Finish Time:", "model_finish_time", run_info)
             exit_status = run_info.get("exit_status")
             if exit_status is not None:
                 status_str = "Success" if exit_status == 0 else "Failed"

--- a/payu/status.py
+++ b/payu/status.py
@@ -114,10 +114,10 @@ def display_wait_time(qtime, stime) -> Optional[str]:
         return None
     elif stime is None:
         start_time = datetime.now()
-        label = "Current queue time"
+        label = "Current Queue Time"
     else:
         start_time = datetime.strptime(stime, "%a %b %d %H:%M:%S %Y")
-        label = "Total queue time"
+        label = "Total Queue Time"
 
     submit_time = datetime.strptime(qtime, "%a %b %d %H:%M:%S %Y")
     wait_time = (start_time - submit_time).total_seconds()
@@ -202,11 +202,15 @@ def build_job_info(
         for run_num, run_jobs in status_data["runs"].items():
             run_jobs["run"] = [run_jobs["run"][-1]]
 
-    if run_info.get("stage") == "model-run":
+    latest_run_num = max(status_data["runs"].keys())
+    latest_run_info = status_data["runs"][latest_run_num]["run"][-1]
+    if latest_run_info.get("stage") == "model-run":
         try:
             cur_expt_time = expt.get_model_cur_expt_time()
             if cur_expt_time is not None:
-                run_info["cur_expt_time"] = cur_expt_time.isoformat()
+                latest_run_info["cur_expt_time"] = cur_expt_time.isoformat()
+            else:
+                logger.debug("Cannot parse current experiment time: expected cftime.datetime but got None.")
         except (FileNotFoundError, IndexError, OSError, json.JSONDecodeError, ValueError, NotImplementedError) as e:
             logger.debug(f"Cannot parse current experiment time: {e}")
         except Exception as e:
@@ -319,7 +323,7 @@ def display_job_info(data: dict[str, Any]) -> None:
             display_wait_time(job_info.get("qtime", None), job_info.get("stime", None))
 
             print_line("Current Expt Time", "cur_expt_time", run_info)
-            print_line("Model Finish Time:", "model_finish_time", run_info)
+            print_line("Model Finish Time", "model_finish_time", run_info)
             exit_status = run_info.get("exit_status")
             if exit_status is not None:
                 status_str = "Success" if exit_status == 0 else "Failed"

--- a/payu/subcommands/status_cmd.py
+++ b/payu/subcommands/status_cmd.py
@@ -9,6 +9,7 @@ import json
 from payu.fsops import read_config
 from payu.metadata import MetadataWarning, Metadata
 from payu.laboratory import Laboratory
+from payu.experiment import Experiment
 import payu.subcommands.args as args
 from payu.status import (
     build_job_info,
@@ -31,21 +32,19 @@ def runcmd(lab_path, config_path, json_output,
     # Suppress output to os.devnull
     with redirect_stdout(open(os.devnull, 'w')):
         # Determine archive path
-        lab = Laboratory(lab_path)
+        lab = Laboratory(config_path=config_path, lab_path=lab_path)
         warnings.filterwarnings("error", category=MetadataWarning)
         try:
-            metadata = Metadata(Path(lab.archive_path),
-                                config_path=config_path)
-            metadata.setup()
+            expt = Experiment(lab, config_path=config_path)
+            expt.init_models()
+            cur_expt_time = expt.get_model_cur_expt_time()
         except MetadataWarning as e:
             raise RuntimeError(
                 "Metadata is not setup - can't determine archive path"
             )
-        archive_path = Path(lab.archive_path) / metadata.experiment_name
 
-        # Determine control path
-        config = read_config(config_path)
-        control_path = Path(config['control_path'])
+        archive_path = Path(expt.archive_path)
+        control_path = Path(expt.control_path)
 
     run_number = int(run_number) if run_number is not None else None
 
@@ -57,8 +56,7 @@ def runcmd(lab_path, config_path, json_output,
     )
     if update_jobs:
         # Get the scheduler
-        scheduler_name = config.get('scheduler', DEFAULT_SCHEDULER_CONFIG)
-        scheduler = scheduler_index[scheduler_name]()
+        scheduler = expt.scheduler
         # Update the job files in data with the latest information
         # from the scheduler
         update_all_job_files(data, scheduler)
@@ -73,6 +71,6 @@ def runcmd(lab_path, config_path, json_output,
     if json_output:
         print(json.dumps(data, indent=4))
     else:
-        display_job_info(data)
+        display_job_info(data, cur_expt_time=cur_expt_time)
 
 runscript = runcmd

--- a/payu/subcommands/status_cmd.py
+++ b/payu/subcommands/status_cmd.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import warnings
 
 import json
+import logging
+logger = logging.getLogger(__name__)
 
 from payu.fsops import read_config
 from payu.metadata import MetadataWarning, Metadata
@@ -37,7 +39,6 @@ def runcmd(lab_path, config_path, json_output,
         try:
             expt = Experiment(lab, config_path=config_path)
             expt.init_models()
-            cur_expt_time = expt.get_model_cur_expt_time()
         except MetadataWarning as e:
             raise RuntimeError(
                 "Metadata is not setup - can't determine archive path"
@@ -69,8 +70,16 @@ def runcmd(lab_path, config_path, json_output,
         )
 
     if json_output:
+        try:
+            cur_expt_time = expt.get_model_cur_expt_time()
+            if cur_expt_time is not None:
+                data["Current Experiment Time"] = cur_expt_time.isoformat()
+        except (FileNotFoundError, IndexError, OSError, json.JSONDecodeError) as e:
+            logger.debug(f"Cannot parse current experiment time: {e}")
+        except Exception as e:
+            logger.warning(f"Unexpected error while parsing current experiment time: {e}")
         print(json.dumps(data, indent=4))
     else:
-        display_job_info(data, cur_expt_time=cur_expt_time)
+        display_job_info(data, expt=expt)
 
 runscript = runcmd

--- a/payu/subcommands/status_cmd.py
+++ b/payu/subcommands/status_cmd.py
@@ -3,10 +3,7 @@ from contextlib import redirect_stdout
 import os
 from pathlib import Path
 import warnings
-
 import json
-import logging
-logger = logging.getLogger(__name__)
 
 from payu.fsops import read_config
 from payu.metadata import MetadataWarning, Metadata
@@ -38,7 +35,6 @@ def runcmd(lab_path, config_path, json_output,
         warnings.filterwarnings("error", category=MetadataWarning)
         try:
             expt = Experiment(lab, config_path=config_path)
-            expt.init_models()
         except MetadataWarning as e:
             raise RuntimeError(
                 "Metadata is not setup - can't determine archive path"
@@ -53,7 +49,8 @@ def runcmd(lab_path, config_path, json_output,
         control_path=control_path,
         archive_path=archive_path,
         run_number=run_number,
-        all_runs=all_runs
+        all_runs=all_runs,
+        expt=expt
     )
     if update_jobs:
         # Get the scheduler
@@ -66,20 +63,13 @@ def runcmd(lab_path, config_path, json_output,
             archive_path=archive_path,
             control_path=control_path,
             run_number=run_number,
-            all_runs=all_runs
+            all_runs=all_runs,
+            expt=expt
         )
 
     if json_output:
-        try:
-            cur_expt_time = expt.get_model_cur_expt_time()
-            if cur_expt_time is not None:
-                data["Current Experiment Time"] = cur_expt_time.isoformat()
-        except (FileNotFoundError, IndexError, OSError, json.JSONDecodeError) as e:
-            logger.debug(f"Cannot parse current experiment time: {e}")
-        except Exception as e:
-            logger.warning(f"Unexpected error while parsing current experiment time: {e}")
         print(json.dumps(data, indent=4))
     else:
-        display_job_info(data, expt=expt)
+        display_job_info(data)
 
 runscript = runcmd

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -495,8 +495,7 @@ def update_run_job_file(
             extra_info: Optional[dict[str, Any]] = None,
             manifests: Optional[dict[str, Any]] = None,
             model_restart_datetimes: Optional[dict[str, Any]] = None,
-            timings: Optional[dict[str, Any]] = None,
-            cur_expt_time: Optional[str] = None
+            timings: Optional[dict[str, Any]] = None
         ) -> None:
     """Update the payu-run job file with the current stage and any extra info
     if defined

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -495,7 +495,8 @@ def update_run_job_file(
             extra_info: Optional[dict[str, Any]] = None,
             manifests: Optional[dict[str, Any]] = None,
             model_restart_datetimes: Optional[dict[str, Any]] = None,
-            timings: Optional[dict[str, Any]] = None
+            timings: Optional[dict[str, Any]] = None,
+            cur_expt_time: Optional[str] = None
         ) -> None:
     """Update the payu-run job file with the current stage and any extra info
     if defined
@@ -530,6 +531,8 @@ def update_run_job_file(
         run_info.update(extra_info)
     if timings:
         run_info.update(get_timings_isoformat(timings))
+    if cur_expt_time:
+        run_info.update({"cur_expt_time": cur_expt_time})
 
     update_job_file(file_path=file_path, data=run_info)
 

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -531,8 +531,6 @@ def update_run_job_file(
         run_info.update(extra_info)
     if timings:
         run_info.update(get_timings_isoformat(timings))
-    if cur_expt_time:
-        run_info.update({"cur_expt_time": cur_expt_time})
 
     update_job_file(file_path=file_path, data=run_info)
 

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -652,7 +652,7 @@ def test_get_cur_expt_time_no_log():
     teardown_cmeps_config()
 
 def test_get_cur_expt_time_no_date():
-    """ Test if get_cur_expt_time returns None if log file does not contain model date. """
+    """ Test if get_cur_expt_time raise error if log file does not contain model date. """
     cmeps_config(1)
 
     with cd(ctrldir):
@@ -665,8 +665,8 @@ def test_get_cur_expt_time_no_date():
         with open(log_path, "w") as f:
             f.write("This log file does not contain the model date.\n")
 
-        cur_expt_time = model.get_cur_expt_time()
-        assert cur_expt_time is None
+        with pytest.raises(ValueError, match="Key string 'memory_write: model date' not found in"):
+            cur_expt_time = model.get_cur_expt_time()
 
     teardown_cmeps_config()
     os.remove(log_path)

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -628,7 +628,7 @@ def test_get_cur_expt_time(tmp_path):
 
         cur_expt_time = model.get_cur_expt_time()
 
-        assert cur_expt_time == "1900-01-02T00:00:00"
+        assert cur_expt_time.isoformat() == "1900-01-02T00:00:00"
 
     teardown_cmeps_config()
 
@@ -646,12 +646,8 @@ def test_get_cur_expt_time_no_log(tmp_path):
         if os.path.exists(log_path):
             os.remove(log_path)
 
-        with pytest.warns(
-            UserWarning, 
-            match=rf"Log file {log_path} does not exist or does not contain current model time."
-        ):
+        with pytest.raises(FileNotFoundError):
             cur_expt_time = model.get_cur_expt_time()
-        assert cur_expt_time is None
 
     teardown_cmeps_config()
 
@@ -669,11 +665,7 @@ def test_get_cur_expt_time_no_date(tmp_path):
         with open(log_path, "w") as f:
             f.write("This log file does not contain the model date.\n")
 
-        with pytest.warns(
-            UserWarning, 
-            match=rf"Log file {log_path} does not exist or does not contain current model time."
-        ):
-            cur_expt_time = model.get_cur_expt_time()
+        cur_expt_time = model.get_cur_expt_time()
         assert cur_expt_time is None
 
     teardown_cmeps_config()

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -611,3 +611,69 @@ def test_collect_restart_files_nonexist_rpointer():
         assert "Restart pointer file not found at the end of payu run" in str(e.value)
 
     teardown_cmeps_config()
+
+def test_get_cur_expt_time(tmp_path):
+    """ Test if get_cur_expt_time correctly parses the model date from the log file. """
+    cmeps_config(1)
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        log_path = os.path.join(model.work_path, "log", "med.log")
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        with open(log_path, "w") as f:
+            f.write(" memory_write: model date = 1900-01-02T00:00:00 \n")
+
+        cur_expt_time = model.get_cur_expt_time()
+
+        assert cur_expt_time == "1900-01-02T00:00:00"
+
+    teardown_cmeps_config()
+
+
+def test_get_cur_expt_time_no_log(tmp_path):
+    """ Test if get_cur_expt_time returns None if log file is missing. """
+    cmeps_config(1)
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        log_path = os.path.join(model.work_path, "log", "med.log")
+        if os.path.exists(log_path):
+            os.remove(log_path)
+
+        with pytest.warns(
+            UserWarning, 
+            match=rf"Log file {log_path} does not exist or does not contain current model time."
+        ):
+            cur_expt_time = model.get_cur_expt_time()
+        assert cur_expt_time is None
+
+    teardown_cmeps_config()
+
+def test_get_cur_expt_time_no_date(tmp_path):
+    """ Test if get_cur_expt_time returns None if log file does not contain model date. """
+    cmeps_config(1)
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        log_path = os.path.join(model.work_path, "log", "med.log")
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        with open(log_path, "w") as f:
+            f.write("This log file does not contain the model date.\n")
+
+        with pytest.warns(
+            UserWarning, 
+            match=rf"Log file {log_path} does not exist or does not contain current model time."
+        ):
+            cur_expt_time = model.get_cur_expt_time()
+        assert cur_expt_time is None
+
+    teardown_cmeps_config()

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -612,7 +612,7 @@ def test_collect_restart_files_nonexist_rpointer():
 
     teardown_cmeps_config()
 
-def test_get_cur_expt_time(tmp_path):
+def test_get_cur_expt_time():
     """ Test if get_cur_expt_time correctly parses the model date from the log file. """
     cmeps_config(1)
 
@@ -631,10 +631,11 @@ def test_get_cur_expt_time(tmp_path):
         assert cur_expt_time.isoformat() == "1900-01-02T00:00:00"
 
     teardown_cmeps_config()
+    os.remove(log_path)
 
 
-def test_get_cur_expt_time_no_log(tmp_path):
-    """ Test if get_cur_expt_time returns None if log file is missing. """
+def test_get_cur_expt_time_no_log():
+    """ Test if get_cur_expt_time raise an error if log file is missing. """
     cmeps_config(1)
 
     with cd(ctrldir):
@@ -643,15 +644,14 @@ def test_get_cur_expt_time_no_log(tmp_path):
         model = expt.models[0]
 
         log_path = os.path.join(model.work_path, "log", "med.log")
-        if os.path.exists(log_path):
-            os.remove(log_path)
 
+        assert not os.path.exists(log_path)
         with pytest.raises(FileNotFoundError):
             cur_expt_time = model.get_cur_expt_time()
 
     teardown_cmeps_config()
 
-def test_get_cur_expt_time_no_date(tmp_path):
+def test_get_cur_expt_time_no_date():
     """ Test if get_cur_expt_time returns None if log file does not contain model date. """
     cmeps_config(1)
 
@@ -669,3 +669,4 @@ def test_get_cur_expt_time_no_date(tmp_path):
         assert cur_expt_time is None
 
     teardown_cmeps_config()
+    os.remove(log_path)

--- a/test/models/test_access.py
+++ b/test/models/test_access.py
@@ -461,3 +461,16 @@ def test_access_get_um_restart_datetime(um_only_config, remove_restart_dirs):
     restart_path = list_expt_archive_dirs()[0]
     parsed_run_dt = expt.model.get_restart_datetime(restart_path)
     assert parsed_run_dt == date
+
+def test_get_cur_expt_time_not_implemented_warning(um_only_config):
+    """
+    Check that a warning is raised when trying to get the current experiment time
+    for the access model, as this functionality is not yet implemented.
+    """
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    with pytest.warns(UserWarning, match="Getting current experiment time is not yet implemented."):
+        cur_expt_time = expt.get_model_cur_expt_time()
+        assert cur_expt_time is None

--- a/test/models/test_access.py
+++ b/test/models/test_access.py
@@ -2,6 +2,8 @@ import copy
 import datetime
 import os
 import shutil
+import logging
+logger = logging.getLogger(__name__)
 
 import pytest
 import cftime
@@ -462,15 +464,17 @@ def test_access_get_um_restart_datetime(um_only_config, remove_restart_dirs):
     parsed_run_dt = expt.model.get_restart_datetime(restart_path)
     assert parsed_run_dt == date
 
-def test_get_cur_expt_time_not_implemented_warning(um_only_config):
+def test_get_cur_expt_time_not_implemented_print(um_only_config, caplog):
     """
-    Check that a warning is raised when trying to get the current experiment time
+    Check that a debug message is logged when trying to get the current experiment time
     for the access model, as this functionality is not yet implemented.
     """
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
-
-    with pytest.warns(UserWarning, match="Getting current experiment time is not yet implemented."):
-        cur_expt_time = expt.get_model_cur_expt_time()
-        assert cur_expt_time is None
+    
+    caplog.set_level(logging.DEBUG)
+    cur_expt_time = expt.get_model_cur_expt_time()
+    assert cur_expt_time is None
+    assert "Current experiment time not implemented for this model." in caplog.records[0].message
+    

--- a/test/models/test_access.py
+++ b/test/models/test_access.py
@@ -2,8 +2,6 @@ import copy
 import datetime
 import os
 import shutil
-import logging
-logger = logging.getLogger(__name__)
 
 import pytest
 import cftime
@@ -24,9 +22,7 @@ from test.models.test_um import make_atmosphere_restart_dir
 from test.models.test_mom_mixin import make_ocean_restart_dir
 from payu.calendar import GREGORIAN, NOLEAP
 
-
 verbose = True
-
 
 INPUT_ICE_FNAME = "input_ice.nml"
 RESTART_DATE_FNAME = "restart_date.nml"
@@ -464,7 +460,7 @@ def test_access_get_um_restart_datetime(um_only_config, remove_restart_dirs):
     parsed_run_dt = expt.model.get_restart_datetime(restart_path)
     assert parsed_run_dt == date
 
-def test_get_cur_expt_time_not_implemented_print(um_only_config, caplog):
+def test_get_cur_expt_time(um_only_config):
     """
     Check that a debug message is logged when trying to get the current experiment time
     for the access model, as this functionality is not yet implemented.
@@ -473,8 +469,54 @@ def test_get_cur_expt_time_not_implemented_print(um_only_config, caplog):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
     
-    caplog.set_level(logging.DEBUG)
+    # write the um.res.yaml with a known restart date
+    restart_calendar_path = os.path.join(expt.work_path, 'atmosphere', 'um.res.yaml')
+    os.makedirs(os.path.dirname(restart_calendar_path), exist_ok=True)
+    with open(restart_calendar_path, 'w') as f:
+        f.write("end_date: 1900-01-31 00:00:00\n")
+
+    #write log file with a known timestep and default step length (30 min)
+    log_path = os.path.join(expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    with open(log_path, 'w') as f:
+        f.write(f"U_MODEL: STEPS_PER_PERIODim=                    48\n")
+        f.write(f"U_MODEL: SECS_PER_PERIODim=                 86400\n")
+        f.write(f"Atm_Step: Timestep                      10\n")
+
     cur_expt_time = expt.get_model_cur_expt_time()
-    assert cur_expt_time is None
-    assert "Current experiment time not implemented for this model." in caplog.records[0].message
-    
+    assert cur_expt_time.isoformat() == "1900-01-31T05:00:00"
+
+@pytest.mark.parametrize("missing_file", [
+    (
+        ['um.res.yaml']
+    ),
+    (
+        ['atm.fort6.pe0']
+    ),
+    (
+        ['um.res.yaml', 'atm.fort6.pe0']
+    )
+])
+def test_get_cur_expt_time_missing_files(um_only_config, missing_file):
+    """
+    Check that a debug message is logged when trying to get the current experiment time
+    for the access model, as this functionality is not yet implemented.
+    """
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    restart_calendar_path = os.path.join(expt.work_path, 'atmosphere', 'um.res.yaml')
+    log_path = os.path.join(expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    with open(restart_calendar_path, 'w') as f:
+        f.write("end_date: 1901-03-01 00:00:00\n")
+    open(log_path, 'a').close()
+
+    if 'um.res.yaml' in missing_file:
+        os.remove(restart_calendar_path)
+    if 'atm.fort6.pe0' in missing_file:
+        os.remove(log_path)
+
+    with pytest.raises(FileNotFoundError):
+        cur_expt_time = expt.get_model_cur_expt_time()

--- a/test/models/test_access.py
+++ b/test/models/test_access.py
@@ -462,8 +462,7 @@ def test_access_get_um_restart_datetime(um_only_config, remove_restart_dirs):
 
 def test_get_cur_expt_time(um_only_config):
     """
-    Check that a debug message is logged when trying to get the current experiment time
-    for the access model, as this functionality is not yet implemented.
+    Check the current experiment time is correctly parsed for the access model 
     """
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
@@ -499,8 +498,7 @@ def test_get_cur_expt_time(um_only_config):
 ])
 def test_get_cur_expt_time_missing_files(um_only_config, missing_file):
     """
-    Check that a debug message is logged when trying to get the current experiment time
-    for the access model, as this functionality is not yet implemented.
+    Check that FileNotFound is raised when missing restart calendar or log paths 
     """
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))

--- a/test/models/test_access_esm1p6.py
+++ b/test/models/test_access_esm1p6.py
@@ -1,10 +1,12 @@
 import copy
 import os
 import shutil
+import f90nml
 
 import pytest
 
 import payu
+from payu.models.access_esm1p6 import AccessEsm1p6
 
 from test.common import cd, expt_workdir
 from test.common import tmpdir, ctrldir, labdir, workdir, archive_dir
@@ -150,3 +152,103 @@ def test_esm1p6_patch_optional_config_files(um_only_ctrl_dir,
         set(esm1p6_um_model.optional_config_files) ==
         set(um_standalone_model.optional_config_files).union(expected_files)
     )
+
+
+def test_get_cur_expt_time(um_only_ctrl_dir, esm1p6_um_only_config):
+    """
+    Test that the access-esm1.6 driver correctly parses the model_basis_time.
+    """
+    # Initialise ESM1.6
+    with cd(ctrldir):
+        esm1p6_lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        esm1p6_expt = payu.experiment.Experiment(esm1p6_lab, reproduce=False)
+
+    # write the namelist with a known model_basis_time (start date)
+    nl_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'namelists')
+    os.makedirs(os.path.dirname(nl_path), exist_ok=True)
+    model_basis_time = [1900, 1, 31, 0, 0, 0]
+    nml = f90nml.Namelist()
+    nml['nlstcall'] = {'model_basis_time': model_basis_time}
+    f90nml.write(nml, nl_path, force=True)
+
+    #write log file with a known timestep and default step length (30 min)
+    log_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+    with open(log_path, 'w') as f:
+        f.write(f"U_MODEL: STEPS_PER_PERIODim=                    48\n")
+        f.write(f"U_MODEL: SECS_PER_PERIODim=                 86400\n")
+        f.write(f"Atm_Step: Timestep                      10\n")
+
+    cur_expt_time = esm1p6_expt.get_model_cur_expt_time()
+    assert cur_expt_time == "1900-01-31T05:00:00"
+
+
+@pytest.mark.parametrize("missing_file", [
+    (
+        ['namelists']
+    ),
+    (
+        ['atm.fort6.pe0']
+    ),
+    (
+        ['namelists', 'atm.fort6.pe0']
+    )
+])
+def test_get_cur_expt_time_missing_files(um_only_ctrl_dir, esm1p6_um_only_config, missing_file):
+    """
+    Test that the access-esm1.6 driver correctly handles missing files.
+    """
+    # Initialise ESM1.6
+    with cd(ctrldir):
+        esm1p6_lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        esm1p6_expt = payu.experiment.Experiment(esm1p6_lab, reproduce=False)
+
+    nl_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'namelists')
+    log_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+    os.makedirs(os.path.dirname(nl_path), exist_ok=True)
+    open(nl_path, 'a').close()
+    open(log_path, 'a').close()
+
+    if 'namelists' in missing_file:
+        os.remove(nl_path)
+    if 'atm.fort6.pe0' in missing_file:
+        os.remove(log_path)
+
+    with pytest.warns(UserWarning, match=f"Could not find required files: {nl_path} or {log_path}"):
+        cur_expt_time = esm1p6_expt.get_model_cur_expt_time()
+        assert cur_expt_time is None
+
+def test_read_start_date(um_only_ctrl_dir, esm1p6_um_only_config):
+    # Initialise ESM1.6
+    with cd(ctrldir):
+        esm1p6_lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        esm1p6_expt = payu.experiment.Experiment(esm1p6_lab, reproduce=False)
+
+    model = AccessEsm1p6(expt=esm1p6_expt, name="test_esm1p6", config={})
+    nl_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'namelists')
+    os.makedirs(os.path.dirname(nl_path), exist_ok=True)
+    nml = f90nml.Namelist()
+    nml['top_key'] = {'key': 'value'}
+    f90nml.write(nml, nl_path, force=True)
+    with pytest.warns(UserWarning, match=f"model_basis_time not found in {nl_path}"):
+        model.read_start_date(nl_path)
+
+def test_convert_timestep(um_only_ctrl_dir, esm1p6_um_only_config):
+    """ Test with an invalid log file"""
+    # Initialise ESM1.6
+    with cd(ctrldir):
+        esm1p6_lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        esm1p6_expt = payu.experiment.Experiment(esm1p6_lab, reproduce=False)
+    
+    model = AccessEsm1p6(expt=esm1p6_expt, name="test_esm1p6", config={})
+    log_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+
+    # write invalid content into log file
+    with open(log_path, 'w') as f:
+        f.write(f"U_MODEL: STEPS_PER_PERIODim=                    48\n")
+        f.write(f"U_MODEL: SECS_PER_PERIODim=                 86400\n")
+        f.write(f"There is no Atm_Step: Timestep\n")
+
+    with pytest.warns(UserWarning, match=f"""Could not find all required entries in file {log_path}
+                to calculate run time"""):
+        model.convert_timestep(log_path)

--- a/test/models/test_access_esm1p6.py
+++ b/test/models/test_access_esm1p6.py
@@ -163,34 +163,33 @@ def test_get_cur_expt_time(um_only_ctrl_dir, esm1p6_um_only_config):
         esm1p6_lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         esm1p6_expt = payu.experiment.Experiment(esm1p6_lab, reproduce=False)
 
-    # write the namelist with a known model_basis_time (start date)
-    nl_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'namelists')
-    os.makedirs(os.path.dirname(nl_path), exist_ok=True)
-    model_basis_time = [1900, 1, 31, 0, 0, 0]
-    nml = f90nml.Namelist()
-    nml['nlstcall'] = {'model_basis_time': model_basis_time}
-    f90nml.write(nml, nl_path, force=True)
+    # write the um.res.yaml with a known restart date
+    restart_calendar_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'um.res.yaml')
+    os.makedirs(os.path.dirname(restart_calendar_path), exist_ok=True)
+    with open(restart_calendar_path, 'w') as f:
+        f.write("end_date: 1900-01-31 00:00:00\n")
 
     #write log file with a known timestep and default step length (30 min)
     log_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
     with open(log_path, 'w') as f:
         f.write(f"U_MODEL: STEPS_PER_PERIODim=                    48\n")
         f.write(f"U_MODEL: SECS_PER_PERIODim=                 86400\n")
         f.write(f"Atm_Step: Timestep                      10\n")
 
     cur_expt_time = esm1p6_expt.get_model_cur_expt_time()
-    assert cur_expt_time == "1900-01-31T05:00:00"
+    assert cur_expt_time.isoformat() == "1900-01-31T05:00:00"
 
 
 @pytest.mark.parametrize("missing_file", [
     (
-        ['namelists']
+        ['um.res.yaml']
     ),
     (
         ['atm.fort6.pe0']
     ),
     (
-        ['namelists', 'atm.fort6.pe0']
+        ['um.res.yaml', 'atm.fort6.pe0']
     )
 ])
 def test_get_cur_expt_time_missing_files(um_only_ctrl_dir, esm1p6_um_only_config, missing_file):
@@ -202,53 +201,17 @@ def test_get_cur_expt_time_missing_files(um_only_ctrl_dir, esm1p6_um_only_config
         esm1p6_lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         esm1p6_expt = payu.experiment.Experiment(esm1p6_lab, reproduce=False)
 
-    nl_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'namelists')
+    restart_calendar_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'um.res.yaml')
     log_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'atm.fort6.pe0')
-    os.makedirs(os.path.dirname(nl_path), exist_ok=True)
-    open(nl_path, 'a').close()
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    with open(restart_calendar_path, 'w') as f:
+        f.write("end_date: 1901-03-01 00:00:00\n")
     open(log_path, 'a').close()
 
-    if 'namelists' in missing_file:
-        os.remove(nl_path)
+    if 'um.res.yaml' in missing_file:
+        os.remove(restart_calendar_path)
     if 'atm.fort6.pe0' in missing_file:
         os.remove(log_path)
 
-    with pytest.warns(UserWarning, match=f"Could not find required files: {nl_path} or {log_path}"):
+    with pytest.raises(FileNotFoundError):
         cur_expt_time = esm1p6_expt.get_model_cur_expt_time()
-        assert cur_expt_time is None
-
-def test_read_start_date(um_only_ctrl_dir, esm1p6_um_only_config):
-    # Initialise ESM1.6
-    with cd(ctrldir):
-        esm1p6_lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        esm1p6_expt = payu.experiment.Experiment(esm1p6_lab, reproduce=False)
-
-    model = AccessEsm1p6(expt=esm1p6_expt, name="test_esm1p6", config={})
-    nl_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'namelists')
-    os.makedirs(os.path.dirname(nl_path), exist_ok=True)
-    nml = f90nml.Namelist()
-    nml['top_key'] = {'key': 'value'}
-    f90nml.write(nml, nl_path, force=True)
-    with pytest.warns(UserWarning, match=f"model_basis_time not found in {nl_path}"):
-        model.read_start_date(nl_path)
-
-def test_convert_timestep(um_only_ctrl_dir, esm1p6_um_only_config):
-    """ Test with an invalid log file"""
-    # Initialise ESM1.6
-    with cd(ctrldir):
-        esm1p6_lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        esm1p6_expt = payu.experiment.Experiment(esm1p6_lab, reproduce=False)
-    
-    model = AccessEsm1p6(expt=esm1p6_expt, name="test_esm1p6", config={})
-    log_path = os.path.join(esm1p6_expt.work_path, 'atmosphere', 'atm.fort6.pe0')
-    os.makedirs(os.path.dirname(log_path), exist_ok=True)
-
-    # write invalid content into log file
-    with open(log_path, 'w') as f:
-        f.write(f"U_MODEL: STEPS_PER_PERIODim=                    48\n")
-        f.write(f"U_MODEL: SECS_PER_PERIODim=                 86400\n")
-        f.write(f"There is no Atm_Step: Timestep\n")
-
-    with pytest.warns(UserWarning, match=f"""Could not find all required entries in file {log_path}
-                to calculate run time"""):
-        model.convert_timestep(log_path)

--- a/test/models/test_access_om2.py
+++ b/test/models/test_access_om2.py
@@ -2,15 +2,12 @@ import copy
 import os
 import shutil
 import pytest
-import logging
 
 import payu
-import cftime
 
 from test.common import cd, tmpdir, ctrldir, labdir, workdir, write_config, config_path
 from test.common import config as config_orig
 from test.common import make_inputs, make_exe
-from test.common import list_expt_archive_dirs, make_expt_archive_dir, remove_expt_archive_dirs
 
 MODEL = 'access-om2'
 
@@ -50,7 +47,7 @@ def teardown_config():
     # Teardown
     os.remove(config_path)
 
-def test_get_cur_expt_time(tmp_path):
+def test_get_cur_expt_time():
     """ Test if get_cur_expt_time correctly parses the model date from the log file. """
     setup_config(1)
 
@@ -69,8 +66,9 @@ def test_get_cur_expt_time(tmp_path):
         assert cur_expt_time.isoformat() == "1900-01-31T00:00:00"
 
     teardown_config()
+    os.remove(log_path)
 
-def test_get_cur_expt_time_no_log(tmp_path):
+def test_get_cur_expt_time_no_log():
     """ Test if get_cur_expt_time returns None if log file is missing. """
     setup_config(1)
 
@@ -80,16 +78,15 @@ def test_get_cur_expt_time_no_log(tmp_path):
         model = expt.models[0]
 
         log_path = os.path.join(model.work_path, "atmosphere", "log", "matmxx.pe00000.log")
-        if os.path.exists(log_path):
-            os.remove(log_path)
-
+        
+        assert not os.path.exists(log_path)
         with pytest.raises(FileNotFoundError):
             cur_expt_time = model.get_cur_expt_time()
 
     teardown_config()
 
-def test_get_cur_expt_time_no_date(tmp_path, caplog):
-    """ Test if get_cur_expt_time returns None if log file does not contain model date. """
+def test_get_cur_expt_time_no_date():
+    """ Test if get_cur_expt_time raise an error if log file does not contain model date. """
     setup_config(1)
 
     with cd(ctrldir):
@@ -102,9 +99,9 @@ def test_get_cur_expt_time_no_date(tmp_path, caplog):
         with open(log_path, "w") as f:
             f.write("This log file does not contain the model date.\n")
 
-        with caplog.at_level('DEBUG'):
+        with pytest.raises(ValueError, match=f"Key 'cur_exp-datetime' not found in {log_path}"):
             cur_expt_time = model.get_cur_expt_time()
-        assert cur_expt_time is None
-        assert f"cur_exp-datetime not found in {log_path}" in caplog.text
+            assert cur_expt_time is None
 
     teardown_config()
+    os.remove(log_path)

--- a/test/models/test_access_om2.py
+++ b/test/models/test_access_om2.py
@@ -1,0 +1,118 @@
+import copy
+import os
+import shutil
+import pytest
+
+import payu
+import cftime
+
+from test.common import cd, tmpdir, ctrldir, labdir, workdir, write_config, config_path
+from test.common import config as config_orig
+from test.common import make_inputs, make_exe
+from test.common import list_expt_archive_dirs, make_expt_archive_dir, remove_expt_archive_dirs
+
+MODEL = 'access-om2'
+
+def setup_module(module):
+    """
+    Put any test-wide setup code in here, e.g. creating test files
+    """
+
+    # Should be taken care of by teardown, in case remnants lying around
+    try:
+        shutil.rmtree(tmpdir)
+    except FileNotFoundError:
+        pass
+
+    try:
+        tmpdir.mkdir()
+        labdir.mkdir()
+        ctrldir.mkdir()
+        workdir.mkdir()
+        # archive_dir.mkdir()
+        make_inputs()
+        make_exe()
+    except Exception as e:
+        print(e)
+
+
+def cmeps_config(ncpu):
+    # Create a config.yaml and nuopc.runconfig file
+
+    config = copy.deepcopy(config_orig)
+    config['model'] = MODEL
+    config['ncpus'] = ncpu
+
+    write_config(config)
+
+    with open(os.path.join(ctrldir, 'nuopc.runconfig'), "w") as f:
+        f.close()
+
+def teardown_cmeps_config():
+    # Teardown
+    os.remove(config_path)
+
+def test_get_cur_expt_time(tmp_path):
+    """ Test if get_cur_expt_time correctly parses the model date from the log file. """
+    cmeps_config(1)
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        log_path = os.path.join(model.work_path, "atmosphere", "log", "matmxx.pe00000.log")
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        with open(log_path, "w") as f:
+            f.write('{ "cur_exp-datetime" :  "1900-01-31T00:00:00" }')
+
+        cur_expt_time = model.get_cur_expt_time()
+
+        assert cur_expt_time == "1900-01-31T00:00:00"
+
+    teardown_cmeps_config()
+
+def test_get_cur_expt_time_no_log(tmp_path):
+    """ Test if get_cur_expt_time returns None if log file is missing. """
+    cmeps_config(1)
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        log_path = os.path.join(model.work_path, "atmosphere", "log", "matmxx.pe00000.log")
+        if os.path.exists(log_path):
+            os.remove(log_path)
+
+        with pytest.warns(
+            UserWarning, 
+            match=rf"Log file {log_path} does not exist or does not contain current model time."
+        ):
+            cur_expt_time = model.get_cur_expt_time()
+        assert cur_expt_time is None
+
+    teardown_cmeps_config()
+
+def test_get_cur_expt_time_no_date(tmp_path):
+    """ Test if get_cur_expt_time returns None if log file does not contain model date. """
+    cmeps_config(1)
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        log_path = os.path.join(model.work_path, "atmosphere", "log", "matmxx.pe00000.log")
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        with open(log_path, "w") as f:
+            f.write("This log file does not contain the model date.\n")
+
+        with pytest.warns(
+            UserWarning, 
+            match=rf"Log file {log_path} does not exist or does not contain current model time."
+        ):
+            cur_expt_time = model.get_cur_expt_time()
+        assert cur_expt_time is None
+
+    teardown_cmeps_config()

--- a/test/models/test_access_om2.py
+++ b/test/models/test_access_om2.py
@@ -2,6 +2,7 @@ import copy
 import os
 import shutil
 import pytest
+import logging
 
 import payu
 import cftime
@@ -36,8 +37,8 @@ def setup_module(module):
         print(e)
 
 
-def cmeps_config(ncpu):
-    # Create a config.yaml and nuopc.runconfig file
+def setup_config(ncpu):
+    # Create a config.yaml
 
     config = copy.deepcopy(config_orig)
     config['model'] = MODEL
@@ -45,16 +46,13 @@ def cmeps_config(ncpu):
 
     write_config(config)
 
-    with open(os.path.join(ctrldir, 'nuopc.runconfig'), "w") as f:
-        f.close()
-
-def teardown_cmeps_config():
+def teardown_config():
     # Teardown
     os.remove(config_path)
 
 def test_get_cur_expt_time(tmp_path):
     """ Test if get_cur_expt_time correctly parses the model date from the log file. """
-    cmeps_config(1)
+    setup_config(1)
 
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
@@ -68,13 +66,13 @@ def test_get_cur_expt_time(tmp_path):
 
         cur_expt_time = model.get_cur_expt_time()
 
-        assert cur_expt_time == "1900-01-31T00:00:00"
+        assert cur_expt_time.isoformat() == "1900-01-31T00:00:00"
 
-    teardown_cmeps_config()
+    teardown_config()
 
 def test_get_cur_expt_time_no_log(tmp_path):
     """ Test if get_cur_expt_time returns None if log file is missing. """
-    cmeps_config(1)
+    setup_config(1)
 
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
@@ -85,18 +83,14 @@ def test_get_cur_expt_time_no_log(tmp_path):
         if os.path.exists(log_path):
             os.remove(log_path)
 
-        with pytest.warns(
-            UserWarning, 
-            match=rf"Log file {log_path} does not exist or does not contain current model time."
-        ):
+        with pytest.raises(FileNotFoundError):
             cur_expt_time = model.get_cur_expt_time()
-        assert cur_expt_time is None
 
-    teardown_cmeps_config()
+    teardown_config()
 
-def test_get_cur_expt_time_no_date(tmp_path):
+def test_get_cur_expt_time_no_date(tmp_path, caplog):
     """ Test if get_cur_expt_time returns None if log file does not contain model date. """
-    cmeps_config(1)
+    setup_config(1)
 
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
@@ -108,11 +102,9 @@ def test_get_cur_expt_time_no_date(tmp_path):
         with open(log_path, "w") as f:
             f.write("This log file does not contain the model date.\n")
 
-        with pytest.warns(
-            UserWarning, 
-            match=rf"Log file {log_path} does not exist or does not contain current model time."
-        ):
+        with caplog.at_level('DEBUG'):
             cur_expt_time = model.get_cur_expt_time()
         assert cur_expt_time is None
+        assert f"cur_exp-datetime not found in {log_path}" in caplog.text
 
-    teardown_cmeps_config()
+    teardown_config()

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -398,11 +398,6 @@ def test_read_start_date():
     nml['top_key'] = {'key': 'value'}
     f90nml.write(nml, input_path, force=True)
 
-    # Write a timestep into ocean.stats
-    stats_path = os.path.join(expt.work_path, 'ocean.stats')
-    with open(stats_path, 'w') as f:
-        f.write("360,      50.000,\n")
-    
     # Write a calendar and current model time into ocean_solo.res
     ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
     os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
@@ -410,8 +405,8 @@ def test_read_start_date():
         f.write("2\n")  # Use Julian calendar
 
     with pytest.raises(ValueError, match=f"Key 'date_init' not found in {input_path}"):
-        cur_expt_time = expt.get_model_cur_expt_time()
-        assert cur_expt_time is None
+        calendar = expt.model.get_calendar(ocean_solo_path)
+        start_date = expt.model.read_start_date(input_path, calendar)
 
 
 def test_read_timestep():
@@ -420,42 +415,19 @@ def test_read_timestep():
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
 
-    # Write a restart date into input.nml
-    input_path = os.path.join(expt.work_path, 'input.nml')
-    nml = f90nml.Namelist()
-    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
-    f90nml.write(nml, input_path, force=True)
-
     # Write a timestep into ocean.stats
     stats_path = os.path.join(expt.work_path, 'ocean.stats')
     with open(stats_path, 'w') as f:
         f.write("0\n")
-    
-    # Write a calendar into ocean_solo.res
-    ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
-    os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
-    with open(ocean_solo_path, 'w') as f:
-        f.write("2\n")  # Use Julian calendar
 
     with pytest.raises(IndexError):
-        cur_expt_time = expt.get_model_cur_expt_time()
+        timestep = expt.model.read_timestep(stats_path)
 
 def test_get_calendar():
     """ Test that get_calendar() correctly handle error when ocean_solo.res is empty."""
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
-
-    # Write a restart date into input.nml
-    input_path = os.path.join(expt.work_path, 'input.nml')
-    nml = f90nml.Namelist()
-    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
-    f90nml.write(nml, input_path, force=True)
-
-    # Write a timestep into ocean.stats
-    stats_path = os.path.join(expt.work_path, 'ocean.stats')
-    with open(stats_path, 'w') as f:
-        f.write("0\n")
     
     # Write a calendar into ocean_solo.res
     ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
@@ -464,4 +436,4 @@ def test_get_calendar():
         f.write("\n")  # Empty
 
     with pytest.raises(IndexError):
-        cur_expt_time = expt.get_model_cur_expt_time()
+        calendar = expt.model.get_calendar(ocean_solo_path)

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 import f90nml
-import logging
 
 import payu
 
@@ -320,26 +319,149 @@ def test_get_cur_expt_time():
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
 
-    # Write a calendar and current model time into ocean_solo.res
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("360,      50.000,\n") # timestep, time in days
+
+    # Write a calendar into ocean_solo.res
     ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
-    os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
+    os.makedirs(expt.restart_path, exist_ok=True)
     with open(ocean_solo_path, 'w') as f:
         f.write("2\n")  # Use Julian calendar
-        f.write("1     1     1     0     0     0        Model start time:\n")  # Initial experiment time
-        f.write("1     3    12     0     0     0        Current model time:\n")  # Current model time
-    
-    cur_expt_time = expt.get_model_cur_expt_time()
-    assert cur_expt_time.isoformat() == "0001-03-12T00:00:00"
-    
 
-def test_get_cur_expt_time_missing_files():
+    cur_expt_time = expt.get_model_cur_expt_time()
+    assert cur_expt_time.isoformat() == "1900-03-21T00:00:00"
+    
+@pytest.mark.parametrize("missing_file",[
+    (
+        ['input.nml']
+    ),
+    (
+        ['ocean.stats']
+    ),
+    (
+        ['ocean_solo.res']
+    ),
+    (
+        ['input.nml', 'ocean.stats', 'ocean_solo.res']
+    )
+])
+def test_get_cur_expt_time_missing_files(missing_file):
     """ Test that get_model_cur_expt_time() correctly handles missing files."""
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
 
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("360,      50.000,\n") # timestep, time in days
+
+    # Write a calendar into ocean_solo.res
     ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
-    if os.path.exists(ocean_solo_path):
-        os.remove(ocean_solo_path)
+    os.makedirs(expt.restart_path, exist_ok=True)
+    with open(ocean_solo_path, 'w') as f:
+        f.write("2\n")  # Use Julian calendar
+
+    for file in missing_file:
+        if file == 'input.nml' or file == 'ocean.stats':
+            os.remove(os.path.join(expt.work_path, file))
+        elif file == 'ocean_solo.res':
+            os.remove(os.path.join(expt.work_path, 'INPUT', file))
+
     with pytest.raises(FileNotFoundError):
+        cur_expt_time = expt.get_model_cur_expt_time()
+
+
+def test_read_start_date():
+    """ Test that read_start_date() correctly handle errors."""
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['top_key'] = {'key': 'value'}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("360,      50.000,\n")
+    
+    # Write a calendar and current model time into ocean_solo.res
+    ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
+    os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
+    with open(ocean_solo_path, 'w') as f:
+        f.write("2\n")  # Use Julian calendar
+
+    with pytest.raises(ValueError, match=f"Key 'date_init' not found in {input_path}"):
+        cur_expt_time = expt.get_model_cur_expt_time()
+        assert cur_expt_time is None
+
+
+def test_read_timestep():
+    """ Test that read_timestep() correctly handle errors."""
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("0\n")
+    
+    # Write a calendar into ocean_solo.res
+    ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
+    os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
+    with open(ocean_solo_path, 'w') as f:
+        f.write("2\n")  # Use Julian calendar
+
+    with pytest.raises(IndexError):
+        cur_expt_time = expt.get_model_cur_expt_time()
+
+def test_get_calendar():
+    """ Test that get_calendar() correctly handle error when ocean_solo.res is empty."""
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("0\n")
+    
+    # Write a calendar into ocean_solo.res
+    ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
+    os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
+    with open(ocean_solo_path, 'w') as f:
+        f.write("\n")  # Empty
+
+    with pytest.raises(IndexError):
         cur_expt_time = expt.get_model_cur_expt_time()

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import f90nml
+import logging
 
 import payu
 
@@ -319,94 +320,26 @@ def test_get_cur_expt_time():
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
 
-    # Write a restart date into input.nml
-    input_path = os.path.join(expt.work_path, 'input.nml')
-    nml = f90nml.Namelist()
-    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
-    f90nml.write(nml, input_path, force=True)
-
-    # Write a timestep into ocean.stats
-    stats_path = os.path.join(expt.work_path, 'ocean.stats')
-    with open(stats_path, 'w') as f:
-        f.write("360,      50.000,\n") # timestep, time in days
-
-    cur_expt_time = expt.get_model_cur_expt_time()
-    assert cur_expt_time == "1900-03-22T00:00:00"
+    # Write a calendar and current model time into ocean_solo.res
+    ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
+    os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
+    with open(ocean_solo_path, 'w') as f:
+        f.write("2\n")  # Use Julian calendar
+        f.write("1     1     1     0     0     0        Model start time:\n")  # Initial experiment time
+        f.write("1     3    12     0     0     0        Current model time:\n")  # Current model time
     
-@pytest.mark.parametrize("missing_file",[
-    (
-        ['input.nml']
-    ),
-    (
-        ['ocean.stats']
-    ),
-    (
-        ['input.nml', 'ocean.stats']
-    )
-])
-def test_get_cur_expt_time_missing_files(missing_file):
+    cur_expt_time = expt.get_model_cur_expt_time()
+    assert cur_expt_time.isoformat() == "0001-03-12T00:00:00"
+    
+
+def test_get_cur_expt_time_missing_files():
     """ Test that get_model_cur_expt_time() correctly handles missing files."""
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
 
-    # Write a restart date into input.nml
-    input_path = os.path.join(expt.work_path, 'input.nml')
-    nml = f90nml.Namelist()
-    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
-    f90nml.write(nml, input_path, force=True)
-
-    # Write a timestep into ocean.stats
-    stats_path = os.path.join(expt.work_path, 'ocean.stats')
-    with open(stats_path, 'w') as f:
-        f.write("360,      50.000,\n") # timestep, time in days
-
-    for file in missing_file:
-        os.remove(os.path.join(expt.work_path, file)) 
-
-    with pytest.warns(UserWarning, match=f"Could not find required files: {input_path} or {stats_path}"):
+    ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
+    if os.path.exists(ocean_solo_path):
+        os.remove(ocean_solo_path)
+    with pytest.raises(FileNotFoundError):
         cur_expt_time = expt.get_model_cur_expt_time()
-
-    assert cur_expt_time is None
-
-def test_read_start_date():
-    """ Test that read_start_date() correctly handle errors."""
-    with cd(ctrldir):
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-
-    # Write a restart date into input.nml
-    input_path = os.path.join(expt.work_path, 'input.nml')
-    nml = f90nml.Namelist()
-    nml['top_key'] = {'key': 'value'}
-    f90nml.write(nml, input_path, force=True)
-
-    # Write a timestep into ocean.stats
-    stats_path = os.path.join(expt.work_path, 'ocean.stats')
-    with open(stats_path, 'w') as f:
-        f.write("360,      50.000,\n")
-
-    with pytest.warns(UserWarning, match=f"date_init not found in {input_path}"):
-        cur_expt_time = expt.get_model_cur_expt_time()
-    assert cur_expt_time is None
-
-def test_read_timestep():
-    """ Test that read_timestep() correctly handle errors."""
-    with cd(ctrldir):
-        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
-
-    # Write a restart date into input.nml
-    input_path = os.path.join(expt.work_path, 'input.nml')
-    nml = f90nml.Namelist()
-    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
-    f90nml.write(nml, input_path, force=True)
-
-    # Write a timestep into ocean.stats
-    stats_path = os.path.join(expt.work_path, 'ocean.stats')
-    with open(stats_path, 'w') as f:
-        f.write("invalid timestep\n")
-
-    with pytest.warns(UserWarning, match=f"Could not read timestep from {stats_path}.*"):
-        cur_expt_time = expt.get_model_cur_expt_time()
-    assert cur_expt_time is None

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -310,3 +310,103 @@ def test_setup():
     input_nml = f90nml.read(work_input_fpath)
     assert input_nml['MOM_input_nml']['input_filename'] == 'n'
     assert input_nml['SIS_input_nml']['input_filename'] == 'n'
+
+
+def test_get_cur_expt_time():
+    """ Test that get_model_cur_expt_time() correctly reads the start date from input.nml 
+    and the time from ocean.stats."""
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("360,      50.000,\n") # timestep, time in days
+
+    cur_expt_time = expt.get_model_cur_expt_time()
+    assert cur_expt_time == "1900-03-22T00:00:00"
+    
+@pytest.mark.parametrize("missing_file",[
+    (
+        ['input.nml']
+    ),
+    (
+        ['ocean.stats']
+    ),
+    (
+        ['input.nml', 'ocean.stats']
+    )
+])
+def test_get_cur_expt_time_missing_files(missing_file):
+    """ Test that get_model_cur_expt_time() correctly handles missing files."""
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("360,      50.000,\n") # timestep, time in days
+
+    for file in missing_file:
+        os.remove(os.path.join(expt.work_path, file)) 
+
+    with pytest.warns(UserWarning, match=f"Could not find required files: {input_path} or {stats_path}"):
+        cur_expt_time = expt.get_model_cur_expt_time()
+
+    assert cur_expt_time is None
+
+def test_read_start_date():
+    """ Test that read_start_date() correctly handle errors."""
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['top_key'] = {'key': 'value'}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("360,      50.000,\n")
+
+    with pytest.warns(UserWarning, match=f"date_init not found in {input_path}"):
+        cur_expt_time = expt.get_model_cur_expt_time()
+    assert cur_expt_time is None
+
+def test_read_timestep():
+    """ Test that read_timestep() correctly handle errors."""
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    # Write a restart date into input.nml
+    input_path = os.path.join(expt.work_path, 'input.nml')
+    nml = f90nml.Namelist()
+    nml['ocean_solo_nml'] = {'date_init': [1900, 1, 31, 0, 0, 0]}
+    f90nml.write(nml, input_path, force=True)
+
+    # Write a timestep into ocean.stats
+    stats_path = os.path.join(expt.work_path, 'ocean.stats')
+    with open(stats_path, 'w') as f:
+        f.write("invalid timestep\n")
+
+    with pytest.warns(UserWarning, match=f"Could not read timestep from {stats_path}.*"):
+        cur_expt_time = expt.get_model_cur_expt_time()
+    assert cur_expt_time is None

--- a/test/models/test_um.py
+++ b/test/models/test_um.py
@@ -6,8 +6,6 @@ import pytest
 import datetime
 import cftime
 import yaml
-import f90nml
-import logging
 
 import payu
 
@@ -133,7 +131,7 @@ def test_um_get_restart_datetime(date):
     parsed_run_dt = expt.model.get_restart_datetime(restart_path)
     assert parsed_run_dt == date
 
-def test_convert_timestep(caplog):
+def test_convert_timestep():
     """ Test with an invalid log file"""
     # Initialise ESM1.6
     with cd(ctrldir):
@@ -149,6 +147,5 @@ def test_convert_timestep(caplog):
         f.write(f"U_MODEL: SECS_PER_PERIODim=                 86400\n")
         f.write(f"There is no Timestep\n")
 
-    with caplog.at_level(logging.DEBUG):
+    with pytest.raises(ValueError, match=f"Could not find all required entries in file {log_path}"):
         expt.model.convert_timestep(log_path)
-        assert f"Could not find all required entries in file {log_path}" in caplog.text

--- a/test/models/test_um.py
+++ b/test/models/test_um.py
@@ -6,6 +6,8 @@ import pytest
 import datetime
 import cftime
 import yaml
+import f90nml
+import logging
 
 import payu
 
@@ -130,3 +132,23 @@ def test_um_get_restart_datetime(date):
     restart_path = list_expt_archive_dirs()[0]
     parsed_run_dt = expt.model.get_restart_datetime(restart_path)
     assert parsed_run_dt == date
+
+def test_convert_timestep(caplog):
+    """ Test with an invalid log file"""
+    # Initialise ESM1.6
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+
+    log_path = os.path.join(expt.work_path, 'atmosphere', 'atm.fort6.pe0')
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+
+    # write invalid content into log file
+    with open(log_path, 'w') as f:
+        f.write(f"U_MODEL: STEPS_PER_PERIODim=                    48\n")
+        f.write(f"U_MODEL: SECS_PER_PERIODim=                 86400\n")
+        f.write(f"There is no Timestep\n")
+
+    with caplog.at_level(logging.DEBUG):
+        expt.model.convert_timestep(log_path)
+        assert f"Could not find all required entries in file {log_path}" in caplog.text

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -304,7 +304,8 @@ def expected_archive_job_info(run_number):
         'stage': 'archive',
         'stderr_file': None,
         'stdout_file': None,
-        'start_time': f'2025-08-1{run_number}T12:00:00'
+        'start_time': f'2025-08-1{run_number}T12:00:00',
+        'model_finish_time': None
     }
 
 
@@ -664,7 +665,7 @@ def test_status_cur_expt_time(tmp_path, monkeypatch, capsys, cur_expt_time):
             run_number=None
         )
 
-    # Check the output contains the expected queue time
+    # Check the output contains the expected cur_expt_time
     output = capsys.readouterr().out
     if cur_expt_time:
         assert "Current Expt Time:" in output

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -10,6 +10,7 @@ from payu.status import (
     build_job_info
 )
 
+from payu.experiment import Experiment
 from payu.subcommands.status_cmd import runcmd
 from payu.git_utils import PayuGitWarning
 
@@ -607,3 +608,117 @@ def test_status_queue_time(tmp_path, capsys, job_stage, qtime, stime, time_label
     output = capsys.readouterr().out
     assert time_label in output
     assert time_message in output
+
+@pytest.mark.parametrize("cur_expt_time", [
+    ("2026-03-11T14:30:00"), 
+    (None)
+])
+def test_status_cur_expt_time(tmp_path, monkeypatch, capsys, cur_expt_time):
+    """Test that current experiment time is displayed at the stage of model-run."""
+    # Create a temporary lab and config
+    lab_path = tmp_path / "lab"
+    archive_path = lab_path / "archive" / "control-exp"
+    archive_path.mkdir(parents=True, exist_ok=True)
+    control_path = tmp_path / "control-exp"
+    control_path.mkdir()
+    config_path = control_path / "config.yaml"
+
+    # Create a minimal config file
+    with open(config_path, 'w') as f:
+        json.dump({'model': 'test'}, f)
+
+    # Create a minimal metadata file
+    metadata_path = control_path / "metadata.yaml"
+    with open(metadata_path, 'w') as f:
+        json.dump({'experiment_uuid': 'test-uuid'}, f)
+
+    # Create a queued job file
+    job_file = archive_path / "payu_jobs" / "3" / "run" / "test-job-id-3.json"
+    job_file.parent.mkdir(parents=True, exist_ok=True)
+
+    job_data = {
+        "scheduler_job_id": "test-job-id-3",
+        "scheduler_type": "pbs",
+        "experiment_metadata": {"experiment_uuid": "test-uuid"},
+        "payu_current_run": 3,
+        "stage": "model-run",
+        "scheduler_job_info":{
+           "Jobs": {
+                "test-job-id-3":{"Job_Name": "double_gyre",}
+            }
+        }
+    }
+    with open(job_file, 'w') as f:
+        json.dump(job_data, f)
+
+    # Run the command
+    monkeypatch.setattr(Experiment, "get_model_cur_expt_time", lambda self: cur_expt_time)
+    with pytest.warns(PayuGitWarning):
+        runcmd(
+            lab_path=str(lab_path),
+            config_path=str(config_path),
+            json_output=False,
+            update_jobs=False,
+            all_runs=False,
+            run_number=None
+        )
+
+    # Check the output contains the expected queue time
+    output = capsys.readouterr().out
+    if cur_expt_time:
+        assert "Current Expt Time:" in output
+        assert cur_expt_time in output
+    else:
+        assert "Current Expt Time:" not in output
+
+
+def test_status_model_finish_time(tmp_path, capsys):
+    """Test that model finish time is displayed for an archived job."""
+    # Create a temporary lab and config
+    lab_path = tmp_path / "lab"
+    archive_path = lab_path / "archive" / "control-exp"
+    archive_path.mkdir(parents=True, exist_ok=True)
+    control_path = tmp_path / "control-exp"
+    control_path.mkdir()
+    config_path = control_path / "config.yaml"
+
+    # Create a minimal config file
+    with open(config_path, 'w') as f:
+        json.dump({'model': 'test'}, f)
+
+    # Create a minimal metadata file
+    metadata_path = control_path / "metadata.yaml"
+    with open(metadata_path, 'w') as f:
+        json.dump({'experiment_uuid': 'test-uuid'}, f)
+
+    # Create an archived job file
+    job_file = archive_path / "payu_jobs" / "3" / "run" / "test-job-id-3.json"
+    job_file.parent.mkdir(parents=True, exist_ok=True)
+
+    job_data = {
+        "scheduler_job_id": "test-job-id-3",
+        "scheduler_type": "pbs",
+        "experiment_metadata": {"experiment_uuid": "test-uuid"},
+        "payu_current_run": 3,
+        "stage": "archive",
+        "payu_model_run_status": 0,
+        "model_finish_time": "2026-03-11T15:00:00"
+    }
+    with open(job_file, 'w') as f:
+        json.dump(job_data, f)
+
+    # Run the command
+    with pytest.warns(PayuGitWarning):
+        runcmd(
+            lab_path=str(lab_path),
+            config_path=str(config_path),
+            json_output=False,
+            update_jobs=False,
+            all_runs=False,
+            run_number=None
+        )
+
+    # Check the output contains the expected model finish time
+    output = capsys.readouterr().out
+    assert "Model Finish Time:" in output
+    assert "2026-03-11T15:00:00" in output

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -2,13 +2,15 @@ import json
 import pytest
 from freezegun import freeze_time
 import cftime
+from unittest.mock import MagicMock
 
 from payu.status import (
     find_file_match,
     get_scheduler_log,
     find_scheduler_logs,
     get_job_file_list,
-    build_job_info
+    build_job_info,
+    display_job_info
 )
 
 from payu.experiment import Experiment
@@ -168,6 +170,7 @@ def archive_jobs(tmp_path, request):
                         "payu_current_run": i,
                         "payu_run_id": f"commit-hash{i}",
                         "stage": "archive",
+                        "model_finish_time": "1901-03-15T00:30:00",
                         "payu_run_status": 0,
                         "payu_model_run_status": 0,
                         "timings": {
@@ -301,7 +304,7 @@ def expected_archive_job_info(run_number):
         'job_id': f'test-job-id-{run_number}',
         'run_id': f'commit-hash{run_number}',
         'model_exit_status': 0,
-        'model_finish_time': None,
+        'model_finish_time': '1901-03-15T00:30:00',
         'stage': 'archive',
         'stderr_file': None,
         'stdout_file': None,
@@ -319,7 +322,8 @@ def expected_running_job_info():
         'stage': 'model-run',
         'stderr_file': None,
         'stdout_file': None,
-        'start_time': '2025-08-15T16:30:00'
+        'start_time': '2025-08-15T16:30:00',
+        'cur_expt_time': '1901-01-15T00:30:00'
     }
 
 
@@ -411,11 +415,15 @@ def remove_job_file_paths(data):
 )
 def test_build_job_info(tmp_path, archive_jobs, running_job,
                         queued_job, failed_job, expected):
+    # Mock expt.get_model_cur_expt_time() in build_job_info
+    mock_expt = MagicMock()
+    mock_expt.get_model_cur_expt_time.return_value = cftime.datetime(1901, 1, 15, 0, 30, 0)
 
     all_runs = build_job_info(
         control_path=tmp_path / "control",
         archive_path=tmp_path / "archive",
-        all_runs=True
+        all_runs=True,
+        expt=mock_expt
     )
 
     # Remove job file from check as it contains tmp_path
@@ -455,10 +463,14 @@ def test_build_job_info(tmp_path, archive_jobs, running_job,
 def test_build_job_info_latest(tmp_path, archive_jobs,
                                running_job, queued_job,
                                failed_job, expected):
+    # Mock expt.get_model_cur_expt_time() in build_job_info
+    mock_expt = MagicMock()
+    mock_expt.get_model_cur_expt_time.return_value = cftime.datetime(1901, 1, 15, 0, 30, 0)
 
     latest_data = build_job_info(
         control_path=tmp_path / "control",
         archive_path=tmp_path / "archive",
+        expt=mock_expt
     )
 
     # Remove job file from check as it contains tmp_path
@@ -537,7 +549,7 @@ def test_status_cmd(tmp_path, capsys):
             "queued",
             "Tue Feb 10 15:00:00 2026",
             None,
-            "Current queue time:",
+            "Current Queue Time:",
             "0h 5m ",
         ),
 
@@ -545,14 +557,14 @@ def test_status_cmd(tmp_path, capsys):
         ("model-run", 
         "Tue Feb 10 15:00:00 2026", 
         "Tue Feb 10 15:05:00 2026", 
-        "Total queue time:", 
+        "Total Queue Time:", 
         "0h 5m 0s"),
 
         # Test archived job with total qtime 30 minutes
         ("archive", 
         "Tue Feb 10 15:00:00 2026", 
         "Tue Feb 10 15:30:00 2026", 
-        "Total queue time:", 
+        "Total Queue Time:", 
         "0h 30m 0s"),
     ]
 )
@@ -727,3 +739,51 @@ def test_status_model_finish_time(tmp_path, capsys):
     output = capsys.readouterr().out
     assert "Model Finish Time:" in output
     assert "2026-03-11T15:00:00" in output
+
+
+@pytest.mark.parametrize("archive_jobs,running_job,queued_job,failed_job, job_info",
+    [
+        (True, False, False, False, expected_archive_job_info(3)),
+        (False, True, False, False, expected_running_job_info()),
+        (False, False, True, False, expected_queued_job_info()),
+        (False, False, False, True, expected_failed_job_info()),
+    ])
+def test_display_job_info(tmp_path, capsys, archive_jobs, running_job, queued_job, failed_job, job_info):
+    """ Test that job info is displayed correctly for different stages and available information."""
+    job_info['job_file'] = str(tmp_path / "payu_jobs" / "3" / "run" / "test-job-id-3.json")
+    data = {'runs': {3: {'run': [job_info]}}}
+    display_job_info(data)
+
+    captured = capsys.readouterr().out
+
+    if archive_jobs:
+        assert "Model Finish Time:" in captured
+        assert job_info['model_finish_time'] in captured
+    elif running_job:
+        assert "Current Expt Time:" in captured
+        assert "1901-01-15T00:30:00" in captured
+    else:
+        assert "Current Expt Time:" not in captured
+        assert "Model Finish Time:" not in captured
+
+
+@pytest.mark.parametrize("running_job", [True], indirect=True)
+def test_build_job_info_error_get_cur_expt_time(tmp_path, running_job):
+    """Test that if get_model_cur_expt_time raises an error, other parts of job info are built correctly."""
+    # Mock get_model_cur_expt_time to raise an error
+    mock_expt = MagicMock()
+    mock_expt.get_model_cur_expt_time.side_effect = FileNotFoundError("Log file not found")
+
+    data = build_job_info(
+        control_path=tmp_path / "control",
+        archive_path=tmp_path / "archive",
+        expt=mock_expt
+    )
+
+    # Remove job file from check as it contains tmp_path
+    remove_job_file_paths(data)
+
+    expected_info = expected_running_job_info()
+    del expected_info["cur_expt_time"]
+
+    assert data == {'runs': {3: {'run': [expected_info]}}}

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from freezegun import freeze_time
+import cftime
 
 from payu.status import (
     find_file_match,
@@ -610,7 +611,7 @@ def test_status_queue_time(tmp_path, capsys, job_stage, qtime, stime, time_label
     assert time_message in output
 
 @pytest.mark.parametrize("cur_expt_time", [
-    ("2026-03-11T14:30:00"), 
+    (cftime.datetime(2026, 2, 10, 15, 0, 0)),
     (None)
 ])
 def test_status_cur_expt_time(tmp_path, monkeypatch, capsys, cur_expt_time):
@@ -667,7 +668,7 @@ def test_status_cur_expt_time(tmp_path, monkeypatch, capsys, cur_expt_time):
     output = capsys.readouterr().out
     if cur_expt_time:
         assert "Current Expt Time:" in output
-        assert cur_expt_time in output
+        assert cur_expt_time.isoformat() in output
     else:
         assert "Current Expt Time:" not in output
 

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -301,11 +301,11 @@ def expected_archive_job_info(run_number):
         'job_id': f'test-job-id-{run_number}',
         'run_id': f'commit-hash{run_number}',
         'model_exit_status': 0,
+        'model_finish_time': None,
         'stage': 'archive',
         'stderr_file': None,
         'stdout_file': None,
-        'start_time': f'2025-08-1{run_number}T12:00:00',
-        'model_finish_time': None
+        'start_time': f'2025-08-1{run_number}T12:00:00'
     }
 
 
@@ -315,6 +315,7 @@ def expected_running_job_info():
         'job_id': 'test-job-id-3',
         'run_id': 'commit-hash3',
         'model_exit_status': None,
+        'model_finish_time': None,
         'stage': 'model-run',
         'stderr_file': None,
         'stdout_file': None,
@@ -328,6 +329,7 @@ def expected_queued_job_info():
         'job_id': 'test-job-id-3',
         'run_id': None,
         'model_exit_status': None,
+        'model_finish_time': None,
         'stage': 'queued',
         'stderr_file': None,
         'stdout_file': None,
@@ -341,6 +343,7 @@ def expected_failed_job_info():
         'job_id': 'test-job-id-failed',
         'run_id': 'commit-hash-failed',
         'model_exit_status': None,
+        'model_finish_time': None,
         'stage': 'setup',
         'stderr_file': None,
         'stdout_file': None,


### PR DESCRIPTION
In `payu status`, display current experiment time for running jobs, as:
```
  Job ID:            xxx.gadi-pbs
  Run ID:            xxx
  Stage:             model-run
  Total queue time:  0h 1m 4s
  Current Expt Time: 1901-02-20T00:00:00
  ::
```
This is implemented in models:
 - OM2
 - ESM1.6
 - MOM6
 - OM3
For other models, no current expt time will be displayed.

In `payu status`, display current model finish time for archived jobs, e.g.,
 ```
 Job ID:            xxx.gadi-pbs
  Run ID:            xxx
  Stage:             archive
  Total queue time:  0h 0m 22s
  Model Finish Time: 1900-05-01T00:00:00
  ::
```


Closes #701 as part of #640.