### PR TITLE
Improve the error message when collecting restart files.

### DIFF
--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -33,6 +33,12 @@ CFTIME_CALENDARS = {
     "GREGORIAN" : "proleptic_gregorian"
 }
 
+restart_error_msg = f"""
+Possible cause: model runtime is shorter than the restart write frequency.
+Fix:
+    1. Remove the incomplete restart subdirectory in the archive path
+    2. Adjust the restart write frequency to be shorter than/equal to the model runtime."""
+
 # Add as needed
 component_info = {
     "mom": {
@@ -328,7 +334,8 @@ class CesmCmeps(Model):
             # rpointer file not exist
             if not os.path.exists(pointer):
                 raise FileNotFoundError(
-                    f"payu: rpointer file {pointer} does not exist!"
+                    f"\nPayu Error: Restart pointer file not found at the end of payu run: {pointer}"
+                    f"{restart_error_msg}"
                     )
 
             with open(pointer, "r") as f:
@@ -348,7 +355,8 @@ class CesmCmeps(Model):
                             continue
 
                     raise FileNotFoundError(
-                        f"payu: restart file {target_restart_path} listed in the rpointer file {pointer} does not exist!"
+                        f"\nPayu Error: Restart file {target_restart_path} listed in the rpointer file {pointer} not found."
+                        f"{restart_error_msg}"
                         )
 
         return sorted(restart_files)

--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -37,7 +37,7 @@ restart_error_msg = f"""
 Possible cause: model runtime is shorter than the restart write frequency.
 Fix:
     1. Remove the incomplete restart subdirectory in the archive path
-    2. Adjust the restart write frequency to be shorter than/equal to the model runtime."""
+    2. Adjust the restart write frequency to write a restart at the end of the model run."""
 
 # Add as needed
 component_info = {

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -5,6 +5,7 @@ import pytest
 
 import payu
 import cftime
+from payu.models.cesm_cmeps import restart_error_msg
 
 from test.common import cd, tmpdir, ctrldir, labdir, workdir, write_config, config_path
 from test.common import config as config_orig
@@ -580,5 +581,33 @@ def test_collect_restart_files_incorrect_parallel():
 
         # Check a representative missing file appears in the message
         assert "access-om3.cice.r.1900-01-01-00000.nc" in str(e.value)
+        assert "rpointer.ice not found." in str(e.value)
+        assert restart_error_msg in str(e.value)
+
+    teardown_cmeps_config()
+    os.remove(os.path.join(model.work_path, expected_present[0]))
+
+def test_collect_restart_files_nonexist_rpointer():
+    """ Test if error is raised when rpointer file does not exist. """
+    cmeps_config(1)
+
+    with cd(ctrldir):
+        lab = payu.laboratory.Laboratory(lab_path=str(labdir))
+        expt = payu.experiment.Experiment(lab, reproduce=False)
+        model = expt.models[0]
+
+        pointer_files = [
+            os.path.join(model.work_path, "test_rpointer.cpl"),
+            os.path.join(model.work_path, "test_rpointer.ice"),
+        ]
+        for file in pointer_files:
+            assert not os.path.exists(file)
+
+        with pytest.raises(FileNotFoundError) as e:
+            model._collect_restart_files(pointer_files)
+
+        # Check a representative missing file appears in the message
+        assert restart_error_msg in str(e.value)
+        assert "Restart pointer file not found at the end of payu run" in str(e.value)
 
     teardown_cmeps_config()


### PR DESCRIPTION
Make the FileNotFound error message clearer when collecting restart files.

Closes #705.
Ref [issue](https://github.com/ACCESS-NRI/access-om3-configs/issues/1223) in OM3 config repo.