### PR TITLE
Add launcher script path to qsub storage flags

### DIFF
--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -353,16 +353,6 @@ class PBS(Scheduler):
         storages.update(find_mounts(extra_search_paths, mounts))
         storages.update(find_mounts(get_manifest_paths(), mounts))
 
-        # Add storage flags. Note that these are sorted to get predictable
-        # behaviour for testing
-        pbs_flags_extend = '+'.join(sorted(storages))
-        if pbs_flags_extend:
-            pbs_flags.append("-l storage={}".format(pbs_flags_extend))
-
-        # Set up environment modules here for PBS.
-        envmod.setup()
-        envmod.module('load', 'pbs')
-
         # Check for custom container launcher script environment variable
         launcher_script = os.environ.get('ENV_LAUNCHER_SCRIPT_PATH')
         if (
@@ -373,6 +363,19 @@ class PBS(Scheduler):
             # Prepend the container launcher script to the python command
             # so the python executable is accessible in the container
             python_exe = f'{launcher_script} {python_exe}'
+
+            # Add the container launcher script path to storage flags
+            storages.update(find_mounts(launcher_script, mounts))
+
+        # Add storage flags. Note that these are sorted to get predictable
+        # behaviour for testing
+        pbs_flags_extend = '+'.join(sorted(storages))
+        if pbs_flags_extend:
+            pbs_flags.append("-l storage={}".format(pbs_flags_extend))
+
+        # Set up environment modules here for PBS.
+        envmod.setup()
+        envmod.module('load', 'pbs')
 
         # Construct job submission command
         cmd = 'qsub {flags} -- {python} {script}'.format(


### PR DESCRIPTION
This PR adds the launcher script path to paths to search for adding storage flags in the `qsub` command. 

This issue came up when testing the new infra for conda containers where python and payu executables paths would be at `/containerised_envs/payu/<VERSION>/bin/` rather than `/g/data/vk83` (the same base path as the launcher script). https://github.com/ACCESS-NRI/containerised-environments-infra/pull/20#issuecomment-4284841136

I've tested this PR with a MOM6 experiment that would typically only have `storage=gdata/tm70+scratch/tm70` (https://github.com/jo-basevi/mom6_double_gyre configuration and a python virtual environment installed to `/scratch/tm70`). I then added a container launcher script environment variable, e.g. 
```
export ENV_LAUNCHER_SCRIPT_PATH="/g/data/vk83/testing/containerised_environments/admin/staging/prerelease/apps/containerised_envs/envs/payu/dev-20260417T162042-ee93bce-pr20/bin/launcher.sh"
```
and re-running `payu run` would set the storage to `-l storage=gdata/tm70+gdata/vk83+scratch/tm70`
