### PR TITLE
Pass warning to logger and add a stacktrace flag.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -510,6 +510,21 @@ repository, run::
       payu branch --verbose # Display local branches metadata 
       payu branch --remote # Display remote branches UUIDs
 
+Common flags
+===============
+
+The flag below can be applied to all payu subcommands.
+
+.. option:: -h, --help
+
+   Display help information about the command and its usage.
+
+.. option:: --stacktrace
+   
+   Enable full Python stacktraces for warnings. 
+   By default, payu displays only the warning messages to remain user-friendly. 
+   It will be helpful to enable this flag when debugging internal issues or reporting bugs.
+
 
 Getting support
 ===============

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -41,8 +41,9 @@ def parse():
     parser = generate_parser(is_interactive = True)
 
     # filter out --stacktrace when counting argument numbers
-    filtered_args = [arg for arg in sys.argv if arg != '--stacktrace']
-    arg_count = len(filtered_args)
+    arg_count = len(sys.argv)
+    if '--stacktrace' in sys.argv:
+        arg_count = arg_count - 1
     # Display help if no arguments are provided
     if arg_count == 1:
         parser.print_help()
@@ -52,6 +53,7 @@ def parse():
     args = vars(parser.parse_args())
     run_cmd = args.pop('run_cmd')
 
+    # We pop --stacktrace here so it will not be propagated to runcmd() in subcommands
     stacktrace = args.pop('stacktrace')
     if not stacktrace:
         # Force warnings.warn() to omit the source code line in the message
@@ -85,6 +87,8 @@ def generate_parser(is_interactive=False):
     for cmd in subcmds:
         cmd_parser = subparsers.add_parser(cmd.title, **cmd.parameters)
         cmd_parser.set_defaults(run_cmd=cmd.runcmd)
+        # Add the stacktrace option to all subcommands for consitent CLI UX.
+        # It will be extracted in the parse() and not propagated to subcommand's runcmd()
         cmd_parser.add_argument(*arg_templates.stacktrace['flags'], **arg_templates.stacktrace['parameters'])
 
         for arg in cmd.arguments:

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -33,7 +33,6 @@ DEFAULT_CONFIG = 'config.yaml'
 
 # Pass the warning through the logger
 logging.captureWarnings(True)
-original_formatwarning = warnings.formatwarning
 
 def parse():
     """Parse the command line inputs and execute the subcommand."""
@@ -60,8 +59,6 @@ def parse():
         warnings.formatwarning = (
             lambda message, category, filename, lineno, line=None: f"{message}"
         )
-    else:
-        warnings.formatwarning = original_formatwarning
         
     run_cmd(**args)
 

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -16,6 +16,7 @@ import shlex
 import subprocess
 import sys
 import warnings
+import logging
 
 # Local imports
 import payu
@@ -25,31 +26,41 @@ from payu.models import index as supported_models
 from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
 import payu.subcommands
 from payu.logger import setup_logger
+import payu.subcommands.args as arg_templates
 
 # Default configuration
 DEFAULT_CONFIG = 'config.yaml'
 
-# Force warnings.warn() to omit the source code line in the message
-formatwarning_orig = warnings.formatwarning
-warnings.formatwarning = (
-    lambda message, category, filename, lineno, line=None: (
-        formatwarning_orig(message, category, filename, lineno, line='')
-    )
-)
-
+# Pass the warning through the logger
+logging.captureWarnings(True)
+original_formatwarning = warnings.formatwarning
 
 def parse():
     """Parse the command line inputs and execute the subcommand."""
     setup_logger()
     parser = generate_parser(is_interactive = True)
+
+    # filter out --stacktrace when counting argument numbers
+    filtered_args = [arg for arg in sys.argv if arg != '--stacktrace']
+    arg_count = len(filtered_args)
     # Display help if no arguments are provided
-    if len(sys.argv) == 1:
+    if arg_count == 1:
         parser.print_help()
         return
-    if len(sys.argv) > 2:
+    if arg_count > 2:
         parser = generate_parser()
     args = vars(parser.parse_args())
     run_cmd = args.pop('run_cmd')
+
+    stacktrace = args.pop('stacktrace')
+    if not stacktrace:
+        # Force warnings.warn() to omit the source code line in the message
+        warnings.formatwarning = (
+            lambda message, category, filename, lineno, line=None: f"{message}"
+        )
+    else:
+        warnings.formatwarning = original_formatwarning
+        
     run_cmd(**args)
 
 
@@ -74,6 +85,7 @@ def generate_parser(is_interactive=False):
     for cmd in subcmds:
         cmd_parser = subparsers.add_parser(cmd.title, **cmd.parameters)
         cmd_parser.set_defaults(run_cmd=cmd.runcmd)
+        cmd_parser.add_argument(*arg_templates.stacktrace['flags'], **arg_templates.stacktrace['parameters'])
 
         for arg in cmd.arguments:
             cmd_parser.add_argument(*arg['flags'], **arg['parameters'])

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -343,3 +343,14 @@ run_number = {
         'help': 'Display information about a specific run number'
     }
 }
+
+# Display stacktrace option
+stacktrace = {
+    'flags': ['--stacktrace'],
+    'parameters': {
+        'dest': 'stacktrace',
+        'action': 'store_true',
+        'default': False,
+        'help': 'Display full stack traces of errors and warnings'
+    }
+}

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -375,6 +375,7 @@ def mock_warn(**kwargs):
 def test_parse_setup_stacktrace_off(monkeypatch):
     """Test that warning message does not include stack trace information
     when --stacktrace is not flagged."""
+    monkeypatch.setattr(warnings, "formatwarning", warnings.formatwarning)
     monkeypatch.setattr(sys, "argv", ["payu", "setup"])
     monkeypatch.setattr("payu.subcommands.setup_cmd.runcmd", mock_warn)
     with pytest.warns(UserWarning) as caught:
@@ -390,6 +391,7 @@ def test_parse_setup_stacktrace_off(monkeypatch):
 def test_parse_setup_stacktrace_on(monkeypatch):
     """Test that warning message includes stack trace information
     when --stacktrace is flagged."""
+    monkeypatch.setattr(warnings, "formatwarning", warnings.formatwarning)
     monkeypatch.setattr(sys, "argv", ["payu", "setup", "--stacktrace"])
     monkeypatch.setattr("payu.subcommands.setup_cmd.runcmd", mock_warn)
     with pytest.warns(UserWarning) as caught:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,6 +1,8 @@
 import pytest
 import shlex
 import sys
+from unittest.mock import patch
+import warnings
 
 import payu
 import payu.cli
@@ -28,6 +30,7 @@ def parse_args(parser, cmd):
     arguments = shlex.split(cmd.format(cmd=cmd))
     args = vars(parser.parse_args(arguments[1:]))
     run_cmd = args.pop("run_cmd")
+    stacktrace = args.pop("stacktrace")
     return run_cmd, args
 
 def test_parse(parser):
@@ -365,3 +368,42 @@ def test_parse_clone(parser):
 
     assert args.pop('repository') == 'test_repo'
     assert args.pop('local_directory') == 'local_dir'
+
+def mock_warn(**kwargs):
+        warnings.warn("Test Warning")
+
+def test_parse_setup_stacktrace_off(monkeypatch):
+    """Test that warning message does not include stack trace information
+    when --stacktrace is not flagged."""
+    monkeypatch.setattr(sys, "argv", ["payu", "setup"])
+    monkeypatch.setattr("payu.subcommands.setup_cmd.runcmd", mock_warn)
+    with pytest.warns(UserWarning) as caught:
+        payu.cli.parse()
+
+    w = caught[0]
+    formatted = warnings.formatwarning(
+        w.message, w.category, w.filename, w.lineno, w.line
+    )
+    assert formatted == "Test Warning"  
+    assert "UserWarning" not in formatted
+    assert str(w.filename) not in formatted
+    assert str(w.lineno) not in formatted
+     
+
+def test_parse_setup_stacktrace_on(monkeypatch):
+    """Test that warning message includes stack trace information
+    when --stacktrace is flagged."""
+    monkeypatch.setattr(sys, "argv", ["payu", "setup", "--stacktrace"])
+    monkeypatch.setattr("payu.subcommands.setup_cmd.runcmd", mock_warn)
+    with pytest.warns(UserWarning) as caught:
+        payu.cli.parse()
+
+    w = caught[0]
+    formatted = warnings.formatwarning(
+        w.message, w.category, w.filename, w.lineno, w.line
+    )
+    
+    assert "Test Warning" in formatted
+    assert "UserWarning" in formatted
+    assert str(w.filename) in formatted
+    assert str(w.lineno) in formatted

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -384,10 +384,7 @@ def test_parse_setup_stacktrace_off(monkeypatch):
     formatted = warnings.formatwarning(
         w.message, w.category, w.filename, w.lineno, w.line
     )
-    assert formatted == "Test Warning"  
-    assert "UserWarning" not in formatted
-    assert str(w.filename) not in formatted
-    assert str(w.lineno) not in formatted
+    assert formatted == "Test Warning"
      
 
 def test_parse_setup_stacktrace_on(monkeypatch):
@@ -407,3 +404,17 @@ def test_parse_setup_stacktrace_on(monkeypatch):
     assert "UserWarning" in formatted
     assert str(w.filename) in formatted
     assert str(w.lineno) in formatted
+
+def test_parse_arg_count(capsys, monkeypatch):
+    """Test that the parser correctly excludes --stacktrace when counting arguments."""
+    # confirm print help is triggered when only --stacktrace is provided
+    monkeypatch.setattr(sys, "argv", ["payu --stacktrace"])
+    payu.cli.parse()
+    assert "usage: payu --stacktrace [-h] [--version]" in capsys.readouterr().out
+
+    # confirm print help is not triggered when a subcommand is provided, even with --stacktrace
+    monkeypatch.setattr(sys, "argv", ["payu", "list", "--stacktrace"])
+    monkeypatch.setattr("payu.subcommands.list_cmd.runcmd", lambda *args, **kwargs: None)
+    payu.cli.parse()
+    assert "usage: payu" not in capsys.readouterr().out
+    assert "[-h] [--version]" not in capsys.readouterr().out


### PR DESCRIPTION
With this new PR, all warnings in payu will be captured and passed through the logging system. By default, only warning messages are displayed.
When `--stacktrace` flag is enabled, the full warning details (including source, line number and message) will be shown.

Related to #673 .