### PR TITLE
`payu support` command to print modules and machine info.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -509,3 +509,25 @@ repository, run::
       payu branch # Display local branches UUIDs
       payu branch --verbose # Display local branches metadata 
       payu branch --remote # Display remote branches UUIDs
+
+
+Getting support
+===============
+
+To display information about the current computing environment and machine 
+configuration, use the support command::
+
+   payu support
+
+The output includes:
+
+* Payu version and installation path.
+
+* Python version and the full system path where packages are loaded from.
+
+* Loaded modules (e.g., PBS).
+
+* Machine information, such as the Operating System and CPU architecture.
+
+This will be helpful in debugging environment issues or providing necessary details 
+when reporting an issue.

--- a/payu/subcommands/support_cmd.py
+++ b/payu/subcommands/support_cmd.py
@@ -32,34 +32,39 @@ def get_machine_info():
 def print_support(label, value):
     """Print support information in a consistent format."""
     label_width = 18
-    print(f"  {f'{label}:':<{label_width}} {value}")
+    # If value is a string, print it directly.
+    if isinstance(value, str):
+        print(f"  {f'{label}:':<{label_width}} {value}")
+        
+    # If value is a list, print each item on a new line with the label only on the first line.
+    elif isinstance(value, list) and len(value) > 0:
+        print(f"  {f'{label}:':<{label_width}} {value[0]}")
+        for item in value[1:]:
+            print(f"  {' ':<{label_width}} {item}")
 
 
 def runcmd():
     print("=" * 40)
-    payu_env_vars = cli.set_env_vars()
-
     # Get payu version and path
     payu_version = payu.__version__
-    payu_path = payu_env_vars.get('PAYU_PATH')
     print_support("Payu Version", payu_version)
+
+    payu_env_vars = cli.set_env_vars()
+    payu_path = payu_env_vars.get('PAYU_PATH')
     print_support("Payu Path", payu_path)
 
     # Get python version and path
     python_version = platform.python_version()
-    python_path = sys.executable
     print_support("Python Version", python_version)
-    print_support("Python Path", python_path)
 
-    # Get python path from environment variable
-    python_path_env = os.environ.get('PYTHONPATH', None)
-    if python_path_env:
-        print_support("Python Path from Environment", python_path_env)
+    # Print system path
+    sys_path_list = sys.path
+    print_support("System Path", sys_path_list)
 
     # Print loaded modules
     loaded_modules = os.environ.get('LOADEDMODULES', None)
     if loaded_modules:
-        print_support("LOADEDMODULES", loaded_modules)
+        print_support("Loaded Modules", loaded_modules)
 
     # Print machine information
     print_support("Machine Info", get_machine_info())

--- a/payu/subcommands/support_cmd.py
+++ b/payu/subcommands/support_cmd.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+
+# Standard Library
+import os
+import sys
+import subprocess
+
+# Local
+import payu
+from payu import cli
+
+title = 'support'
+parameters = {'description': 'generate report of system information for debugging and support requests'}
+
+arguments = []
+
+def get_machine_info():
+    """Get machine information using `uname -snrmo`."""
+    result = subprocess.run(['uname', '-snrmo'], capture_output=True, text=True)
+    return result.stdout.strip()
+
+def print_support(label, value):
+    """Print support information in a consistent format."""
+    label_width = 18
+    print(f"  {f'{label}:':<{label_width}} {value}")
+
+
+def runcmd():
+    print("=" * 40)
+    payu_env_vars = cli.set_env_vars()
+
+    # Get payu version and path
+    payu_version = payu.__version__
+    payu_path = payu_env_vars.get('PAYU_PATH')
+    print_support("Payu Version", payu_version)
+    print_support("Payu Path", payu_path)
+
+    # Get python version and path
+    python_version = sys.version.split()[0]
+    python_path = sys.executable
+    print_support("Python Version", python_version)
+    print_support("Python Path", python_path)
+
+    # Get python path from environment variable
+    python_path_env = os.environ.get('PYTHONPATH', None)
+    if python_path_env:
+        print_support("Python Path from Environment", python_path_env)
+
+    # Print loaded modules
+    loaded_modules = os.environ.get('LOADEDMODULES', None)
+    if loaded_modules:
+        print_support("LOADEDMODULES", loaded_modules)
+
+    # Print machine information
+    print_support("Machine Info", get_machine_info())
+
+    print("=" * 40)
+
+runscript = runcmd

--- a/payu/subcommands/support_cmd.py
+++ b/payu/subcommands/support_cmd.py
@@ -4,10 +4,14 @@
 import os
 import sys
 import subprocess
+import platform
+import warnings
 
 # Local
 import payu
 from payu import cli
+
+warning_msg = "Unable to get machine information using platform module."
 
 title = 'support'
 parameters = {'description': 'generate report of system information for debugging and support requests'}
@@ -15,9 +19,15 @@ parameters = {'description': 'generate report of system information for debuggin
 arguments = []
 
 def get_machine_info():
-    """Get machine information using `uname -snrmo`."""
-    result = subprocess.run(['uname', '-snrmo'], capture_output=True, text=True)
-    return result.stdout.strip()
+    """Get machine information using platform module."""
+    os_info = platform.freedesktop_os_release()
+    
+    system_name = os_info.get('NAME', None)
+    version_id = os_info.get('VERSION_ID', None)
+
+    machine_type = platform.machine()
+
+    return f"{system_name}-{version_id}-{machine_type}"
 
 def print_support(label, value):
     """Print support information in a consistent format."""
@@ -36,7 +46,7 @@ def runcmd():
     print_support("Payu Path", payu_path)
 
     # Get python version and path
-    python_version = sys.version.split()[0]
+    python_version = platform.python_version()
     python_path = sys.executable
     print_support("Python Version", python_version)
     print_support("Python Path", python_path)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -192,7 +192,7 @@ def test_update_file(mock_repo, uuid, experiment_name,
             True, True, True, False, True, False,
             "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", "ctrl-mock_branch-3d18b3b6"
         ),
-        # Keep UUID on not new experiement - UUID Exists -legacy archive exists
+        # Keep UUID on not new experiment - UUID Exists -legacy archive exists
         (
             True, True, False, False, True, False,
             "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", "ctrl"

--- a/test/test_support.py
+++ b/test/test_support.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -8,7 +9,7 @@ expect_output_list = [
     "Payu Version",
     "Payu Path",
     "Python Version",
-    "Python Path",
+    "System Path",
     "Machine Info",]
 
 mock_machine_info = MagicMock(return_value="Rocky Linux-8.10-x86_64")
@@ -17,10 +18,9 @@ mock_os_release = {
         'VERSION_ID': '8.10'
     }
 
-mock_payu_env_vars = {'PAYU_PATH': '/path/to/payu'}
+mock_payu_env_vars = {'PAYU_PATH': os.pathsep.join(['/path/to/payu', '/another/path/to/payu'])}
 mock_environ = {
-    'PYTHONPATH': '/path/to/python',
-    'LOADEDMODULES': 'module1 module2'
+    'LOADEDMODULES': 'module1:module2'
 }
 
 def test_support_cmd(capsys):
@@ -32,21 +32,19 @@ def test_support_cmd(capsys):
         captured = capsys.readouterr()
         for expected in expect_output_list:
             assert expected in captured.out
-        assert "Python Path from Environment" in captured.out
-        assert "LOADEDMODULES" in captured.out
+        assert "Loaded Modules" in captured.out
+        assert os.pathsep.join(['/path/to/payu', '/another/path/to/payu']) in captured.out
 
 
 def test_support_cmd_empty_env(capsys):
     """Test the support command with empty environment variables"""
     with patch('payu.subcommands.support_cmd.get_machine_info', mock_machine_info),\
-        patch('payu.subcommands.support_cmd.cli.set_env_vars', return_value={}),\
-        patch.dict('os.environ', {}, clear=True):
+        patch('payu.subcommands.support_cmd.os.environ.get', return_value={}):
         support_cmd.runcmd()
         captured = capsys.readouterr()
         for expected in expect_output_list:
             assert expected in captured.out
-        assert "Python Path from Environment" not in captured.out
-        assert "LOADEDMODULES" not in captured.out
+        assert "Loaded Modules" not in captured.out
 
 
 def test_get_machine_info():

--- a/test/test_support.py
+++ b/test/test_support.py
@@ -11,7 +11,12 @@ expect_output_list = [
     "Python Path",
     "Machine Info",]
 
-mock_machine_info = MagicMock(return_value="Linux test-machine x86_64 GNU/Linux")
+mock_machine_info = MagicMock(return_value="Rocky Linux-8.10-x86_64")
+mock_os_release = {
+        'NAME': 'Rocky Linux',
+        'VERSION_ID': '8.10'
+    }
+
 mock_payu_env_vars = {'PAYU_PATH': '/path/to/payu'}
 mock_environ = {
     'PYTHONPATH': '/path/to/python',
@@ -42,3 +47,11 @@ def test_support_cmd_empty_env(capsys):
             assert expected in captured.out
         assert "Python Path from Environment" not in captured.out
         assert "LOADEDMODULES" not in captured.out
+
+
+def test_get_machine_info():
+    """Test get_machine_info returns expected format"""
+    with patch('platform.freedesktop_os_release', MagicMock(return_value=mock_os_release)),\
+        patch('platform.machine', MagicMock(return_value="x86_64")):
+        machine_info = support_cmd.get_machine_info()
+        assert machine_info == "Rocky Linux-8.10-x86_64"

--- a/test/test_support.py
+++ b/test/test_support.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+import payu
+from payu.subcommands import support_cmd
+
+expect_output_list = [
+    "Payu Version",
+    "Payu Path",
+    "Python Version",
+    "Python Path",
+    "Machine Info",]
+
+mock_machine_info = MagicMock(return_value="Linux test-machine x86_64 GNU/Linux")
+mock_payu_env_vars = {'PAYU_PATH': '/path/to/payu'}
+mock_environ = {
+    'PYTHONPATH': '/path/to/python',
+    'LOADEDMODULES': 'module1 module2'
+}
+
+def test_support_cmd(capsys):
+    """Test the support command runs as expected"""
+    with patch('payu.subcommands.support_cmd.get_machine_info', mock_machine_info),\
+        patch('payu.subcommands.support_cmd.cli.set_env_vars', return_value=mock_payu_env_vars),\
+        patch.dict('os.environ', mock_environ):
+        support_cmd.runcmd()
+        captured = capsys.readouterr()
+        for expected in expect_output_list:
+            assert expected in captured.out
+        assert "Python Path from Environment" in captured.out
+        assert "LOADEDMODULES" in captured.out
+
+
+def test_support_cmd_empty_env(capsys):
+    """Test the support command with empty environment variables"""
+    with patch('payu.subcommands.support_cmd.get_machine_info', mock_machine_info),\
+        patch('payu.subcommands.support_cmd.cli.set_env_vars', return_value={}),\
+        patch.dict('os.environ', {}, clear=True):
+        support_cmd.runcmd()
+        captured = capsys.readouterr()
+        for expected in expect_output_list:
+            assert expected in captured.out
+        assert "Python Path from Environment" not in captured.out
+        assert "LOADEDMODULES" not in captured.out


### PR DESCRIPTION
Thanks to @CodeGat 's suggestion!

This PR creates a `payu support` command which prints out some system information for troubleshooting and support requests.

Example of usage:
```
$USER@gadi $ payu support
========================================
  Payu Version:      1.2.1+101.gd97ecfa.dirty
  Payu Path:         /scratch/$PROJECT/$USER/payu-training-venv/bin
  Python Version:    3.11.13
  Python Path:       /scratch/$PROJECT/$USER/payu-training-venv/bin/python3
  LOADEDMODULES:     pbs
  Machine Info:      Linux gadi-login-05.gadi.nci.org.au xxxxx.el8.nci.x86_64 x86_64 GNU/Linux
========================================
