### PR TITLE
Update payu telemetry

### DIFF
--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -5,17 +5,14 @@ this data to telemetry services at the end of a run, if configured.
 
 import datetime
 import json
+import jsonschema
 import os
-import stat
 from pathlib import Path
 import requests
-import shutil
-import tempfile
 import threading
 from typing import Any, Optional
 import warnings
 from filelock import FileLock, Timeout
-import warnings
 
 import cftime
 
@@ -25,6 +22,7 @@ from payu.fsops import atomic_write_file
 
 # Environment variable for external telemetry configuration file
 TELEMETRY_CONFIG = "PAYU_TELEMETRY_CONFIG_PATH"
+TELEMETRY_CONFIG_SCHEMA = Path(__file__).parent / "telemetry" / "telemetry_config.schema.json"
 
 # Required telemetry configuration fields
 CONFIG_FIELDS = {
@@ -152,12 +150,15 @@ def get_external_telemetry_config(
         write_error_log(archive_path, job_file_path, error_msg)
         return None
 
-    # Check for required fields in the telemetry configuration
-    missing_fields = CONFIG_FIELDS.values() - telemetry_config.keys()
-    if missing_fields:
+    # Check that the telemetry configuration follows its schema
+    with open(TELEMETRY_CONFIG_SCHEMA, 'r') as f:
+        schema = json.load(f)
+    try:
+        jsonschema.validate(instance=telemetry_config, schema=schema)
+    except jsonschema.ValidationError as e:
         error_msg = (
-            f"Required field(s) {missing_fields} not found in configuration "
-            f"file specified by {TELEMETRY_CONFIG}: {config_path}."
+            f"The telemetry configuration file {config_path} specified by {TELEMETRY_CONFIG} "
+            f"does not follow the required schema: {e.message}"
         )
         write_error_log(archive_path, job_file_path, error_msg)
         return None

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -24,8 +24,7 @@ from payu.schedulers.scheduler import Scheduler
 from payu.fsops import atomic_write_file
 
 # Environment variable for external telemetry configuration file
-TELEMETRY_CONFIG = "PAYU_TELEMETRY_CONFIG"
-TELEMETRY_CONFIG_VERSION = "1-0-0"
+TELEMETRY_CONFIG = "PAYU_TELEMETRY_CONFIG_PATH"
 
 # Required telemetry configuration fields
 CONFIG_FIELDS = {
@@ -133,11 +132,10 @@ def get_external_telemetry_config(
     If a valid file does not exist, return None
     """
     # Check path to telemetry config file exists
-    config_dir = Path(os.environ[TELEMETRY_CONFIG])
-    config_path = config_dir / f"{TELEMETRY_CONFIG_VERSION}.json"
+    config_path = Path(os.environ[TELEMETRY_CONFIG])
     if not (config_path.exists() and config_path.is_file()):
         error_msg = (
-            f"No config file found at {TELEMETRY_CONFIG}: {config_path}."
+            f"No config file found at the path specified by {TELEMETRY_CONFIG}: {config_path}."
         )
         write_error_log(archive_path, job_file_path, error_msg)
         return None
@@ -148,7 +146,7 @@ def get_external_telemetry_config(
             telemetry_config = json.load(f)
     except json.JSONDecodeError:
         error_msg = (
-            "Error parsing json in configuration file at "
+            "Error parsing json in configuration file specified by "
             f"{TELEMETRY_CONFIG}: {config_path}."
         )
         write_error_log(archive_path, job_file_path, error_msg)
@@ -159,7 +157,7 @@ def get_external_telemetry_config(
     if missing_fields:
         error_msg = (
             f"Required field(s) {missing_fields} not found in configuration "
-            f"file at {TELEMETRY_CONFIG}: {config_path}."
+            f"file specified by {TELEMETRY_CONFIG}: {config_path}."
         )
         write_error_log(archive_path, job_file_path, error_msg)
         return None

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import jsonschema
 import os
+from importlib.resources import files
 from pathlib import Path
 import requests
 import threading
@@ -22,7 +23,7 @@ from payu.fsops import atomic_write_file
 
 # Environment variable for external telemetry configuration file
 TELEMETRY_CONFIG = "PAYU_TELEMETRY_CONFIG_PATH"
-TELEMETRY_CONFIG_SCHEMA = Path(__file__).parent / "telemetry" / "telemetry_config.schema.json"
+TELEMETRY_CONFIG_SCHEMA = files(__package__) / "telemetry" / "telemetry_config.schema.json"
 
 # Required telemetry configuration fields
 CONFIG_FIELDS = {

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -21,8 +21,10 @@ from payu.metadata import Metadata
 from payu.schedulers.scheduler import Scheduler
 from payu.fsops import atomic_write_file
 
-# Environment variable for external telemetry configuration file
+# Environment variables from payu environment
 TELEMETRY_CONFIG = "PAYU_TELEMETRY_CONFIG_PATH"
+TELEMETRY_ENV_VERSION = "PAYU_TELEMETRY_ENV_VERSION"
+
 TELEMETRY_CONFIG_SCHEMA = files(__package__) / "telemetry" / "telemetry_config.schema.json"
 
 # Required telemetry configuration fields
@@ -288,6 +290,8 @@ def record_telemetry(run_info: dict[str, Any],
 
     # Add hostname to the run info fields
     run_info["hostname"] = external_config[CONFIG_FIELDS["HOSTNAME"]]
+    # Add environment version to the run info fields
+    run_info["env_version"] = os.environ.get(TELEMETRY_ENV_VERSION)
 
     # Using threading to run the one post request in the background
     thread = threading.Thread(

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -270,7 +270,7 @@ def record_telemetry(run_info: dict[str, Any],
     # and whether the model was run
     if not (
         config.get("telemetry", {}).get("enable", True)
-        and TELEMETRY_CONFIG in os.environ
+        and os.environ.get(TELEMETRY_CONFIG) not in (None, "")
         and "payu_model_run_status" in run_info
     ):
         return

--- a/payu/telemetry/telemetry_config.json
+++ b/payu/telemetry/telemetry_config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0",
+    "version": "1.0.0",
     "telemetry_url": "{{ env['PAYU_TELEMETRY_URL'] }}",
     "telemetry_proxy_url": "{{ env['PAYU_TELEMETRY_PROXY_URL'] }}",
     "telemetry_token": "{{ env['PAYU_TELEMETRY_TOKEN'] }}",

--- a/payu/telemetry/telemetry_config.json
+++ b/payu/telemetry/telemetry_config.json
@@ -1,0 +1,8 @@
+{
+    "version": "1.0",
+    "telemetry_url": "{{ env['PAYU_TELEMETRY_URL'] }}",
+    "telemetry_proxy_url": "{{ env['PAYU_TELEMETRY_PROXY_URL'] }}",
+    "telemetry_token": "{{ env['PAYU_TELEMETRY_TOKEN'] }}",
+    "telemetry_service_name": "{{ env['PAYU_TELEMETRY_SERVICE_NAME'] }}",
+    "hostname": "{{ env['PAYU_TELEMETRY_HOSTNAME'] }}"
+}

--- a/payu/telemetry/telemetry_config.json
+++ b/payu/telemetry/telemetry_config.json
@@ -3,6 +3,6 @@
     "telemetry_url": "{{ env['PAYU_TELEMETRY_URL'] }}",
     "telemetry_proxy_url": "{{ env['PAYU_TELEMETRY_PROXY_URL'] }}",
     "telemetry_token": "{{ env['PAYU_TELEMETRY_TOKEN'] }}",
-    "telemetry_service_name": "{{ env['PAYU_TELEMETRY_SERVICE_NAME'] }}",
+    "telemetry_service_name": "payu",
     "hostname": "{{ env['PAYU_TELEMETRY_HOSTNAME'] }}"
 }

--- a/payu/telemetry/telemetry_config.schema.json
+++ b/payu/telemetry/telemetry_config.schema.json
@@ -15,12 +15,10 @@
         },
         "telemetry_url": {
             "type": "string",
-            "format": "uri",
             "description": "The endpoint URL for the payu telemetry service"
         },
         "telemetry_proxy_url": {
             "type": "string",
-            "format": "uri",
             "description": "The proxy URL for the payu telemetry service"
         },
         "telemetry_token": {

--- a/payu/telemetry/telemetry_config.schema.json
+++ b/payu/telemetry/telemetry_config.schema.json
@@ -10,24 +10,30 @@
     "additionalProperties": false,
     "properties": {
         "version": {
-            "type": "string"
+            "type": "string",
+            "description": "The version of the telemetry configuration"
         },
         "telemetry_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "The endpoint URL for the payu telemetry service"
         },
         "telemetry_proxy_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "The proxy URL for the payu telemetry service"
         },
         "telemetry_token": {
-            "type": "string"
+            "type": "string",
+            "description": "The authentication token for the payu telemetry service"
         },
         "telemetry_service_name": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the service sending telemetry data"
         },
         "hostname": {
-            "type": "string"
+            "type": "string",
+            "description": "The name of the HPC host where payu is running"
         }
     }
 }

--- a/payu/telemetry/telemetry_config.schema.json
+++ b/payu/telemetry/telemetry_config.schema.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+        "telemetry_url",
+        "telemetry_token",
+        "telemetry_service_name",
+        "hostname"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "version": {
+            "type": "string"
+        },
+        "telemetry_url": {
+            "type": "string",
+            "format": "uri"
+        },
+        "telemetry_proxy_url": {
+            "type": "string",
+            "format": "uri"
+        },
+        "telemetry_token": {
+            "type": "string"
+        },
+        "telemetry_service_name": {
+            "type": "string"
+        },
+        "hostname": {
+            "type": "string"
+        }
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ requires = [
 include = ["payu*"]
 namespaces = false
 
+[tool.setuptools.package-data]
+"payu" = ["telemetry/*.json"]
+
 [tool.pytest.ini_options]
 addopts = "--cov=payu"
 testpaths = ["test/"]

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -174,7 +174,7 @@ def test_get_external_telemetry_config_no_file(
     "telemetry_service_name",
     "telemetry_token",
 ])
-def test_get_external_telemetry_config_missing_fields(
+def test_get_external_telemetry_config_failed_schema_validation(
             tmp_path, setup_env, config_path, missing_field
         ):
     config_data = {
@@ -190,8 +190,8 @@ def test_get_external_telemetry_config_missing_fields(
         json.dump(config_data, f)
 
     expected_error = (
-        f"Required field(s) {set([missing_field])} not found in "
-        f"configuration file specified by {TELEMETRY_CONFIG}: {config_path}."
+        f"The telemetry configuration file {config_path} specified by {TELEMETRY_CONFIG} does "
+        f"not follow the required schema: '{missing_field}' is a required property"
     )
     check_invalid_get_external_config(tmp_path, expected_error)
 

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -301,6 +301,30 @@ def test_telemetry_not_enabled_no_environment_config(
     mock_telemetry_get_external_config.assert_not_called()
     mock_post_telemetry_data.assert_not_called()
 
+def test_telemetry_not_enabled_empty_environment_config(
+            tmp_path,
+            mock_telemetry_get_external_config,
+            mock_post_telemetry_data,
+            monkeypatch
+        ):
+    # Ensure telemetry config in environment is set and empty
+    monkeypatch.setenv(TELEMETRY_CONFIG, "")
+    # Ensure the other conditions to skip record_telemetry are not met
+    config = {
+        "telemetry": {
+            "enable": True
+        }
+    }
+    run_info={"payu_model_run_status": "fake_value"}
+
+    record_telemetry(run_info=run_info, config=config,
+                     archive_path=tmp_path / "archive",
+                     job_file_path=tmp_path / "job_file.json")
+
+    # Check post telemetry method was not called
+    mock_telemetry_get_external_config.assert_not_called()
+    mock_post_telemetry_data.assert_not_called()
+
 def test_telemetry_not_enabled_config(
             tmp_path,
             monkeypatch,

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -113,15 +113,13 @@ def mock_telemetry_get_external_config():
 @pytest.fixture
 def config_path(tmp_path):
     """Returns the path to the telemetry config file"""
-    config_dir = tmp_path / "telemetry_config"
-    config_dir.mkdir()
-    return config_dir / "1-0-0.json"
+    return tmp_path / "telemetry_config.json"
 
 
 @pytest.fixture
 def setup_env(config_path, monkeypatch):
     """Set the telemetry config environment variable for the test"""
-    monkeypatch.setenv(TELEMETRY_CONFIG, str(config_path.parent))
+    monkeypatch.setenv(TELEMETRY_CONFIG, str(config_path))
 
 
 @pytest.fixture
@@ -165,7 +163,7 @@ def test_get_external_telemetry_config_no_file(
             tmp_path, setup_env, config_path
         ):
     expected_error = (
-        f"No config file found at {TELEMETRY_CONFIG}: {config_path}."
+        f"No config file found at the path specified by {TELEMETRY_CONFIG}: {config_path}."
     )
     check_invalid_get_external_config(tmp_path, expected_error)
 
@@ -193,7 +191,7 @@ def test_get_external_telemetry_config_missing_fields(
 
     expected_error = (
         f"Required field(s) {set([missing_field])} not found in "
-        f"configuration file at {TELEMETRY_CONFIG}: {config_path}."
+        f"configuration file specified by {TELEMETRY_CONFIG}: {config_path}."
     )
     check_invalid_get_external_config(tmp_path, expected_error)
 
@@ -225,7 +223,7 @@ def test_get_external_telemetry_config_invalid_json(
         f.write("{invalid_json")
 
     expected_error = (
-        f"Error parsing json in configuration file at "
+        f"Error parsing json in configuration file specified by "
         f"{TELEMETRY_CONFIG}: {config_path}."
     )
     check_invalid_get_external_config(tmp_path, expected_error)

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -285,8 +285,15 @@ def test_telemetry_not_enabled_no_environment_config(
     # Ensure telemetry config is not in os environment
     if TELEMETRY_CONFIG in os.environ:
         monkeypatch.delenv(TELEMETRY_CONFIG, raising=False)
-
-    record_telemetry(run_info={}, config={},
+    # Ensure the other conditions to skip record_telemetry are not met
+    config = {
+        "telemetry": {
+            "enable": True
+        }
+    }
+    run_info={"payu_model_run_status": "fake_value"}
+    
+    record_telemetry(run_info=run_info, config=config,
                      archive_path=tmp_path / "archive",
                      job_file_path=tmp_path / "job_file.json")
 
@@ -294,20 +301,24 @@ def test_telemetry_not_enabled_no_environment_config(
     mock_telemetry_get_external_config.assert_not_called()
     mock_post_telemetry_data.assert_not_called()
 
-
 def test_telemetry_not_enabled_config(
             tmp_path,
+            monkeypatch,
             mock_telemetry_get_external_config,
             mock_post_telemetry_data,
             setup_env
         ):
+    # Ensure telemetry config is not enabled
     config = {
         "telemetry": {
             "enable": False
         }
     }
-
-    record_telemetry(run_info={}, config={},
+    # Ensure the other conditions to skip record_telemetry are not met
+    monkeypatch.setenv(TELEMETRY_CONFIG, "Some_value")
+    run_info={"payu_model_run_status": "fake_value"}
+    
+    record_telemetry(run_info=run_info, config=config,
                      archive_path=tmp_path / "archive",
                      job_file_path=tmp_path / "job_file.json")
 


### PR DESCRIPTION
More context in #725 and [ACCESS-NRI/containerised-environments-infra/issues/4](https://github.com/ACCESS-NRI/containerised-environments-infra/issues/4).

Updated payu telemetry's module:

- [x] the env variable name where the config path is stored has been updated to `PAYU_TELEMETRY_CONFIG_PATH`
- [x] Updated logic to skip telemetry recording if the `PAYU_TELEMETRY_CONFIG_PATH` is set but empty
- [x] Updated telemetry not enabled tests to enforce testing only the specific condition to skip telemetry (before there were multiple conditions not met, so the tests would not really test what they should have been testing)
- [x] Added telemetry configuration specification as a JSON jinja template to be interpolated using the [cuchi/jinja2-action](https://github.com/cuchi/jinja2-action) action