### PR TITLE
Payu general command wrapper for warning and exceptions formats

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -35,8 +35,7 @@ warnings.formatwarning = (
     lambda message, category, filename, lineno, line=None: (
         formatwarning_orig(message, category, filename, lineno, line='')
     )
-)
-
+)    
 
 def parse():
     """Parse the command line inputs and execute the subcommand."""
@@ -51,6 +50,43 @@ def parse():
     args = vars(parser.parse_args())
     run_cmd = args.pop('run_cmd')
     run_cmd(**args)
+
+
+# Add wrappers for runscript commands
+def parse_run():
+    _parse_runscript("run")
+
+
+def parse_collate():
+    _parse_runscript("collate")
+
+
+def parse_sync():
+    _parse_runscript("sync")
+
+
+def parse_profile():
+    _parse_runscript("profile")
+
+
+def _parse_runscript(cmd_name):
+
+    # Attempt to import the requested runscript command module
+    try:
+        cmd = importlib.import_module(f'payu.subcommands.{cmd_name}_cmd')
+    except ImportError:
+        print(f'payu: error: Unknown runscript command payu-{cmd_name}')
+        sys.exit(1)
+
+    # Construct the subcommand parser
+    parser = argparse.ArgumentParser(**cmd.parameters)
+
+    for arg in cmd.arguments:
+        parser.add_argument(*arg['flags'], **arg['parameters'])
+
+    args = parser.parse_args()
+
+    cmd.runscript(args)
 
 
 def generate_parser(is_interactive=False):

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -32,14 +32,6 @@ logger = logging.getLogger(__name__)
 # Default configuration
 DEFAULT_CONFIG = 'config.yaml'
 
-# Force warnings.warn() to omit the source code line in the message
-formatwarning_orig = warnings.formatwarning
-warnings.formatwarning = (
-    lambda message, category, filename, lineno, line=None: (
-        formatwarning_orig(message, category, filename, lineno, line='')
-    )
-)    
-
 
 def _run_command(func, *args, **kwargs):
     """Execute a payu command with error handling and logging.
@@ -50,6 +42,11 @@ def _run_command(func, *args, **kwargs):
     setup_logger()
     # Capture warnings through the logging system
     logging.captureWarnings(True)
+
+    # Only display the warning message
+    warnings.formatwarning = (
+        lambda message, category, filename, lineno, line=None: str(message)
+    )
 
     try:
         func(*args, **kwargs)

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -10,6 +10,7 @@
 import argparse
 import sysconfig
 import importlib
+import logging
 import os
 import pkgutil
 import shlex
@@ -26,6 +27,8 @@ from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
 import payu.subcommands
 from payu.logger import setup_logger
 
+logger = logging.getLogger(__name__)
+
 # Default configuration
 DEFAULT_CONFIG = 'config.yaml'
 
@@ -37,9 +40,30 @@ warnings.formatwarning = (
     )
 )    
 
+
+def _run_command(func, *args, **kwargs):
+    """Execute a payu command with error handling and logging.
+
+    Sets up logging, captures warnings through the logging system,
+    and catches exceptions to provide clean error messages.
+    """
+    setup_logger()
+    # Capture warnings through the logging system
+    logging.captureWarnings(True)
+
+    try:
+        func(*args, **kwargs)
+    except SystemExit:
+        # TODO: We want to remove any sys.exit(1) calls in the code
+        # and replace with exceptions! 
+        raise
+    except Exception as exc:
+        logger.error(str(exc))
+        sys.exit(1)
+
+
 def parse():
     """Parse the command line inputs and execute the subcommand."""
-    setup_logger()
     parser = generate_parser(is_interactive = True)
     # Display help if no arguments are provided
     if len(sys.argv) == 1:
@@ -49,7 +73,7 @@ def parse():
         parser = generate_parser()
     args = vars(parser.parse_args())
     run_cmd = args.pop('run_cmd')
-    run_cmd(**args)
+    _run_command(run_cmd, **args)
 
 
 # Add wrappers for runscript commands
@@ -86,7 +110,7 @@ def _parse_runscript(cmd_name):
 
     args = parser.parse_args()
 
-    cmd.runscript(args)
+    _run_command(cmd.runscript, args)
 
 
 def generate_parser(is_interactive=False):

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -25,6 +25,7 @@ from payu.fsops import is_conda
 from payu.models import index as supported_models
 from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
 import payu.subcommands
+import payu.subcommands.args as arg_templates
 from payu.logger import setup_logger
 
 logger = logging.getLogger(__name__)
@@ -33,20 +34,21 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONFIG = 'config.yaml'
 
 
-def _run_command(func, *args, **kwargs):
+def _run_command(func, *args, stacktrace=False, log_level=None, **kwargs):
     """Execute a payu command with error handling and logging.
 
     Sets up logging, captures warnings through the logging system,
     and catches exceptions to provide clean error messages.
     """
-    setup_logger()
+    setup_logger(log_level=log_level or logging.INFO)
     # Capture warnings through the logging system
     logging.captureWarnings(True)
 
-    # Only display the warning message
-    warnings.formatwarning = (
-        lambda message, category, filename, lineno, line=None: str(message)
-    )
+    if not stacktrace:
+        # Only display the warning message
+        warnings.formatwarning = (
+            lambda message, category, filename, lineno, line=None: str(message)
+        )
 
     try:
         func(*args, **kwargs)
@@ -55,7 +57,10 @@ def _run_command(func, *args, **kwargs):
         # and replace with exceptions! 
         raise
     except Exception as exc:
-        logger.error(str(exc))
+        if stacktrace:
+            logger.exception(str(exc), exc_info=True)
+        else:
+            logger.error(str(exc))
         sys.exit(1)
 
 
@@ -70,7 +75,9 @@ def parse():
         parser = generate_parser()
     args = vars(parser.parse_args())
     run_cmd = args.pop('run_cmd')
-    _run_command(run_cmd, **args)
+    stacktrace = args.pop('stacktrace')
+    log_level = args.pop('log_level')
+    _run_command(run_cmd, stacktrace=stacktrace, log_level=log_level, **args)
 
 
 # Add wrappers for runscript commands
@@ -102,12 +109,21 @@ def _parse_runscript(cmd_name):
     # Construct the subcommand parser
     parser = argparse.ArgumentParser(**cmd.parameters)
 
+    # Add global flags to each command
+    for arg in [arg_templates.stacktrace, arg_templates.log_level]:
+        parser.add_argument(*arg['flags'], **arg['parameters'])
+
     for arg in cmd.arguments:
         parser.add_argument(*arg['flags'], **arg['parameters'])
 
     args = parser.parse_args()
+    stacktrace = args.stacktrace
+    log_level = args.log_level
+    # Remove them so they don't get passed to runscript
+    delattr(args, 'stacktrace')
+    delattr(args, 'log_level')
 
-    _run_command(cmd.runscript, args)
+    _run_command(cmd.runscript, args, stacktrace=stacktrace, log_level=log_level)
 
 
 def generate_parser(is_interactive=False):
@@ -131,6 +147,10 @@ def generate_parser(is_interactive=False):
     for cmd in subcmds:
         cmd_parser = subparsers.add_parser(cmd.title, **cmd.parameters)
         cmd_parser.set_defaults(run_cmd=cmd.runcmd)
+
+        # Add global flags to each subcommand
+        for arg in [arg_templates.stacktrace, arg_templates.log_level]:
+            cmd_parser.add_argument(*arg['flags'], **arg['parameters'])
 
         for arg in cmd.arguments:
             cmd_parser.add_argument(*arg['flags'], **arg['parameters'])

--- a/payu/logger.py
+++ b/payu/logger.py
@@ -22,14 +22,14 @@ class ColoredFormatter(logging.Formatter):
         formatter = logging.Formatter(log_color + self.FORMAT + self.RESET)
         return formatter.format(record)
 
-def setup_logger():
+def setup_logger(log_level=logging.INFO):
     """Configure the root logger"""
     
     # Color Formatter: Initialize Colorama for cross-platform compatibility and auto-reset
     init(autoreset=True)
     
     logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+    logger.setLevel(log_level)
 
     # Create a stream handler and set the custom formatter
     console_handler = logging.StreamHandler()

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -343,3 +343,23 @@ run_number = {
         'help': 'Display information about a specific run number'
     }
 }
+
+stacktrace = {
+    'flags': ('--stacktrace',),
+    'parameters': {
+        'action': 'store_true',
+        'default': False,
+        'dest': 'stacktrace',
+        'help': 'Show full stack traces on errors and warnings'
+    }
+}
+
+log_level = {
+    'flags': ('--log-level',),
+    'parameters': {
+        'dest': 'log_level',
+        'choices': ['DEBUG', 'INFO', 'WARNING', 'ERROR'],
+        'default': None,
+        'help': 'Set logging verbosity level'
+    }
+}

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -89,14 +89,7 @@ def runcmd(model_type, config_path, init_run, lab_path, dir_path):
     cli.submit_job('payu-collate', pbs_config, pbs_vars)
 
 
-def runscript():
-
-    parser = argparse.ArgumentParser()
-    for arg in arguments:
-        parser.add_argument(*arg['flags'], **arg['parameters'])
-
-    run_args = parser.parse_args()
-
+def runscript(run_args):
     pbs_vars = cli.set_env_vars(init_run=run_args.init_run,
                                 lab_path=run_args.lab_path,
                                 dir_path=run_args.dir_path)

--- a/payu/subcommands/profile_cmd.py
+++ b/payu/subcommands/profile_cmd.py
@@ -65,14 +65,7 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path):
     cli.submit_job('payu-profile', pbs_config, pbs_vars)
 
 
-def runscript():
-
-    parser = argparse.ArgumentParser()
-    for arg in arguments:
-        parser.add_argument(*arg['flags'], **arg['parameters'])
-
-    run_args = parser.parse_args()
-
+def runscript(run_args):
     pbs_vars = cli.set_env_vars(init_run=run_args.init_run,
                                 n_runs=run_args.n_runs)
     for var in pbs_vars:

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -189,13 +189,7 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
     )
 
 
-def runscript():
-    parser = argparse.ArgumentParser()
-    for arg in arguments:
-        parser.add_argument(*arg['flags'], **arg['parameters'])
-
-    run_args = parser.parse_args()
-
+def runscript(run_args):
     lab = Laboratory(run_args.model_type, run_args.config_path,
                      run_args.lab_path)
 

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -61,13 +61,7 @@ def runcmd(model_type, config_path, lab_path, dir_path, sync_restarts,
     cli.submit_job('payu-sync', pbs_config, pbs_vars)
 
 
-def runscript():
-    parser = argparse.ArgumentParser()
-    for arg in arguments:
-        parser.add_argument(*arg['flags'], **arg['parameters'])
-
-    run_args = parser.parse_args()
-
+def runscript(run_args):
     pbs_vars = cli.set_env_vars(lab_path=run_args.lab_path,
                                 dir_path=run_args.dir_path,
                                 sync_restarts=run_args.sync_restarts,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,10 @@ mitgcm = ["mnctools>=0.2"]
 
 [project.scripts]
 payu = "payu.cli:parse"
-payu-run = "payu.subcommands.run_cmd:runscript"
-payu-collate = "payu.subcommands.collate_cmd:runscript"
-payu-profile = "payu.subcommands.profile_cmd:runscript"
-payu-sync = "payu.subcommands.sync_cmd:runscript"
+payu-run = "payu.cli:parse_run"
+payu-collate = "payu.cli:parse_collate"
+payu-profile = "payu.cli:parse_profile"
+payu-sync = "payu.cli:parse_sync"
 
 [build-system]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,6 @@ payu-run = "payu.subcommands.run_cmd:runscript"
 payu-collate = "payu.subcommands.collate_cmd:runscript"
 payu-profile = "payu.subcommands.profile_cmd:runscript"
 payu-sync = "payu.subcommands.sync_cmd:runscript"
-payu-branch = "payu.subcommands.branch_cmd:runscript"
-payu-clone = "payu.subcommands.clone_cmd:runscript"
-payu-checkout = "payu.subcommands.checkout_cmd:runscript"
 
 [build-system]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR:
- Removes `payu-branch`, `payu-clone`, `payu-checkout` runscript commands (I think I mistakingly added these..)
- Adds a wrapper script for running the `runscript` commands (e.g. `payu-run`, `payu-sync`, etc) and moved the parsing logic out of the subcommand modules. 
- Add another wrapper function to format logs, warnings, and catch exceptions. This is used by above wrapper and the general  parse() method (used by `payu setup`, `payu run`)
- Add `--stacktrace` flag for enabling stacktraces with exceptions and warnings (`--verbose` name for a flag was already taken by another payu command)
- Add `--log-level` flag for enabling different level of logs.

I've only done a couple tests so far - which are mostly just manually adding random `logger.debug`, `raise ValueError` and `warnings.warn()` lines to methods to trigger errors. 

Related to #673 
