### PR TITLE
673/jasmeen jo/handling errors payu

### DIFF
--- a/payu/branch.py
+++ b/payu/branch.py
@@ -20,7 +20,8 @@ import git
 from payu.fsops import read_config, DEFAULT_CONFIG_FNAME, list_archive_dirs
 from payu.laboratory import Laboratory
 from payu.metadata import Metadata, UUID_FIELD, METADATA_FILENAME
-from payu.git_utils import GitRepository, git_clone, PayuBranchError
+from payu.git_utils import GitRepository, git_clone
+import payu.errors as errors
 
 LAB_WRITE_ACCESS_ERROR = """
 Failed to initialise laboratory directories. Skipping creating metadata,
@@ -47,7 +48,7 @@ Where BRANCH_NAME is the name of the branch"""
 
 def remove_traceback_hook(kind, message, traceback):
     """Remove traceback for only PayuBranchError"""
-    if kind is PayuBranchError:
+    if kind is errors.PayuBranchError:
         print(f'{kind.__name__}: {message}', file=sys.stderr)
     else:
         sys.__excepthook__(kind, message, traceback)
@@ -298,7 +299,7 @@ def clone(repository: str,
     control_path = directory.resolve()
 
     if control_path.exists():
-        raise PayuBranchError(
+        raise errors.PayuBranchError(
             f"Directory path `{control_path}` already exists. "
             "Clone to a different path, or cd into the existing directory " +
             "and use `payu checkout` if it is the same git repository"
@@ -306,7 +307,7 @@ def clone(repository: str,
 
     # Check -b is set when -s/--start-point is set
     if start_point is not None and new_branch_name is None:
-        raise PayuBranchError(
+        raise errors.PayuBranchError(
             "Starting from a specific commit or tag requires a new branch "
             "name to be specified. Use the --new-branch/-b flag in payu clone "
             "to create a new git branch.\n"
@@ -352,7 +353,7 @@ def clone(repository: str,
                             lab_path=lab_path,
                             is_new_experiment=True,
                             parent_experiment=parent_experiment)
-    except PayuBranchError as e:
+    except errors.PayuBranchError as e:
         # Remove directory if incomplete checkout
         shutil.rmtree(control_path)
         msg = (
@@ -362,7 +363,7 @@ def clone(repository: str,
             f"\n  Checkout error: {e}\n"
             "For more infomation on payu clone, run `payu clone --help`"
         )
-        raise PayuBranchError(msg)
+        raise errors.PayuBranchError(msg)
     finally:
         # Change back to original working directory
         os.chdir(owd)

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -17,7 +17,7 @@ import sys
 from ruamel.yaml import YAML, CommentedMap, constructor
 import git
 
-from payu.fsops import read_config, DEFAULT_CONFIG_FNAME, list_archive_dirs
+from payu.fsops import read_config, DEFAULT_CONFIG_FNAME, list_sorted_archive_dirs
 from payu.laboratory import Laboratory
 from payu.metadata import Metadata, UUID_FIELD, METADATA_FILENAME
 from payu.git_utils import GitRepository, git_clone
@@ -86,7 +86,7 @@ def check_restart(restart_path: Path,
 
     # Check for pre-existing restarts in archive
     if archive_path and archive_path.exists():
-        if len(list_archive_dirs(archive_path, dir_type="restart")) > 0:
+        if len(list_sorted_archive_dirs(archive_path, dir_type="restart")) > 0:
             warnings.warn((
                 f"Pre-existing restarts found in archive: {archive_path}."
                 f"Skipping adding 'restart: {restart_path}' to config file"))

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -301,7 +301,7 @@ def clone(repository: str,
     if control_path.exists():
         raise errors.PayuBranchError(
             f"Directory path `{control_path}` already exists. "
-            "Clone to a different path, or cd into the existing directory " +
+            "Clone to a different path, or cd into the existing directory "
             "and use `payu checkout` if it is the same git repository"
         )
 

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -27,6 +27,7 @@ from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
 import payu.subcommands
 from payu.logger import setup_logger
 import payu.subcommands.args as arg_templates
+import payu.errors as errors
 
 # Default configuration
 DEFAULT_CONFIG = 'config.yaml'
@@ -59,8 +60,23 @@ def parse():
         warnings.formatwarning = (
             lambda message, category, filename, lineno, line=None: f"{message}"
         )
-        
-    run_cmd(**args)
+    try:
+        run_cmd(**args)
+
+    except errors.PayuError as e:
+        # CLEAN EXIT for expected errors
+        if stacktrace:
+            # Shows the full stacktrace
+            logging.exception(str(e), exc_info=True)
+        else:
+            print(f'payu: error: {e}', file=sys.stderr)
+        sys.exit(1)
+
+    except Exception as e:
+        # CRASH EXIT for unexpected bugs (ValueError, TypeError etc.)
+        print('payu: An unexpected internal error occurred!', file=sys.stderr)
+        logging.exception(str(e)) # Always show stacktrace for unknown bugs
+        sys.exit(1)
 
 
 def generate_parser(is_interactive=False):

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -65,18 +65,14 @@ def parse():
     run_cmd(**args)
 
     except errors.PayuError as e:
-        # CLEAN EXIT for expected errors
-        if stacktrace:
-            # Shows the full stacktrace
-            logging.exception(str(e), exc_info=True)
-        else:
-            print(f'payu: error: {e}', file=sys.stderr)
+        # Logs a clean message, and attaches stacktrace 'only' if requested.
+        logging.error(e, exc_info=stacktrace)
         sys.exit(1)
 
     except Exception as e:
         # CRASH EXIT for unexpected bugs (ValueError, TypeError etc.)
         print('payu: error: An unexpected internal error occurred!', file=sys.stderr)
-        logging.exception(str(e)) # Always show stacktrace for unknown bugs
+        logging.exception(e) # Always show stacktrace for unknown bugs
         sys.exit(1)
 
 

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -64,6 +64,21 @@ def parse():
         
     run_cmd(**args)
 
+    except errors.PayuError as e:
+        # CLEAN EXIT for expected errors
+        if stacktrace:
+            # Shows the full stacktrace
+            logging.exception(str(e), exc_info=True)
+        else:
+            print(f'payu: error: {e}', file=sys.stderr)
+        sys.exit(1)
+
+    except Exception as e:
+        # CRASH EXIT for unexpected bugs (ValueError, TypeError etc.)
+        print('payu: error: An unexpected internal error occurred!', file=sys.stderr)
+        logging.exception(str(e)) # Always show stacktrace for unknown bugs
+        sys.exit(1)
+
 
 def generate_parser(is_interactive=False):
     """Parse the command line inputs generate and return parser."""

--- a/payu/errors.py
+++ b/payu/errors.py
@@ -1,4 +1,12 @@
-'''Custom Payu Exceptions - for catching user errors.
+'''Custom Payu Exceptions. For catching user errors.
+ - Use them when user inputs are not recognised. 
+ - They intend to provide a polite, actionable message to users.
+
+Standard Exceptions (ex. ValueError, TypeError) are for the Developer.
+ - Use them to catch exceptions from another piece of code or 
+   function calls.
+ - We want the program to crash with a stack trace so developer 
+   could fix the bug.
 '''
 
 class PayuError(Exception):
@@ -36,4 +44,3 @@ class PayuRunError(PayuError):
     Raised when an active model run fails unexpectedly.
     '''
     exit_code = 5
-    

--- a/payu/errors.py
+++ b/payu/errors.py
@@ -1,0 +1,39 @@
+'''Custom Payu Exceptions - for catching user errors.
+'''
+
+class PayuError(Exception):
+    '''
+    Base class for all Payu Exceptions. 
+    Any error that inherits from this class - represents an expected failure 
+    mode (ex. bad user input, missing files) rather than a code bug.
+    '''
+    exit_code = 1
+
+
+class PayuConfigError(PayuError):
+    '''
+    Raised when there is an error reading the config.yaml file.
+    '''
+    exit_code = 2
+
+
+class PayuFileNotFoundError(PayuError):
+    '''
+    Raised when a required file or directory for a model is missing.
+    '''
+    exit_code = 3
+
+
+class PayuBranchError(PayuError):
+    '''
+    Raised when there are issues with Git branches.
+    '''
+    exit_code = 4
+
+
+class PayuRunError(PayuError):
+    '''
+    Raised when an active model run fails unexpectedly.
+    '''
+    exit_code = 5
+    

--- a/payu/errors.py
+++ b/payu/errors.py
@@ -1,19 +1,20 @@
-'''Custom Payu Exceptions. For catching user errors.
- - Use them when user inputs are not recognised. 
+'''Custom Payu Exceptions for handling user-facing errors.
+ - Use these when user input is invalid or not recognised. 
  - They intend to provide a polite, actionable message to users.
 
-Standard Exceptions (ex. ValueError, TypeError) are for the Developer.
- - Use them to catch exceptions from another piece of code or 
-   function calls.
- - We want the program to crash with a stack trace so developer 
-   could fix the bug.
+---
+
+Note: 
+Standard Exceptions (e.g. ValueError, TypeError) are intended for
+developer-facing errors. Use them when catching issues from internal
+code or function calls.
 '''
 
 class PayuError(Exception):
     '''
     Base class for all Payu Exceptions. 
     Any error that inherits from this class - represents an expected failure 
-    mode (ex. bad user input, missing files) rather than a code bug.
+    mode (e.g. bad user input, missing files) rather than a code bug.
     '''
     exit_code = 1
 
@@ -44,3 +45,4 @@ class PayuRunError(PayuError):
     Raised when an active model run fails unexpectedly.
     '''
     exit_code = 5
+ 

--- a/payu/errors.py
+++ b/payu/errors.py
@@ -35,7 +35,7 @@ class PayuFileNotFoundError(PayuError):
 
 class PayuRunError(PayuError):
     '''
-    Raised when an active model run fails unexpectedly.
+    Raised when an active model run fails.
     '''
     exit_code = 4
 

--- a/payu/errors.py
+++ b/payu/errors.py
@@ -33,16 +33,23 @@ class PayuFileNotFoundError(PayuError):
     exit_code = 3
 
 
-class PayuBranchError(PayuError):
-    '''
-    Raised when there are issues with Git branches.
-    '''
-    exit_code = 4
-
-
 class PayuRunError(PayuError):
     '''
     Raised when an active model run fails unexpectedly.
     '''
+    exit_code = 4
+
+
+class PayuGitError(PayuError):
+    '''
+    Raised when there are Git related issues .
+    '''
     exit_code = 5
+
+
+class PayuBranchError(PayuError):
+    '''
+    Custom exception for payu branch operations
+    '''
+    exit_code = 6
  

--- a/payu/errors.py
+++ b/payu/errors.py
@@ -43,13 +43,19 @@ class PayuRunError(PayuError):
 class PayuGitError(PayuError):
     '''
     Raised when there are Git related issues.
+
+    Ex. failed 'git clone', or file permission issues
+    with the Git repository.
     '''
     exit_code = 5
 
 
 class PayuBranchError(PayuError):
     '''
-    Custom exception for payu branch operations
+    Custom exception for payu branch operations.
+
+    Ex. when checking out to non-existent branches,
+    or if there is an error while fetching branches.
     '''
     exit_code = 6
  

--- a/payu/errors.py
+++ b/payu/errors.py
@@ -12,7 +12,7 @@ code or function calls.
 
 class PayuError(Exception):
     '''
-    Base class for all Payu Exceptions. 
+    Base class for all Payu Exceptions caused by user behavior. 
     Any error that inherits from this class - represents an expected failure 
     mode (e.g. bad user input, missing files) rather than a code bug.
     '''
@@ -42,7 +42,7 @@ class PayuRunError(PayuError):
 
 class PayuGitError(PayuError):
     '''
-    Raised when there are Git related issues .
+    Raised when there are Git related issues.
     '''
     exit_code = 5
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -888,7 +888,8 @@ class Experiment(object):
         )
         # Check there is a work directory, otherwise bail
         if not os.path.exists(self.work_sym_path):
-            raise errors.PayuFileNotFoundError('payu: error: No work directory to archive.')
+            raise errors.PayuFileNotFoundError('payu: error: \
+                No work directory to archive.')
             # sys.exit('payu: error: No work directory to archive.')
 
         os.makedirs(self.archive_path, exist_ok=True)
@@ -909,7 +910,8 @@ class Experiment(object):
 
         # Double-check that the run path does not exist
         if os.path.exists(self.output_path):
-            sys.exit('payu: error: Output path already exists.')
+            raise errors.PayuError('payu: error: output path already exists')
+            # sys.exit('payu: error: Output path already exists.')
 
         movetree(self.work_path, self.output_path)
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -792,8 +792,9 @@ class Experiment(object):
                 self.run_userscript(error_script, 'error')
 
             # Terminate payu
-            sys.exit('payu: Model exited with error code {0}; aborting.'
-                     ''.format(rc))
+            raise errors.PayuRunError(f'payu: exited with error code {rc}; aborting.')
+            # sys.exit('payu: Model exited with error code {0}; aborting.'
+            #          ''.format(rc))
 
         # Decrement run counter on successful run
         stop_file_path = os.path.join(self.control_path, 'stop_run')

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -476,7 +476,8 @@ class Experiment(object):
 
         # Confirm that no output path already exists
         if os.path.exists(self.output_path):
-            raise errors.PayuError(f'payu: error: output path already exists: {self.output_path}')
+            raise errors.PayuError(f'payu: error: output path already exists:\
+                 {self.output_path}')
             # sys.exit('payu: error: Output path already exists: '
             #          '{path}.'.format(path=self.output_path))
 
@@ -487,8 +488,11 @@ class Experiment(object):
                       '      Sweeping as --force option is True.')
                 self.sweep()
             else:
-                raise errors.PayuError(f"""payu: error: work path already exists: {self.work_path}.
-                             payu sweep and then payu run""")
+                raise errors.PayuError(
+                    f'''
+                    payu: error: work path already exists: {self.work_path}.
+                             payu sweep and then payu run
+                    ''')
             
                 # sys.exit('payu: error: work path already exists: {path}.\n'
                 #          '             payu sweep and then payu run'

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -888,7 +888,8 @@ class Experiment(object):
         )
         # Check there is a work directory, otherwise bail
         if not os.path.exists(self.work_sym_path):
-            sys.exit('payu: error: No work directory to archive.')
+            raise errors.PayuFileNotFoundError('payu: error: No work directory to archive.')
+            # sys.exit('payu: error: No work directory to archive.')
 
         os.makedirs(self.archive_path, exist_ok=True)
         make_symlink(self.archive_path, self.archive_sym_path)

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -44,6 +44,7 @@ from payu.calendar import parse_date_offset
 from payu.sync import SyncToRemoteArchive
 from payu.metadata import Metadata
 import payu.telemetry as telemetry
+import payu.errors as errors
 
 # Environment module support on vayu
 # TODO: To be removed
@@ -475,8 +476,9 @@ class Experiment(object):
 
         # Confirm that no output path already exists
         if os.path.exists(self.output_path):
-            sys.exit('payu: error: Output path already exists: '
-                     '{path}.'.format(path=self.output_path))
+            raise errors.PayuError(f'Output path already exists: {self.output_path}')
+            # sys.exit('payu: error: Output path already exists: '
+            #          '{path}.'.format(path=self.output_path))
 
         # Confirm that no work path already exists
         if os.path.exists(self.work_path):

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -476,7 +476,7 @@ class Experiment(object):
 
         # Confirm that no output path already exists
         if os.path.exists(self.output_path):
-            raise errors.PayuError(f'Output path already exists: {self.output_path}')
+            raise errors.PayuError(f'payu: error: output path already exists: {self.output_path}')
             # sys.exit('payu: error: Output path already exists: '
             #          '{path}.'.format(path=self.output_path))
 
@@ -487,9 +487,12 @@ class Experiment(object):
                       '      Sweeping as --force option is True.')
                 self.sweep()
             else:
-                sys.exit('payu: error: work path already exists: {path}.\n'
-                         '             payu sweep and then payu run'
-                         .format(path=self.work_path))
+                raise errors.PayuError(f"""payu: error: work path already exists: {self.work_path}.
+                             payu sweep and then payu run""")
+            
+                # sys.exit('payu: error: work path already exists: {path}.\n'
+                #          '             payu sweep and then payu run'
+                #          .format(path=self.work_path))
 
         os.makedirs(self.work_path, exist_ok=True)
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -32,7 +32,7 @@ from packaging import version
 # Local
 from payu import envmod
 from payu.fsops import make_symlink, read_config, movetree
-from payu.fsops import list_archive_dirs
+from payu.fsops import list_sorted_archive_dirs
 from payu.fsops import run_script_command
 from payu.fsops import needs_subprocess_shell
 from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
@@ -259,7 +259,7 @@ class Experiment(object):
         """Given a output directory type (output or restart),
         return the maximum index of output directories found"""
         try:
-            output_dirs = list_archive_dirs(archive_path=self.archive_path,
+            output_dirs = list_sorted_archive_dirs(archive_path=self.archive_path,
                                             dir_type=output_type)
         except FileNotFoundError:
             # Archive path does not exist yet
@@ -1033,9 +1033,10 @@ class Experiment(object):
         sync_config = self.config.get('sync', {})
         syncing = sync_config.get('enable', False)
         if syncing:
-            cmd = '{python} {payu} sync'.format(
+            cmd = '{python} {payu} sync -i {expt}'.format(
                 python=sys.executable,
-                payu=self.payu_path
+                payu=self.payu_path,
+                expt=self.counter
             )
 
             if self.postscript:
@@ -1169,7 +1170,7 @@ class Experiment(object):
             return []
 
         # Sorted list of restart directories in archive
-        restarts = list_archive_dirs(archive_path=self.archive_path,
+        restarts = list_sorted_archive_dirs(archive_path=self.archive_path,
                                      dir_type='restart')
         restart_indices = {}
         for restart in restarts:

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -498,10 +498,9 @@ class Experiment(object):
                 self.sweep()
             else:
                 raise errors.PayuRunError(
-                    f'''
-                    payu: error: work path already exists: {self.work_path}.
-                             payu sweep and then payu run
-                    ''')
+                    f'payu: error: work path already exists: {self.work_path}.\n'
+                    '         payu sweep and then payu run'
+                    )
             
                 # sys.exit('payu: error: work path already exists: {path}.\n'
                 #          '             payu sweep and then payu run'

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -497,7 +497,7 @@ class Experiment(object):
                       '      Sweeping as --force option is True.')
                 self.sweep()
             else:
-                raise errors.PayuError(
+                raise errors.PayuRunError(
                     f'''
                     payu: error: work path already exists: {self.work_path}.
                              payu sweep and then payu run

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -897,7 +897,8 @@ class Experiment(object):
         )
         # Check there is a work directory, otherwise bail
         if not os.path.exists(self.work_sym_path):
-            sys.exit('payu: error: No work directory to archive.')
+            raise errors.PayuFileNotFoundError('payu: error: No work directory to archive.')
+            # sys.exit('payu: error: No work directory to archive.')
 
         os.makedirs(self.archive_path, exist_ok=True)
         make_symlink(self.archive_path, self.archive_sym_path)

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -485,7 +485,7 @@ class Experiment(object):
 
         # Confirm that no output path already exists
         if os.path.exists(self.output_path):
-            raise errors.PayuError(f'payu: error: output path already exists:\
+            raise errors.PayuRunError(f'payu: error: output path already exists:\
                  {self.output_path}')
             # sys.exit('payu: error: Output path already exists: '
             #          '{path}.'.format(path=self.output_path))

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -897,7 +897,8 @@ class Experiment(object):
         )
         # Check there is a work directory, otherwise bail
         if not os.path.exists(self.work_sym_path):
-            raise errors.PayuFileNotFoundError('payu: error: No work directory to archive.')
+            raise errors.PayuFileNotFoundError('payu: error: \
+                No work directory to archive.')
             # sys.exit('payu: error: No work directory to archive.')
 
         os.makedirs(self.archive_path, exist_ok=True)
@@ -918,7 +919,8 @@ class Experiment(object):
 
         # Double-check that the run path does not exist
         if os.path.exists(self.output_path):
-            sys.exit('payu: error: Output path already exists.')
+            raise errors.PayuError('payu: error: output path already exists')
+            # sys.exit('payu: error: Output path already exists.')
 
         movetree(self.work_path, self.output_path)
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -485,7 +485,7 @@ class Experiment(object):
 
         # Confirm that no output path already exists
         if os.path.exists(self.output_path):
-            raise errors.PayuError(f'Output path already exists: {self.output_path}')
+            raise errors.PayuError(f'payu: error: output path already exists: {self.output_path}')
             # sys.exit('payu: error: Output path already exists: '
             #          '{path}.'.format(path=self.output_path))
 
@@ -496,9 +496,12 @@ class Experiment(object):
                       '      Sweeping as --force option is True.')
                 self.sweep()
             else:
-                sys.exit('payu: error: work path already exists: {path}.\n'
-                         '             payu sweep and then payu run'
-                         .format(path=self.work_path))
+                raise errors.PayuError(f"""payu: error: work path already exists: {self.work_path}.
+                             payu sweep and then payu run""")
+            
+                # sys.exit('payu: error: work path already exists: {path}.\n'
+                #          '             payu sweep and then payu run'
+                #          .format(path=self.work_path))
 
         os.makedirs(self.work_path, exist_ok=True)
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -44,6 +44,7 @@ from payu.calendar import parse_date_offset
 from payu.sync import SyncToRemoteArchive
 from payu.metadata import Metadata
 import payu.telemetry as telemetry
+import payu.errors as errors
 
 # Environment module support on vayu
 # TODO: To be removed
@@ -484,8 +485,9 @@ class Experiment(object):
 
         # Confirm that no output path already exists
         if os.path.exists(self.output_path):
-            sys.exit('payu: error: Output path already exists: '
-                     '{path}.'.format(path=self.output_path))
+            raise errors.PayuError(f'Output path already exists: {self.output_path}')
+            # sys.exit('payu: error: Output path already exists: '
+            #          '{path}.'.format(path=self.output_path))
 
         # Confirm that no work path already exists
         if os.path.exists(self.work_path):

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -923,7 +923,7 @@ class Experiment(object):
 
         # Double-check that the run path does not exist
         if os.path.exists(self.output_path):
-            raise errors.PayuError('payu: error: output path already exists')
+            raise errors.PayuRunError('payu: error: output path already exists')
             # sys.exit('payu: error: Output path already exists.')
 
         movetree(self.work_path, self.output_path)

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -485,7 +485,8 @@ class Experiment(object):
 
         # Confirm that no output path already exists
         if os.path.exists(self.output_path):
-            raise errors.PayuError(f'payu: error: output path already exists: {self.output_path}')
+            raise errors.PayuError(f'payu: error: output path already exists:\
+                 {self.output_path}')
             # sys.exit('payu: error: Output path already exists: '
             #          '{path}.'.format(path=self.output_path))
 
@@ -496,8 +497,11 @@ class Experiment(object):
                       '      Sweeping as --force option is True.')
                 self.sweep()
             else:
-                raise errors.PayuError(f"""payu: error: work path already exists: {self.work_path}.
-                             payu sweep and then payu run""")
+                raise errors.PayuError(
+                    f'''
+                    payu: error: work path already exists: {self.work_path}.
+                             payu sweep and then payu run
+                    ''')
             
                 # sys.exit('payu: error: work path already exists: {path}.\n'
                 #          '             payu sweep and then payu run'

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -26,7 +26,7 @@ import warnings
 import pwd
 
 # Extensions
-import yaml
+from ruamel.yaml import YAML
 from packaging import version
 
 # Local
@@ -724,8 +724,10 @@ class Experiment(object):
             os.environ['PAYU_RUN_ID'] = str(self.run_id)
 
         # Dump out environment
+        yaml = YAML()
+        yaml.default_flow_style = False
         with open(self.env_fname, 'w') as file:
-            file.write(yaml.dump(dict(os.environ), default_flow_style=False))
+            yaml.dump(dict(os.environ), file)
 
         # Update run info file
         telemetry.update_run_job_file(

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -801,8 +801,9 @@ class Experiment(object):
                 self.run_userscript(error_script, 'error')
 
             # Terminate payu
-            sys.exit('payu: Model exited with error code {0}; aborting.'
-                     ''.format(rc))
+            raise errors.PayuRunError(f'payu: exited with error code {rc}; aborting.')
+            # sys.exit('payu: Model exited with error code {0}; aborting.'
+            #          ''.format(rc))
 
         # Decrement run counter on successful run
         stop_file_path = os.path.join(self.control_path, 'stop_run')

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -239,7 +239,7 @@ def required_libs(bin_path):
     return parse_ldd_output(ldd_out)
 
 
-def list_archive_dirs(archive_path: Union[Path, str],
+def list_sorted_archive_dirs(archive_path: Union[Path, str],
                       dir_type: str = "output") -> List[str]:
     """Return a sorted list of restart or output directories in archive"""
     naming_pattern = re.compile(fr"^{dir_type}[0-9][0-9][0-9]+$")
@@ -253,7 +253,7 @@ def list_archive_dirs(archive_path: Union[Path, str],
         if real_path.is_dir() and naming_pattern.match(path.name):
             dirs.append(path.name)
 
-    dirs.sort(key=lambda d: int(d.lstrip(dir_type)))
+    dirs.sort(key=lambda d: int(d.removeprefix(dir_type)))
     return dirs
 
 

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -23,7 +23,8 @@ import stat
 import warnings
 
 # Extensions
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.constructor import DuplicateKeyError
 
 DEFAULT_CONFIG_FNAME = 'config.yaml'
 
@@ -36,6 +37,11 @@ EXTENSION_TO_INTERPRETER = {'.py': sys.executable,
                             '.sh': '/bin/bash',
                             '.csh': '/bin/tcsh'}
 
+duplicate_key_warning = """
+    ---------------------------
+    Duplicate key found in config file.
+    Payu will keep the first value for this key.
+    --------------------------- """
 
 def movetree(src, dst, symlinks=False):
     """
@@ -56,26 +62,6 @@ def movetree(src, dst, symlinks=False):
     shutil.rmtree(src)
 
 
-class DuplicateKeyWarnLoader(yaml.SafeLoader):
-    def construct_mapping(self, node, deep=False):
-        """Add warning for duplicate keys in yaml file, as currently
-        PyYAML overwrites duplicate keys even though in YAML, keys
-        are meant to be unique
-        """
-        mapping = {}
-        for key_node, value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)
-            value = self.construct_object(value_node, deep=deep)
-            if key in mapping:
-                warnings.warn(
-                    "Duplicate key found in config.yaml: "
-                    f"key '{key}' with value '{value}'. "
-                    f"This overwrites the original value: '{mapping[key]}'"
-                )
-            mapping[key] = value
-
-        return super().construct_mapping(node, deep)
-
 
 def read_config(config_fname=None):
     """Parse input configuration file and return a config dict."""
@@ -85,7 +71,22 @@ def read_config(config_fname=None):
 
     try:
         with open(config_fname, 'r') as config_file:
-            config = yaml.load(config_file, Loader=DuplicateKeyWarnLoader)
+
+            try:
+                # Attempt to load config with duplicate key checking first
+                yaml = YAML(typ='safe')
+                yaml.allow_duplicate_keys = False
+                config = yaml.load(config_file)
+
+            except DuplicateKeyError as e:
+                # Warn the user about duplicated keys,
+                # Second attempt to load config with duplicated key allowed.
+                warnings.warn("Details: " + str(e) + duplicate_key_warning, UserWarning)
+                yaml = YAML(typ='safe')
+                config_file.seek(0)
+                yaml.allow_duplicate_keys = True
+                config = yaml.load(config_file)
+                
 
         # NOTE: A YAML file with no content returns `None`
         if config is None:

--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -10,6 +10,7 @@ from typing import Optional, Union, List, Dict
 
 import git
 import configparser
+import payu.errors as errors
 
 
 class PayuGitWarning(Warning):
@@ -58,13 +59,13 @@ class GitRepository:
         not a git repository"""
         if self.repo:
             if self.repo.head.is_detached:
-                raise errors.PayuGitError("""
+                raise errors.PayuGitError('''
                 Repo is in detached HEAD state.
                 Before running again checkout a branch using 
 
                     payu checkout <branch>
 
-                """)
+                ''')
                 # sys.exit("\nRepo is in a detached HEAD state.\n"
                 #          "Before running again checkout a branch using\n\n"
                 #          "    payu checkout <branch>\n\n")
@@ -173,7 +174,7 @@ class GitRepository:
         """Checkout branch and create branch if specified"""
         # First check for staged changes
         if self.repo.is_dirty(index=True, working_tree=False):
-            raise PayuBranchError(
+            raise errors.PayuBranchError(
                 "There are staged git changes. Please stash or commit them "
                 "before running the checkout command again.\n"
                 "To see what files are staged, run: git status"
@@ -187,7 +188,7 @@ class GitRepository:
         # Create new branch, if specified
         if new_branch:
             if branch_name in all_branches:
-                raise PayuBranchError(
+                raise errors.PayuBranchError(
                     f"A branch named {branch_name} already exists. "
                     "To checkout this branch, remove the new branch flag '-b' "
                     "from the checkout command."
@@ -208,7 +209,7 @@ class GitRepository:
 
         # Checkout branch
         if branch_name not in all_branches:
-            raise PayuBranchError(
+            raise errors.PayuBranchError(
                 f"There is no existing branch called {branch_name}. "
                 "To create this branch, add the new branch flag '-b' "
                 "to the checkout command."

--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -59,13 +59,14 @@ class GitRepository:
         not a git repository"""
         if self.repo:
             if self.repo.head.is_detached:
-                raise errors.PayuGitError('''
-                Repo is in detached HEAD state.
-                Before running again checkout a branch using 
+                raise errors.PayuGitError(
+                    '''
+                    Repo is in detached HEAD state.
+                    Before running again checkout a branch using 
 
-                    payu checkout <branch>
+                        payu checkout <branch>
 
-                ''')
+                    ''')
                 # sys.exit("\nRepo is in a detached HEAD state.\n"
                 #          "Before running again checkout a branch using\n\n"
                 #          "    payu checkout <branch>\n\n")

--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -12,13 +12,8 @@ import git
 import configparser
 
 
-class PayuBranchError(Exception):
-    """Custom exception for payu branch operations"""
-
-
 class PayuGitWarning(Warning):
     """Custom warning class - useful for testing"""
-
 
 def get_git_repository(repo_path: Union[Path, str],
                        initialise: bool = False,
@@ -63,9 +58,16 @@ class GitRepository:
         not a git repository"""
         if self.repo:
             if self.repo.head.is_detached:
-                sys.exit("\nRepo is in a detached HEAD state.\n"
-                         "Before running again checkout a branch using\n\n"
-                         "    payu checkout <branch>\n\n")
+                raise errors.PayuGitError("""
+                Repo is in detached HEAD state.
+                Before running again checkout a branch using 
+
+                    payu checkout <branch>
+
+                """)
+                # sys.exit("\nRepo is in a detached HEAD state.\n"
+                #          "Before running again checkout a branch using\n\n"
+                #          "    payu checkout <branch>\n\n")
             else:
                 return self.repo.active_branch
         else:

--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -60,13 +60,9 @@ class GitRepository:
         if self.repo:
             if self.repo.head.is_detached:
                 raise errors.PayuGitError(
-                    '''
-                    Repo is in detached HEAD state.
-                    Before running again checkout a branch using 
-
-                        payu checkout <branch>
-
-                    ''')
+                    'Repo is in detached HEAD state.'
+                    'Before running again checkout a branch using '
+                    '    payu checkout <branch>')
                 # sys.exit("\nRepo is in a detached HEAD state.\n"
                 #          "Before running again checkout a branch using\n\n"
                 #          "    payu checkout <branch>\n\n")
@@ -176,9 +172,9 @@ class GitRepository:
         # First check for staged changes
         if self.repo.is_dirty(index=True, working_tree=False):
             raise errors.PayuBranchError(
-                "There are staged git changes. Please stash or commit them "
-                "before running the checkout command again.\n"
-                "To see what files are staged, run: git status"
+                'There are staged git changes. Please stash or commit them '
+                'before running the checkout command again.\n'
+                'To see what files are staged, run: git status'
             )
 
         # Existing branches

--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -60,9 +60,9 @@ class GitRepository:
         if self.repo:
             if self.repo.head.is_detached:
                 raise errors.PayuGitError(
-                    'Repo is in detached HEAD state.'
-                    'Before running again checkout a branch using '
-                    '    payu checkout <branch>')
+                    '\nRepo is in detached HEAD state. \n'
+                    'Before running again checkout a branch using \n\n'
+                    '    payu checkout <branch>\n\n')
                 # sys.exit("\nRepo is in a detached HEAD state.\n"
                 #          "Before running again checkout a branch using\n\n"
                 #          "    payu checkout <branch>\n\n")

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -21,6 +21,9 @@ from yamanifest.manifest import Manifest as YaManifest
 
 from payu.fsops import make_symlink
 
+# Internal
+import payu.errors as errors
+
 
 # fast_hashes = ['nchash','binhash']
 fast_hashes = ['binhash']
@@ -122,14 +125,21 @@ class PayuManifest(YaManifest):
                     )
 
         if len(differences) != 0:
-            sys.stderr.write(
-                f'Run cannot reproduce: manifest {self.path} is not correct\n'
-            )
-            print(f"Manifest path: stored hash != calculated hash")
-            for row in differences:
-                print(row)
+            diff_text = '\n'.join(str(row) for row in differences)
+            raise errors.PayuRunError(f'''
+                Run cannot reproduce: manifest {self.path} is not correct.
+                Manifest path: stored hash != calculated hash
+                {diff_text}
+                ''')
 
-            sys.exit(1)
+            # sys.stderr.write(
+            #     f'Run cannot reproduce: manifest {self.path} is not correct\n'
+            # )
+            # print(f"Manifest path: stored hash != calculated hash")
+            # for row in differences:
+            #     print(row)
+
+            # sys.exit(1)
 
 
     def add_filepath(self, filepath, fullpath, hashes, copy=False):

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -126,7 +126,8 @@ class PayuManifest(YaManifest):
 
         if len(differences) != 0:
             diff_text = '\n'.join(str(row) for row in differences)
-            raise errors.PayuRunError(f'''
+            raise errors.PayuRunError(
+                f'''
                 Run cannot reproduce: manifest {self.path} is not correct.
                 Manifest path: stored hash != calculated hash
                 {diff_text}

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -126,11 +126,9 @@ class PayuManifest(YaManifest):
         if len(differences) != 0:
             diff_text = '\n'.join(str(row) for row in differences)
             raise errors.PayuRunError(
-                f'''
-                payu: error: Run cannot reproduce: manifest {self.path} is not correct.
-                Manifest path: stored hash != calculated hash
-                {diff_text}
-                ''')
+                f'payu: error: Run cannot reproduce: manifest {self.path} is not correct.\n'
+                'Manifest path: stored hash != calculated hash\n'
+                f'{diff_text}')
 
             # sys.stderr.write(
             #     f'Run cannot reproduce: manifest {self.path} is not correct\n'

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -20,6 +20,9 @@ from yamanifest.manifest import Manifest as YaManifest
 
 from payu.fsops import make_symlink
 
+# Internal
+import payu.errors as errors
+
 
 # fast_hashes = ['nchash','binhash']
 fast_hashes = ['binhash']
@@ -121,14 +124,21 @@ class PayuManifest(YaManifest):
                     )
 
         if len(differences) != 0:
-            sys.stderr.write(
-                f'Run cannot reproduce: manifest {self.path} is not correct\n'
-            )
-            print(f"Manifest path: stored hash != calculated hash")
-            for row in differences:
-                print(row)
+            diff_text = '\n'.join(str(row) for row in differences)
+            raise errors.PayuRunError(f'''
+                Run cannot reproduce: manifest {self.path} is not correct.
+                Manifest path: stored hash != calculated hash
+                {diff_text}
+                ''')
 
-            sys.exit(1)
+            # sys.stderr.write(
+            #     f'Run cannot reproduce: manifest {self.path} is not correct\n'
+            # )
+            # print(f"Manifest path: stored hash != calculated hash")
+            # for row in differences:
+            #     print(row)
+
+            # sys.exit(1)
 
 
     def add_filepath(self, filepath, fullpath, hashes, copy=False):

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -127,7 +127,7 @@ class PayuManifest(YaManifest):
             diff_text = '\n'.join(str(row) for row in differences)
             raise errors.PayuRunError(
                 f'''
-                Run cannot reproduce: manifest {self.path} is not correct.
+                payu: error: Run cannot reproduce: manifest {self.path} is not correct.
                 Manifest path: stored hash != calculated hash
                 {diff_text}
                 ''')

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -125,7 +125,8 @@ class PayuManifest(YaManifest):
 
         if len(differences) != 0:
             diff_text = '\n'.join(str(row) for row in differences)
-            raise errors.PayuRunError(f'''
+            raise errors.PayuRunError(
+                f'''
                 Run cannot reproduce: manifest {self.path} is not correct.
                 Manifest path: stored hash != calculated hash
                 {diff_text}

--- a/payu/models/cable.py
+++ b/payu/models/cable.py
@@ -14,7 +14,9 @@ import shutil
 
 # Extensions
 import f90nml
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 # Local
 from payu.models.model import Model
@@ -113,7 +115,7 @@ class Cable(Model):
         self.cable_nml = f90nml.read(self.cable_nml_path)
         if self.prior_restart_path:
             with open(self.restart_calendar_path, 'r') as restart_file:
-                self.restart_info = yaml.safe_load(restart_file)
+                self.restart_info = yaml.load(restart_file)
         else:
             self.restart_info = {'year': self.cable_nml['cable']['ncciy']}
 
@@ -130,7 +132,7 @@ class Cable(Model):
         forcing_year_config_path = os.path.join(self.work_path, self.forcing_year_config)
         if os.path.exists(forcing_year_config_path):
             with open(forcing_year_config_path, 'r') as file:
-                conf = yaml.safe_load(file)
+                conf = yaml.load(file)
                 forcing_year_config = conf if conf else {}
             for var in self.met_forcing_vars:
                 path = _get_forcing_path(
@@ -152,7 +154,7 @@ class Cable(Model):
         with open(os.path.join(self.restart_path,
                   self.restart_calendar_file), 'w') as restart_file:
             restart = {'year': self.restart_info['year'] + 1}
-            restart_file.write(yaml.dump(restart, default_flow_style=False))
+            yaml.dump(restart, restart_file)
 
         super(Cable, self).archive()
 

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -29,6 +29,7 @@ import payu.calendar as cal
 from payu.fsops import make_symlink
 from payu.models.model import Model
 from payu.namcouple import Namcouple
+import payu.errors as errors
 
 
 class Cice(Model):
@@ -97,26 +98,38 @@ class Cice(Model):
                 input_path = path
             else:
                 if path != input_path:
-                    print('payu: error: Grid file path in {nmlfile} '
-                          '({path}) does not match input path '
-                          '({inputpath})'.format(
-                            nmlfile=self.ice_nml_fname,
-                            path=path,
-                            inputpath=input_path))
-                    sys.exit(1)
+                    raise errors.PayuError(
+                        f'''
+                        payu: error: Grid file path in {self.ice_nml_fname} 
+                        ({path}) does not match input path 
+                        ({input_path})
+                        ''')
+                    # print('payu: error: Grid file path in {nmlfile} '
+                    #       '({path}) does not match input path '
+                    #       '({inputpath})'.format(
+                    #         nmlfile=self.ice_nml_fname,
+                    #         path=path,
+                    #         inputpath=input_path))
+                    # sys.exit(1)
 
         # Check for consistency in input paths due to cice having the same
         # information in multiple locations
         path, _ = os.path.split(self.ice_in['grid_nml'].get('kmt_file'))
         path = os.path.normpath(path)
         if path != input_path:
-            print('payu: error: '
-                  'kmt file path in {nmlfile} ({path}) does not match '
-                  'input path ({inputpath})'.format(
-                    nmlfile=self.ice_nml_fname,
-                    path=path,
-                    inputpath=input_path))
-            sys.exit(1)
+            raise errors.PayuError(
+                f'''
+                payu: error: 
+                kmt file path in {self.ice_nml_fname} ({path}) does not match 
+                input path ({input_path})
+                ''')
+            # print('payu: error: '
+            #       'kmt file path in {nmlfile} ({path}) does not match '
+            #       'input path ({inputpath})'.format(
+            #         nmlfile=self.ice_nml_fname,
+            #         path=path,
+            #         inputpath=input_path))
+            # sys.exit(1)
 
         if not os.path.isabs(input_path):
             input_path = os.path.join(self.work_path, input_path)
@@ -230,9 +243,15 @@ class Cice(Model):
             # If we cannot find a prior namelist, then we cannot determine
             # the start time and must abort the run.
             if not os.path.exists(prior_nml_path):
-                print('payu: error: Cannot find prior namelist {nml}'.format(
-                    nml=self.ice_nml_fname))
-                sys.exit(errno.ENOENT)
+                raise errors.PayuFileNotFoundError(
+                    f'''
+                    payu: error: Cannot find prior namelist {self.ice_nml_fname}
+                    '''
+                )
+
+                # print('payu: error: Cannot find prior namelist {nml}'.format(
+                #     nml=self.ice_nml_fname))
+                # sys.exit(errno.ENOENT)
 
             prior_setup_nml = f90nml.read(prior_nml_path)['setup_nml']
 

--- a/payu/models/cice.py
+++ b/payu/models/cice.py
@@ -99,11 +99,9 @@ class Cice(Model):
             else:
                 if path != input_path:
                     raise errors.PayuError(
-                        f'''
-                        payu: error: Grid file path in {self.ice_nml_fname} 
-                        ({path}) does not match input path 
-                        ({input_path})
-                        ''')
+                        f'payu: error: Grid file path in {self.ice_nml_fname} '
+                        f'({path}) does not match input path '
+                        f'({input_path})')
                     # print('payu: error: Grid file path in {nmlfile} '
                     #       '({path}) does not match input path '
                     #       '({inputpath})'.format(
@@ -118,11 +116,9 @@ class Cice(Model):
         path = os.path.normpath(path)
         if path != input_path:
             raise errors.PayuError(
-                f'''
-                payu: error: 
-                kmt file path in {self.ice_nml_fname} ({path}) does not match 
-                input path ({input_path})
-                ''')
+                'payu: error: '
+                f'kmt file path in {self.ice_nml_fname} ({path}) does not match '
+                f'input path ({input_path})')
             # print('payu: error: '
             #       'kmt file path in {nmlfile} ({path}) does not match '
             #       'input path ({inputpath})'.format(
@@ -244,9 +240,7 @@ class Cice(Model):
             # the start time and must abort the run.
             if not os.path.exists(prior_nml_path):
                 raise errors.PayuFileNotFoundError(
-                    f'''
-                    payu: error: Cannot find prior namelist {self.ice_nml_fname}
-                    '''
+                    f'payu: error: Cannot find prior namelist {self.ice_nml_fname}'
                 )
 
                 # print('payu: error: Cannot find prior namelist {nml}'.format(

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -22,6 +22,7 @@ import warnings
 from payu.models.model import Model
 from payu import envmod
 from payu.fsops import required_libs
+import payu.errors as errors
 
 # There is a limit on the number of command line arguments in a forked
 # MPI process. This applies only to mppnccombine-fast. The limit is higher
@@ -253,11 +254,22 @@ def fms_collate(model):
     if any(rc is not None for rc in codes):
         for p, rc, op in zip(count(), codes, outputs):
             if rc is not None:
-                print('payu: error: Thread {p} crashed with error code '
-                      '{rc}.'.format(p=p, rc=rc), file=sys.stderr)
-                print(' Error message:', file=sys.stderr)
-                print(op.decode(), file=sys.stderr)
-        sys.exit(-1)
+                error_msg = op.decode()
+                raise errors.PayuRunError(
+                    f'''
+                    payu: error: Thread {p} crashed with error code 
+                    {rc}
+
+                    Error message: 
+                    {error_msg}
+                    '''
+                )
+
+                # print('payu: error: Thread {p} crashed with error code '
+                #       '{rc}.'.format(p=p, rc=rc), file=sys.stderr)
+                # print(' Error message:', file=sys.stderr)
+                # print(op.decode(), file=sys.stderr)
+        # sys.exit(-1)
 
 
 class Fms(Model):

--- a/payu/models/fms.py
+++ b/payu/models/fms.py
@@ -329,11 +329,26 @@ def fms_collate(model):
     if any(rc is not None for rc in codes):
         for p, rc, op in zip(count(), codes, outputs):
             if rc is not None:
+<<<<<<< HEAD
                 print('payu: error: Thread {p} crashed with error code '
                       '{rc}.'.format(p=p, rc=rc), file=sys.stderr)
                 print(' Error message:', file=sys.stderr)
                 print(op.decode(), file=sys.stderr)
         sys.exit(-1)
+=======
+                error_msg = op.decode()
+                raise errors.PayuRunError(
+                    f'payu: error: Thread {p} crashed with error code '
+                    f'{rc}\n'
+                    f'Error message: {error_msg}'
+                )
+
+                # print('payu: error: Thread {p} crashed with error code '
+                #       '{rc}.'.format(p=p, rc=rc), file=sys.stderr)
+                # print(' Error message:', file=sys.stderr)
+                # print(op.decode(), file=sys.stderr)
+        # sys.exit(-1)
+>>>>>>> f844ed7 (Fixed fstrings as per Q suggestions)
 
     # Get full hash for collated files and write collate mapping into job file
     mapping_collate_dict = restart_mapping_log(uncollate_hashes_dict)

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -21,6 +21,7 @@ import yaml
 
 # Local
 from payu.models.model import Model
+import payu.errors as errors 
 
 
 class Mitgcm(Model):
@@ -81,8 +82,11 @@ class Mitgcm(Model):
             try:
                 # NOTE: Use the most recent, in case of multiple restarts
                 n_iter0 = max([int(f.split('.')[1]) for f in core_restarts])
-            except ValueError:
-                sys.exit("payu: error: no restart files found.")
+            except ValueError as e:
+                raise errors.PayuFileNotFoundError(
+                    'payu: error: no restart files found') from e
+                    
+                # sys.exit("payu: error: no restart files found.")
         else:
             n_iter0 = 0
 

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -160,11 +160,15 @@ class Mitgcm(Model):
                 n_iter0 = 0
 
             if n_iter0 + n_timesteps == n_iter0_previous:
-                mesg = ('payu : error: Timestep changed to {dt}. '
-                        'Timestep at end identical to previous pickups: '
-                        '{niter}\nThis would overwrite previous '
-                        'pickups'.format(dt=dt, niter=(n_iter0 + n_timesteps)))
-                sys.exit(mesg)
+                niter = n_iter0 + n_timesteps
+                msg = (
+                    f'''
+                    payu : error: Timestep changed to {dt}. 
+                    Timestep at end identical to previous pickups: {niter}
+                    This would overwrite previous pickups
+                    ''')
+                raise errors.PayuRunError(msg)
+                # sys.exit(mesg)
 
         t_end = t_start + dt * n_timesteps
         pchkpt_freq = t_end - t_start
@@ -178,10 +182,15 @@ class Mitgcm(Model):
         print('  end - start:     {}'.format(pchkpt_freq))
         print('  dt * ntimesteps: {}'.format(dt * n_timesteps))
         if pchkpt_freq != dt * n_timesteps:
-            print('payu : error : time inconsistencies, '
-                  'pchkptfreq ({}) != experiment length ({})'
-                  ''.format(pchkpt_freq, dt * n_timesteps))
-            sys.exit(1)
+            raise errors.PayuRunError(
+                f'''
+                payu: error: time inconsistences, 
+                pchkptfreq ({pchkpt_freq}) != experiment length ({dt * n_timesteps})
+                ''')
+            # print('payu : error : time inconsistencies, '
+            #       'pchkptfreq ({}) != experiment length ({})'
+            #       ''.format(pchkpt_freq, dt * n_timesteps))
+            # sys.exit(1)
 
         data_nml['parm03']['startTime'] = t_start
         data_nml['parm03']['niter0'] = n_iter0

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -164,11 +164,9 @@ class Mitgcm(Model):
             if n_iter0 + n_timesteps == n_iter0_previous:
                 niter = n_iter0 + n_timesteps
                 msg = (
-                    f'''
-                    payu : error: Timestep changed to {dt}. 
-                    Timestep at end identical to previous pickups: {niter}
-                    This would overwrite previous pickups
-                    ''')
+                    f'payu : error: Timestep changed to {dt}. '
+                    f'Timestep at end identical to previous pickups: {niter}'
+                    'This would overwrite previous pickups')
                 raise errors.PayuRunError(msg)
                 # sys.exit(mesg)
 
@@ -185,10 +183,8 @@ class Mitgcm(Model):
         print('  dt * ntimesteps: {}'.format(dt * n_timesteps))
         if pchkpt_freq != dt * n_timesteps:
             raise errors.PayuRunError(
-                f'''
-                payu: error: time inconsistences, 
-                pchkptfreq ({pchkpt_freq}) != experiment length ({dt * n_timesteps})
-                ''')
+                'payu: error: time inconsistences, '
+                f'pchkptfreq ({pchkpt_freq}) != experiment length ({dt * n_timesteps})')
             # print('payu : error : time inconsistencies, '
             #       'pchkptfreq ({}) != experiment length ({})'
             #       ''.format(pchkpt_freq, dt * n_timesteps))

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -17,7 +17,9 @@ import subprocess as sp
 
 # Extensions
 import f90nml
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 # Local
 from payu.models.model import Model
@@ -135,7 +137,7 @@ class Mitgcm(Model):
             # Look for a restart file from a previous run
             if os.path.exists(restart_calendar_path):
                 with open(restart_calendar_path, 'r') as restart_file:
-                    restart_info = yaml.safe_load(restart_file)
+                    restart_info = yaml.load(restart_file)
                 t_start = float(restart_info['endtime'])
             else:
                 # Use same logic as MITgcm and assume
@@ -244,7 +246,7 @@ class Mitgcm(Model):
         with open(os.path.join(self.restart_path,
                   self.restart_calendar_file), 'w') as restart_file:
             restart = {'endtime': data_nml['parm03']['endTime']}
-            restart_file.write(yaml.dump(restart, default_flow_style=False))
+            yaml.dump(restart, restart_file)
 
         # Remove symbolic links to input or pickup files:
         for f in os.listdir(self.work_path):

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -12,6 +12,7 @@ import subprocess as sp
 
 from payu import envmod
 from payu.fsops import required_libs
+import payu.errors as errors
 
 class Model(object):
     """Abstract model class."""
@@ -139,8 +140,14 @@ class Model(object):
 
                     self.input_paths.append(rel_path)
                 else:
-                    sys.exit('payu: error: Input directory {0} not found; '
-                             'aborting.'.format(rel_path))
+                    raise errors.PayuFileNotFoundError(
+                        f'''
+                        payu: error: Input directory {rel_path} not found;
+                        aborting.
+                        '''
+                    )
+                    # sys.exit('payu: error: Input directory {0} not found; '
+                    #          'aborting.'.format(rel_path))
 
     def set_model_output_paths(self):
 

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -141,11 +141,8 @@ class Model(object):
                     self.input_paths.append(rel_path)
                 else:
                     raise errors.PayuFileNotFoundError(
-                        f'''
-                        payu: error: Input directory {rel_path} not found;
-                        aborting.
-                        '''
-                    )
+                        f'payu: error: Input directory {rel_path} not found; '
+                        'aborting.')
                     # sys.exit('payu: error: Input directory {0} not found; '
                     #          'aborting.'.format(rel_path))
 

--- a/payu/models/staged_cable.py
+++ b/payu/models/staged_cable.py
@@ -14,7 +14,8 @@ import itertools
 
 # Extensions
 import f90nml
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
 
 # Local
 from payu.models.model import Model
@@ -70,7 +71,7 @@ class StagedCable(Model):
 
         # Read the stage_config.yaml file
         with open('stage_config.yaml', 'r') as stage_conf_f:
-            self.stage_config = yaml.safe_load(stage_conf_f)
+            self.stage_config = yaml.load(stage_conf_f)
 
         # On the first run, we need to read the 'stage_config.yaml' file.
         cable_stages = self._prepare_configuration()
@@ -85,7 +86,7 @@ class StagedCable(Model):
     def _read_configuration_log(self):
         """Read the existing configuration log."""
         with open('configuration_log.yaml') as conf_log_file:
-            self.configuration_log = yaml.safe_load(conf_log_file)
+            self.configuration_log = yaml.load(conf_log_file)
 
     def _prepare_configuration(self):
         """Prepare the stages in the CABLE configuration."""

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -18,7 +18,9 @@ import string
 
 # Extensions
 import f90nml
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 # Local
 from payu.fsops import make_symlink
@@ -86,8 +88,7 @@ class UnifiedModel(Model):
         # Save model time to restart next run
         with open(os.path.join(self.restart_path,
                   self.restart_calendar_file), 'w') as restart_file:
-            restart_file.write(yaml.dump({'end_date': end_date},
-                               default_flow_style=False))
+            yaml.dump({'end_date': end_date}, restart_file)
 
         end_date = date_to_um_dump_date(end_date)
 
@@ -131,7 +132,7 @@ class UnifiedModel(Model):
         # Set up environment variables needed to run UM.
         um_env_path = os.path.join(self.control_path, 'um_env.yaml')
         with open(um_env_path, 'r') as um_env_yaml:
-            um_env_vars = yaml.safe_load(um_env_yaml)
+            um_env_vars = yaml.load(um_env_yaml)
 
 
         # Stage the UM restart file.
@@ -219,7 +220,7 @@ class UnifiedModel(Model):
             )
 
         with open(restart_calendar_path, 'r') as calendar_file:
-            date_info = yaml.safe_load(calendar_file)
+            date_info = yaml.load(calendar_file)
 
         restart_date = date_info['end_date']
         if not isinstance(restart_date, datetime.date):

--- a/payu/profilers/oss.py
+++ b/payu/profilers/oss.py
@@ -3,6 +3,7 @@ import sys
 
 from payu import envmod
 from payu.profilers.profiler import Profiler
+import payu.errors as errors
 
 
 class OpenSpeedShop(Profiler):
@@ -20,17 +21,24 @@ class OpenSpeedShop(Profiler):
         if oss:
             oss_runcmd = oss.get('runcmd')
             if not oss_runcmd:
-                print('payu: error: OpenSpeedShop requires an executable.')
-                sys.exit(1)
+                raise errors.PayuError(
+                    'payu: error: OpenSpeedShop requires an executable')
+                # print('payu: error: OpenSpeedShop requires an executable.')
+                # sys.exit(1)
 
             cmd = '{0} "{1}"'.format(oss_runcmd, cmd)
 
             if oss_runcmd.startswith('osshwc'):
                 oss_hwc = oss.get('hwc')
                 if not oss_hwc:
-                    print('payu: error: This OSS command requires hardware '
-                          'counters.')
-                    sys.exit(1)
+                    raise errors.PayuError(
+                        '''
+                        payu: error: This OSS command required hardware 
+                        counters.
+                        ''')
+                    # print('payu: error: This OSS command requires hardware '
+                    #       'counters.')
+                    # sys.exit(1)
                 else:
                     cmd = ' '.join([cmd, oss_hwc])
 

--- a/payu/profilers/oss.py
+++ b/payu/profilers/oss.py
@@ -32,10 +32,7 @@ class OpenSpeedShop(Profiler):
                 oss_hwc = oss.get('hwc')
                 if not oss_hwc:
                     raise errors.PayuError(
-                        '''
-                        payu: error: This OSS command required hardware 
-                        counters.
-                        ''')
+                        'payu: error: This OSS command required hardware counters.')
                     # print('payu: error: This OSS command requires hardware '
                     #       'counters.')
                     # sys.exit(1)

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -19,6 +19,7 @@ import requests
 
 # Local
 from payu.fsops import DEFAULT_CONFIG_FNAME
+import payu.errors as errors
 
 
 # Compatibility
@@ -137,10 +138,16 @@ class Runlog(object):
                                     ssh_key)
 
         if not os.path.isfile(ssh_key_path):
-            print('payu: error: Github SSH key {key} not found.'
-                  ''.format(key=ssh_key_path))
-            print('payu: error: Run `payu ghsetup` to generate a new key.')
-            sys.exit(-1)
+            raise errors.PayuGitError(
+                f'''
+                payu: error: GitHub SSH Key {ssh_key_path} not found.
+                payu: error: Run `payu ghsetup` to generate a new key.
+                ''')
+
+            # print('payu: error: Github SSH key {key} not found.'
+            #       ''.format(key=ssh_key_path))
+            # print('payu: error: Run `payu ghsetup` to generate a new key.')
+            # sys.exit(-1)
 
         cmd = ('ssh-agent bash -c "ssh-add {key}; git push --all payu"'
                ''.format(key=ssh_key_path))
@@ -180,8 +187,9 @@ class Runlog(object):
 
             else:
                 # TODO: Exit with grace
-                print('payu: abort!')
-                sys.exit(-1)
+                raise errors.PayuGitError('payu: error: abort!')
+                # print('payu: abort!')
+                # sys.exit(-1)
 
             repo_query_url = os.path.join(github_api_url, 'orgs', org_name,
                                           'repos')
@@ -240,11 +248,20 @@ class Runlog(object):
                    ''.format(name=remote_name, url=remote_url))
             subprocess.check_call(shlex.split(cmd), cwd=self.expt.control_path)
         elif git_remotes[remote_name] != remote_url:
-            print('payu: error: Existing remote URL does not match '
-                  'the proposed URL.')
-            print('payu: error: To delete the old remote, type '
-                  '`git remote rm {name}`.'.format(name=remote_name))
-            sys.exit(-1)
+            raise errors.PayuGitError(
+                f'''
+                payu: error: Existing remote URL does not match 
+                the proposed URL.
+                
+                payu: error: To delete the old remote, type 
+                `git remote rm {remote_name}`
+                ''')
+
+            # print('payu: error: Existing remote URL does not match '
+            #       'the proposed URL.')
+            # print('payu: error: To delete the old remote, type '
+            #       '`git remote rm {name}`.'.format(name=remote_name))
+            # sys.exit(-1)
 
         # 4. Generate a payu-specific SSH key
         default_ssh_key = 'id_rsa_payu_' + expt_name

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -139,10 +139,8 @@ class Runlog(object):
 
         if not os.path.isfile(ssh_key_path):
             raise errors.PayuGitError(
-                f'''
-                payu: error: GitHub SSH Key {ssh_key_path} not found.
-                payu: error: Run `payu ghsetup` to generate a new key.
-                ''')
+                f'payu: error: GitHub SSH Key {ssh_key_path} not found.'
+                'payu: error: Run `payu ghsetup` to generate a new key.')
 
             # print('payu: error: Github SSH key {key} not found.'
             #       ''.format(key=ssh_key_path))
@@ -249,13 +247,11 @@ class Runlog(object):
             subprocess.check_call(shlex.split(cmd), cwd=self.expt.control_path)
         elif git_remotes[remote_name] != remote_url:
             raise errors.PayuGitError(
-                f'''
-                payu: error: Existing remote URL does not match 
-                the proposed URL.
+                'payu: error: Existing remote URL does not match '
+                'the proposed URL.\n\n'
                 
-                payu: error: To delete the old remote, type 
-                `git remote rm {remote_name}`
-                ''')
+                'payu: error: To delete the old remote, \n'
+                f'type `git remote rm {remote_name}`')
 
             # print('payu: error: Existing remote URL does not match '
             #       'the proposed URL.')

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -353,16 +353,6 @@ class PBS(Scheduler):
         storages.update(find_mounts(extra_search_paths, mounts))
         storages.update(find_mounts(get_manifest_paths(), mounts))
 
-        # Add storage flags. Note that these are sorted to get predictable
-        # behaviour for testing
-        pbs_flags_extend = '+'.join(sorted(storages))
-        if pbs_flags_extend:
-            pbs_flags.append("-l storage={}".format(pbs_flags_extend))
-
-        # Set up environment modules here for PBS.
-        envmod.setup()
-        envmod.module('load', 'pbs')
-
         # Check for custom container launcher script environment variable
         launcher_script = os.environ.get('ENV_LAUNCHER_SCRIPT_PATH')
         if (
@@ -373,6 +363,19 @@ class PBS(Scheduler):
             # Prepend the container launcher script to the python command
             # so the python executable is accessible in the container
             python_exe = f'{launcher_script} {python_exe}'
+
+            # Add the container launcher script path to storage flags
+            storages.update(find_mounts(launcher_script, mounts))
+
+        # Add storage flags. Note that these are sorted to get predictable
+        # behaviour for testing
+        pbs_flags_extend = '+'.join(sorted(storages))
+        if pbs_flags_extend:
+            pbs_flags.append("-l storage={}".format(pbs_flags_extend))
+
+        # Set up environment modules here for PBS.
+        envmod.setup()
+        envmod.module('load', 'pbs')
 
         # Construct job submission command
         cmd = 'qsub {flags} -- {python} {script}'.format(

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -24,6 +24,7 @@ import payu.envmod as envmod
 from payu.fsops import check_exe_path, atomic_write_file
 from payu.manifest import Manifest
 from payu.schedulers.scheduler import Scheduler
+import payu.errors as errors
 
 PBSNODE_TIMEOUT = 60
 LOCK_TIMEOUT = 5
@@ -305,8 +306,10 @@ class PBS(Scheduler):
 
         pbs_join = pbs_config.get('join', 'n')
         if pbs_join not in ('oe', 'eo', 'n'):
-            print('payu: error: unknown qsub IO stream join setting.')
-            sys.exit(-1)
+            raise errors.PayuRunError(
+                'payu: error: unknown qsub IO stream join setting.')
+            # print('payu: error: unknown qsub IO stream join setting.')
+            # sys.exit(-1)
         else:
             pbs_flags.append('-j {join}'.format(join=pbs_join))
 
@@ -500,8 +503,10 @@ def pbs_env_init():
                 except ValueError:
                     pass
     except IOError as ec:
-        print('Unable to find PBS_CONF_FILE ... ' + pbs_conf_fpath)
-        sys.exit(1)
+        raise errors.PayuFileNotFoundError(
+            f'Unable to find PBS_CONF_FILE ... {pbs_conf_fpath}') from ec
+        # print('Unable to find PBS_CONF_FILE ... ' + pbs_conf_fpath)
+        # sys.exit(1)
 
 
 def encode_mount(mount):

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -24,6 +24,7 @@ import payu.envmod as envmod
 from payu.fsops import check_exe_path, atomic_write_file
 from payu.manifest import Manifest
 from payu.schedulers.scheduler import Scheduler
+import payu.errors as errors
 
 PBSNODE_TIMEOUT = 60
 LOCK_TIMEOUT = 5
@@ -305,8 +306,10 @@ class PBS(Scheduler):
 
         pbs_join = pbs_config.get('join', 'n')
         if pbs_join not in ('oe', 'eo', 'n'):
-            print('payu: error: unknown qsub IO stream join setting.')
-            sys.exit(-1)
+            raise errors.PayuRunError(
+                'payu: error: unknown qsub IO stream join setting.')
+            # print('payu: error: unknown qsub IO stream join setting.')
+            # sys.exit(-1)
         else:
             pbs_flags.append('-j {join}'.format(join=pbs_join))
 
@@ -504,8 +507,10 @@ def pbs_env_init():
                 except ValueError:
                     pass
     except IOError as ec:
-        print('Unable to find PBS_CONF_FILE ... ' + pbs_conf_fpath)
-        sys.exit(1)
+        raise errors.PayuFileNotFoundError(
+            f'Unable to find PBS_CONF_FILE ... {pbs_conf_fpath}') from ec
+        # print('Unable to find PBS_CONF_FILE ... ' + pbs_conf_fpath)
+        # sys.exit(1)
 
 
 def encode_mount(mount):

--- a/payu/subcommands/clone_cmd.py
+++ b/payu/subcommands/clone_cmd.py
@@ -13,6 +13,7 @@ from prompt_toolkit.completion import PathCompleter
 
 from payu.branch import clone
 import payu.subcommands.args as args
+import payu.errors as errors
 
 accessible_style = questionary.Style([
     ('question', 'bold'),               
@@ -170,8 +171,9 @@ def fetch_branches(url):
         branches = [line.split('\t')[1].replace("refs/heads/", "") for line in result.stdout.splitlines()]
         return branches
     except subprocess.CalledProcessError as e:
-        print(f"Error fetching branches: {e}")
-        sys.exit(1)
+        raise errors.PayuBranchError(f'Error fetching branches: {e}') from e
+        # print(f"Error fetching branches: {e}")
+        # sys.exit(1)
 
 def fetch_tags(url):
     """Fetch all tags from the remote repository."""
@@ -186,8 +188,9 @@ def fetch_tags(url):
         tags = [line.split('\t')[1].replace("refs/tags/", "") for line in result.stdout.splitlines()]
         return tags
     except subprocess.CalledProcessError as e:
-        print(f"Error fetching tags: {e}")
-        sys.exit(1)
+        raise errors.PayuBranchError(f'Error fetching branches: {e}') from e
+        # print(f"Error fetching tags: {e}")
+        # sys.exit(1)
 
 def safe_ask(question_obj):
     """ A helper function to safely ask a question and handle KeyboardInterrupt. """

--- a/payu/subcommands/clone_cmd.py
+++ b/payu/subcommands/clone_cmd.py
@@ -15,6 +15,7 @@ from prompt_toolkit.completion import PathCompleter
 
 from payu.branch import clone
 import payu.subcommands.args as args
+import payu.errors as errors
 
 accessible_style = questionary.Style([
     # Question
@@ -198,8 +199,9 @@ def fetch_branches(url):
         branches = [line.split('\t')[1].replace("refs/heads/", "") for line in result.stdout.splitlines()]
         return branches
     except subprocess.CalledProcessError as e:
-        print(f"Error fetching branches: {e}")
-        sys.exit(1)
+        raise errors.PayuBranchError(f'Error fetching branches: {e}') from e
+        # print(f"Error fetching branches: {e}")
+        # sys.exit(1)
 
 def fetch_tags(url):
     """Fetch all tags from the remote repository."""
@@ -214,8 +216,9 @@ def fetch_tags(url):
         tags = [line.split('\t')[1].replace("refs/tags/", "") for line in result.stdout.splitlines()]
         return tags
     except subprocess.CalledProcessError as e:
-        print(f"Error fetching tags: {e}")
-        sys.exit(1)
+        raise errors.PayuBranchError(f'Error fetching branches: {e}') from e
+        # print(f"Error fetching tags: {e}")
+        # sys.exit(1)
 
 def show_flowchart():
     """Show the flowchart for the clone process."""

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -15,6 +15,7 @@ from payu import fsops
 from payu.manifest import Manifest
 from payu.telemetry import write_queued_job_file, record_run
 from payu.schedulers.pbs import PBS
+import payu.errors as errors
 
 title = 'run'
 parameters = {'description': 'Run the model experiment'}
@@ -168,10 +169,12 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
 
     # Check if the work directory exists, then show warning to the user.
     if os.path.exists(expt.work_path) and not expt.force:
-        logger.error('Work path already exists. Please use `payu sweep` or use `payu run -f`.')
+        raise errors.PayuRunError(
+            'Work path already exists. Please use `payu sweep` or use `payu run -f`.')
+        # logger.error('Work path already exists. Please use `payu sweep` or use `payu run -f`.')
 
         # Return error code.
-        sys.exit(1)
+        # sys.exit(1)
 
     job_id = cli.submit_job('payu-run', pbs_config, pbs_vars)
 

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -15,6 +15,7 @@ from payu import fsops
 from payu.manifest import Manifest
 from payu.telemetry import record_run
 from payu.schedulers.pbs import PBS
+import payu.errors as errors
 
 title = 'run'
 parameters = {'description': 'Run the model experiment'}
@@ -168,10 +169,12 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
 
     # Check if the work directory exists, then show warning to the user.
     if os.path.exists(expt.work_path) and not expt.force:
-        logger.error('Work path already exists. Please use `payu sweep` or use `payu run -f`.')
+        raise errors.PayuRunError(
+            'Work path already exists. Please use `payu sweep` or use `payu run -f`.')
+        # logger.error('Work path already exists. Please use `payu sweep` or use `payu run -f`.')
 
         # Return error code.
-        sys.exit(1)
+        # sys.exit(1)
 
     current_run = init_run if init_run is not None else expt.counter
 

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -14,16 +14,17 @@ from payu import fsops
 title = 'sync'
 parameters = {'description': 'Sync model output to a remote directory'}
 
-arguments = [args.model, args.config, args.laboratory, args.dir_path,
+arguments = [args.model, args.config, args.initial, args.laboratory, args.dir_path,
              args.sync_restarts, args.sync_ignore_last]
 
 
-def runcmd(model_type, config_path, lab_path, dir_path, sync_restarts,
+def runcmd(model_type, config_path, init_run, lab_path, dir_path, sync_restarts,
            sync_ignore_last):
 
     pbs_config = fsops.read_config(config_path)
 
-    pbs_vars = cli.set_env_vars(lab_path=lab_path,
+    pbs_vars = cli.set_env_vars(init_run=init_run,
+                                lab_path=lab_path,
                                 dir_path=dir_path,
                                 sync_restarts=sync_restarts,
                                 sync_ignore_last=sync_ignore_last)
@@ -69,7 +70,8 @@ def runscript():
 
     run_args = parser.parse_args()
 
-    pbs_vars = cli.set_env_vars(lab_path=run_args.lab_path,
+    pbs_vars = cli.set_env_vars(init_run=run_args.init_run,
+                                lab_path=run_args.lab_path,
                                 dir_path=run_args.dir_path,
                                 sync_restarts=run_args.sync_restarts,
                                 sync_ignore_last=run_args.sync_ignore_last)

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -5,17 +5,18 @@
 """
 
 # Standard
-import getpass
+import warnings
 import glob
 import os
 import shutil
 import subprocess
 from ruamel.yaml import YAML
 from pathlib import Path
+import time
 
 
 # Local
-from payu.fsops import list_archive_dirs
+from payu.fsops import list_sorted_archive_dirs
 from payu.metadata import METADATA_FILENAME, UUID_FIELD
 
 DEST_NOT_CONFIGURED_MSG ="""
@@ -42,6 +43,27 @@ class SourcePath():
         self.path = path
         self.is_log_file = is_log_file
 
+def filter_previous_runs(all_dir, prefix):
+    """Given a list of directories of all runs (e.g., ['output001', 'output002']), 
+    filter to only include dir that is less than or equal to current run."""
+    if all_dir == []:
+        return []
+
+    current_run = os.environ.get('PAYU_CURRENT_RUN')
+    if current_run is None:
+        warnings.warn("PAYU_CURRENT_RUN environment variable not set. "
+              "Syncing all runs in archive.")
+        return all_dir
+
+    for i in range(len(all_dir)-1, -1, -1):
+        suffix = all_dir[i].removeprefix(prefix)
+
+        # Only include suffix that is less than or equal to the current run
+        if int(suffix) <= int(current_run):
+            return all_dir[0:i+1]
+
+    # Return empty list if no directories are <= current run
+    return []
 
 class SyncToRemoteArchive():
     """Class used for archiving experiment outputs to a remote directory"""
@@ -62,8 +84,9 @@ class SyncToRemoteArchive():
     def add_outputs_to_sync(self):
         """Add paths of outputs in archive to sync. The last output is
         protected"""
-        outputs = list_archive_dirs(archive_path=self.expt.archive_path,
+        all_outputs = list_sorted_archive_dirs(archive_path=self.expt.archive_path,
                                     dir_type='output')
+        outputs = filter_previous_runs(all_outputs, prefix='output')
         outputs = [os.path.join(self.expt.archive_path, output)
                    for output in outputs]
         if len(outputs) > 0:
@@ -85,8 +108,9 @@ class SyncToRemoteArchive():
             return
 
         # Get sorted list of restarts in archive
-        restarts = list_archive_dirs(archive_path=self.expt.archive_path,
+        all_restarts = list_sorted_archive_dirs(archive_path=self.expt.archive_path,
                                      dir_type='restart')
+        restarts = filter_previous_runs(all_restarts, prefix='restart')
         restarts = [os.path.join(self.expt.archive_path, restart)
                     for restart in restarts]
         if restarts == []:
@@ -220,7 +244,7 @@ class SyncToRemoteArchive():
     def run_cmd(self, source_path):
         """Given an source path, build and run rsync command"""
         cmd = self.build_cmd(source_path)
-        print(cmd)
+        print(f"Running command: {cmd}")
         try:
             subprocess.check_call(cmd, shell=True)
         except subprocess.CalledProcessError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dynamic = ["version"]
 dependencies = [
     "f90nml >=0.16",
     "yamanifest >=0.3.4",
-    "PyYAML",
     "requests",
     "python-dateutil",
     "tenacity >=8.0.0",

--- a/test/common.py
+++ b/test/common.py
@@ -5,7 +5,9 @@ from pathlib import Path
 import re
 import shutil
 
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 # Namespace clash if import setup_cmd.runcmd as setup. For
 # consistency use payu_ prefix for all commands
@@ -94,7 +96,7 @@ def get_manifests(mfdir):
     for mf in ['exe', 'input', 'restart']:
         mfpath = Path(mfdir)/"{}.yaml".format(mf)
         with mfpath.open() as fh:
-            manifests[mfpath.name] = list(yaml.safe_load_all(fh))[1]
+            manifests[mfpath.name] = list(yaml.load_all(fh))[1]
     return manifests
 
 
@@ -138,8 +140,7 @@ def payu_setup(model_type=None,
 
 def write_config(config, path=config_path):
     with path.open('w') as file:
-        file.write(yaml.dump(config, default_flow_style=False,
-                   sort_keys=False))
+        yaml.dump(config, file)
 
 
 def make_exe(exe_name=None):
@@ -220,7 +221,7 @@ def remove_expt_archive_dirs(type='restart'):
 
 def write_metadata(metadata=metadata, path=metadata_path):
     with path.open('w') as file:
-        file.write(yaml.dump(metadata, default_flow_style=False))
+        yaml.dump(metadata, file)
 
 
 def make_all_files():

--- a/test/models/test_mitgcm.py
+++ b/test/models/test_mitgcm.py
@@ -6,7 +6,9 @@ import shutil
 
 import f90nml
 import pytest
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 import payu
 
@@ -192,7 +194,7 @@ def test_setup_restartdir(config, data):
     mitgcm_restart['endtime'] = 12000.
 
     with (restartdir / 'mitgcm.res.yaml').open('w') as file:
-        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+        yaml.dump(mitgcm_restart, file)
 
     manifests = get_manifests(ctrldir/'manifests')
     payu_setup(lab_path=str(labdir))
@@ -254,7 +256,7 @@ def test_setup_change_deltat_no_start_end(config, data, case):
     mitgcm_restart['endtime'] = 12000.
 
     with (restartdir / 'mitgcm.res.yaml').open('w') as file:
-        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+        yaml.dump(mitgcm_restart, file)
 
     if case['ntimesteps'] == 10:
         # This should throw an error, as it would overwrite the existing
@@ -324,7 +326,7 @@ def test_setup_change_deltat_no_ntimesteps(config, data, case):
     mitgcm_restart['endtime'] = 12000.
 
     with (restartdir / 'mitgcm.res.yaml').open('w') as file:
-        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+        yaml.dump(mitgcm_restart, file)
 
     if case['deltat'] == 2400.:
         # This should throw an error, as it would overwrite the existing
@@ -398,7 +400,7 @@ def test_setup_change_deltat(config, data, case):
     mitgcm_restart['endtime'] = 12000.
 
     with (restartdir / 'mitgcm.res.yaml').open('w') as file:
-        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+        yaml.dump(mitgcm_restart, file)
 
     payu_setup(lab_path=str(labdir))
 

--- a/test/models/test_um.py
+++ b/test/models/test_um.py
@@ -5,7 +5,9 @@ import shutil
 import pytest
 import datetime
 import cftime
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 import payu
 
@@ -68,8 +70,7 @@ def make_atmosphere_restart_dir(date,
                                      date.hour,
                                      date.minute,
                                      date.second)
-        um_cal_file.write(yaml.dump({'end_date': date_out},
-                                    default_flow_style=False))
+        yaml.dump({'end_date': date_out}, um_cal_file)
 
 
 @pytest.mark.parametrize(

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -9,10 +9,11 @@ from ruamel.yaml import YAML
 from unittest.mock import patch, MagicMock
 
 from payu.branch import add_restart_to_config, check_restart, switch_symlink
-from payu.branch import checkout_branch, clone, list_branches, PayuBranchError
+from payu.branch import checkout_branch, clone, list_branches
 from payu.metadata import MetadataWarning
 from payu.fsops import read_config
 from payu.subcommands import clone_cmd
+import payu.errors as errors
 
 from test.common import cd
 from test.common import tmpdir, ctrldir, labdir, archive_dir
@@ -676,7 +677,7 @@ def test_clone_startpoint_with_no_new_branch_error():
     # Run Clone
     cloned_repo_path = tmpdir / "clonedRepo"
     with cd(tmpdir):
-        with pytest.raises(PayuBranchError, match=expected_msg):
+        with pytest.raises(errors.PayuBranchError, match=expected_msg):
             clone(
                 repository=str(source_repo_path),
                 directory=cloned_repo_path,

--- a/test/test_fsops.py
+++ b/test/test_fsops.py
@@ -6,10 +6,10 @@ from unittest.mock import patch
 from pathlib import Path
 
 # import payu packages
-from payu.fsops import atomic_write_file, movetree
+from payu.fsops import atomic_write_file, movetree, list_sorted_archive_dirs
 
 # import some common variables for testing
-from .common import tmpdir, testdir, make_all_files
+from .common import tmpdir, testdir, labdir, archive_dir, make_all_files
 
 def scantree(path):
     """
@@ -131,3 +131,36 @@ def test_atomic_write_file_disrupt_dump(monkeypatch):
         content_after_error = json.load(f)
     assert content_after_error == content
 
+
+def test_list_sorted_archive_dirs(setup_test_dir):
+    """Test that list_sorted_archive_dirs correctly lists and sorts directory names."""
+    # Create archive directories - mix of valid/invalid names
+    archive_dirs = [
+        'output000', 'output1001', 'output023', 'output404',
+        'output', 'Output001', 'output44', # not valid output dir
+        'Restart', 'restart2', 'restart', 'restart55', # not valid restart dir
+        'restart102932', 'restart021', 'restart009', 'restart606'
+    ]
+
+    os.makedirs(archive_dir, exist_ok=True)
+    for dir in archive_dirs:
+        (archive_dir / dir).mkdir(parents=True)
+
+    # Add some files
+    (archive_dir / 'restart005').touch()
+    (archive_dir / 'output005').touch()
+
+    # Add a restart symlink
+    archive_dir2 = labdir / 'archive2'
+    source_path = archive_dir2 / 'restart999'
+    source_path.mkdir(parents=True)
+    (archive_dir / 'restart23042').symlink_to(source_path)
+
+    # Test list output dirs and with string archive path
+    outputs = list_sorted_archive_dirs(str(archive_dir), dir_type="output")
+    assert outputs == ['output000', 'output023', 'output404', 'output1001']
+
+    # Test list restarts
+    restarts = list_sorted_archive_dirs(archive_dir, dir_type="restart")
+    assert restarts == ['restart009', 'restart021', 'restart606',
+                        'restart23042', 'restart102932']

--- a/test/test_git_utils.py
+++ b/test/test_git_utils.py
@@ -5,7 +5,8 @@ import git
 import pytest
 
 from payu.git_utils import get_git_repository, GitRepository
-from payu.git_utils import PayuBranchError, PayuGitWarning
+from payu.git_utils import PayuGitWarning
+import payu.errors as errors
 
 from test.common import tmpdir
 
@@ -151,7 +152,7 @@ def test_git_checkout_new_branch_existing():
 
     # Test checkout branch with existing branch
     repo = GitRepository(repo_path)
-    with pytest.raises(PayuBranchError):
+    with pytest.raises(errors.PayuBranchError):
         repo.checkout_branch(str(existing_branch),
                              new_branch=True)
 
@@ -163,7 +164,7 @@ def test_git_checkout_non_existent_branch():
 
     # Test checkout branch with non-existent branch
     repo = GitRepository(repo_path)
-    with pytest.raises(PayuBranchError):
+    with pytest.raises(errors.PayuBranchError):
         repo.checkout_branch("Gibberish")
 
 
@@ -181,7 +182,7 @@ def test_git_checkout_staged_changes():
 
     # Test checkout raises error with staged changes
     repo.repo.index.add([file_path])
-    with pytest.raises(PayuBranchError):
+    with pytest.raises(errors.PayuBranchError):
         repo.checkout_branch(new_branch=True, branch_name="NewBranch2")
 
 

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pdb
 import pytest
 import shutil
-import yaml
 
 import payu
 import payu.models.test

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -165,42 +165,6 @@ def test_lib_update_if_nci_module_not_required():
     assert (result == '')
 
 
-def test_list_archive_dirs():
-    # Create archive directories - mix of valid/invalid names
-    archive_dirs = [
-        'output000', 'output1001', 'output023',
-        'output', 'Output001', 'output1',
-        'Restart', 'restart2', 'restart',
-        'restart102932', 'restart021', 'restart001',
-    ]
-    tmp_archive = tmpdir / 'test_archive'
-    for dir in archive_dirs:
-        (tmp_archive / dir).mkdir(parents=True)
-
-    # Add some files
-    (tmp_archive / 'restart005').touch()
-    (tmp_archive / 'output005').touch()
-
-    # Add a restart symlink
-    tmp_archive_2 = tmpdir / 'test_archive_2'
-    source_path = tmp_archive_2 / 'restart999'
-    source_path.mkdir(parents=True)
-    (tmp_archive / 'restart23042').symlink_to(source_path)
-
-    # Test list output dirs and with string archive path
-    outputs = payu.fsops.list_archive_dirs(str(tmp_archive), dir_type="output")
-    assert outputs == ['output000', 'output023', 'output1001']
-
-    # Test list restarts
-    restarts = payu.fsops.list_archive_dirs(tmp_archive, dir_type="restart")
-    assert restarts == ['restart001', 'restart021',
-                        'restart23042', 'restart102932']
-
-    # Clean up test archive
-    shutil.rmtree(tmp_archive)
-    shutil.rmtree(tmp_archive_2)
-
-
 def test_env_with_python_path_is_first():
     """Test that python directory is at the front of PATH env var"""
     env = payu.fsops.env_with_python_path()
@@ -362,7 +326,7 @@ def test_needs_shell(command, expected):
     assert payu.fsops.needs_subprocess_shell(command) == expected
 
 
-def test_read_config_yaml_duplicate_key():
+def test_read_config_yaml_duplicate_key(setup_test_dir):
     """The PyYAML library is used for reading config.yaml, but use ruamel yaml
     is used in when modifying config.yaml as part of payu checkout
     (ruamel is used to preserve comments and multi-line strings).

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -15,6 +15,7 @@ import payu.laboratory
 import payu.envmod
 
 from .common import tmpdir, cd
+from payu.fsops import duplicate_key_warning
 
 
 sys.path.insert(1, '../')
@@ -327,12 +328,7 @@ def test_needs_shell(command, expected):
 
 
 def test_read_config_yaml_duplicate_key(setup_test_dir):
-    """The PyYAML library is used for reading config.yaml, but use ruamel yaml
-    is used in when modifying config.yaml as part of payu checkout
-    (ruamel is used to preserve comments and multi-line strings).
-    This led to bug #441, where pyyaml allowed duplicate keys but
-    ruamel.library raises an error
-    """
+    """ Test that a warning is raised when a duplicate key is found """
     # Create a yaml file with a duplicate key
     config_content = """
 pbs_flags: value1
@@ -343,10 +339,9 @@ pbs_flags: value2
         file.write(config_content)
 
     # Test read config passes without an error but a warning is raised
-    warn_msg = "Duplicate key found in config.yaml: key 'pbs_flags' with "
-    warn_msg += "value 'value2'. This overwrites the original value: 'value1'"
-    with pytest.warns(UserWarning, match=warn_msg):
-        payu.fsops.read_config(config_path)
+    with pytest.warns(UserWarning, match=duplicate_key_warning):
+        config = payu.fsops.read_config(config_path)
+        assert config['pbs_flags'] == 'value1'  # Check that the first value is used
 
     restart_path = tmpdir / "restarts"
 

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 
 import pdb
 import pytest
-import yaml
 
 import payu
 

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -21,18 +21,15 @@ config = copy.deepcopy(config_orig)
 
 # Enable metadata
 config.pop('metadata')
-pytestmark = pytest.mark.filterwarnings(
-    "ignore::payu.git_utils.PayuGitWarning")
 
 @pytest.fixture(autouse=True)
-def setup_module(setup_test_dir, empty_workdir):
+def setup_module(setup_test_dir):
     """
     Put any test-wide setup code in here, e.g. creating test files.
     Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     make_all_files()
     write_metadata()
-    write_config(config)
 
     # Create 5 restarts and outputs
     for dir_type in ['restart', 'output']:
@@ -40,11 +37,17 @@ def setup_module(setup_test_dir, empty_workdir):
             path = make_expt_archive_dir(type=dir_type, index=i)
             make_random_file(os.path.join(path, f'test-{dir_type}00{i}-file'))
 
+    yield
 
 
-def setup_sync(additional_config, add_envt_vars=None):
+def setup_sync(additional_config, monkeypatch, add_envt_vars=None):
     """Given additional configuration and envt_vars, return initialised
     class used to build/run rsync commands"""
+
+    # Clean up all environment variables that may affect sync
+    for var in ['PAYU_CURRENT_RUN', 'PAYU_SYNC_IGNORE_LAST', 'PAYU_SYNC_RESTARTS']:
+        monkeypatch.delenv(var, raising=False)
+
     # Set experiment config
     test_config = copy.deepcopy(config)
     test_config.update(additional_config)
@@ -58,7 +61,7 @@ def setup_sync(additional_config, add_envt_vars=None):
     # Set enviroment vars
     if add_envt_vars is not None:
         for var, value in add_envt_vars.items():
-            os.environ[var] = value
+            monkeypatch.setenv(var, value)
 
     return payu.sync.SyncToRemoteArchive(experiment)
 
@@ -83,6 +86,35 @@ def assert_expected_archive_paths(source_paths,
     assert protected_dirs == expected_protected_dirs
 
 
+def test_filter_previous_runs(monkeypatch):
+    """
+    Test filter_previous_runs pick up runs <= the current run.
+    filter_previous_runs expects to have sorted directories from lowest to highest as inputs.
+    """
+    # Set current run to 3
+    monkeypatch.setenv("PAYU_CURRENT_RUN", "999")
+
+    all_dirs = ['output997', 'output998', 'output999', 'output1001', 'output1002']
+    prefix = 'output'
+    
+    expected = ['output997', 'output998', 'output999']
+    result = payu.sync.filter_previous_runs(all_dirs, prefix=prefix)
+    
+    assert result == expected
+
+
+def test_filter_previous_runs_no_current_run(monkeypatch):
+    """Test filter_previous_runs returns all dirs when PAYU_CURRENT_RUN is not set."""
+    
+    monkeypatch.delenv("PAYU_CURRENT_RUN", raising=False)
+
+    all_dirs = ['output997', 'output998', 'output999', 'output1001', 'output1002']
+    prefix = 'output'
+
+    result = payu.sync.filter_previous_runs(all_dirs, prefix=prefix)
+    assert result == all_dirs
+
+
 @pytest.mark.parametrize(
     "envt_vars, expected_outputs, expected_protected_outputs",
     [
@@ -95,9 +127,9 @@ def assert_expected_archive_paths(source_paths,
             ['output000', 'output001', 'output002', 'output003'], []
         ),
     ])
-def test_add_outputs_to_sync(envt_vars, expected_outputs,
+def test_add_outputs_to_sync(monkeypatch, envt_vars, expected_outputs,
                              expected_protected_outputs):
-    sync = setup_sync(additional_config={}, add_envt_vars=envt_vars)
+    sync = setup_sync(additional_config={}, monkeypatch=monkeypatch, add_envt_vars=envt_vars)
 
     # Test function
     sync.add_outputs_to_sync()
@@ -106,10 +138,6 @@ def test_add_outputs_to_sync(envt_vars, expected_outputs,
     assert_expected_archive_paths(sync.source_paths,
                                   expected_outputs,
                                   expected_protected_outputs)
-
-    # Tidy up test - Remove any added enviroment variables
-    for envt_var in envt_vars.keys():
-        del os.environ[envt_var]
 
 
 @pytest.mark.parametrize(
@@ -148,9 +176,9 @@ def test_add_outputs_to_sync(envt_vars, expected_outputs,
             ['restart003', 'restart004']
         ),
     ])
-def test_restarts_to_sync(add_config, envt_vars,
+def test_restarts_to_sync(monkeypatch,add_config, envt_vars,
                           expected_restarts, expected_protected_restarts):
-    sync = setup_sync(add_config, envt_vars)
+    sync = setup_sync(add_config, monkeypatch, envt_vars)
 
     # Test function
     sync.add_restarts_to_sync()
@@ -159,10 +187,6 @@ def test_restarts_to_sync(add_config, envt_vars,
     assert_expected_archive_paths(sync.source_paths,
                                   expected_restarts,
                                   expected_protected_restarts)
-
-    # Tidy up test - Remove any added enviroment variables
-    for envt_var in envt_vars.keys():
-        del os.environ[envt_var]
 
 
 @pytest.mark.parametrize(
@@ -190,20 +214,21 @@ def test_restarts_to_sync(add_config, envt_vars,
     ]
 )
 
-def test_set_destination_path(config_sync_path, expected_sync_dest):
+def test_set_destination_path(monkeypatch, config_sync_path, expected_sync_dest):
     """Test setting destination path with different combinations of
     base_path, path, url and user"""
     additional_config = config_sync_path
-    sync = setup_sync(additional_config=additional_config)
+    sync = setup_sync(additional_config=additional_config, monkeypatch=monkeypatch)
     sync.expt.name = "expt_name"
 
     # Test destination_path
     sync.set_destination_path()
     assert sync.destination_path == expected_sync_dest
 
-def test_set_destination_path_value_error():
+
+def test_set_destination_path_value_error(monkeypatch):
     """Test value error raised when path is not set"""
-    sync = setup_sync(additional_config={})
+    sync = setup_sync(additional_config={}, monkeypatch=monkeypatch)
     with pytest.raises(ValueError, match="payu: error: Sync path is not defined."):
         sync.set_destination_path()
 
@@ -227,8 +252,7 @@ def test_set_destination_path_value_error():
             tmpdir / "diff_sync_dir" / "metadata.yaml")
     ]
 )
-
-def test_check_uuid(existing_metadata, path_for_sync, path_for_metadata):
+def test_check_uuid(monkeypatch, existing_metadata, path_for_sync, path_for_metadata):
     """Test check_uuid pass when UUIDs match, no UUID and no metadata.yaml"""
     # First, make sure the sync dir and metadata.yaml path exist
     path_for_sync.mkdir(parents=True, exist_ok=True)
@@ -242,13 +266,13 @@ def test_check_uuid(existing_metadata, path_for_sync, path_for_metadata):
             "path": str(path_for_sync),
         }
     }
-    sync = setup_sync(additional_config=additional_config)
+    sync = setup_sync(additional_config=additional_config, monkeypatch=monkeypatch)
 
     # Test destination_path
     sync.set_destination_path()
     assert sync.destination_path == str(path_for_sync)
 
-def test_check_uuid_value_error():
+def test_check_uuid_value_error(monkeypatch):
     """Test check_uuid raises ValueError when UUIDs do not match"""
     # First, set up a metadata.yaml with `different-UUID` in the destination sync path
     sync_dir = tmpdir / "sync_dir"
@@ -263,7 +287,7 @@ def test_check_uuid_value_error():
             "path": str(sync_dir),
         }
     }
-    sync = setup_sync(additional_config=additional_config)
+    sync = setup_sync(additional_config=additional_config, monkeypatch=monkeypatch)
 
     # Test check_uuid raises ValueError
     with pytest.raises(ValueError, match="payu: error: Mismatched experiment UUIDs in sync destination."):
@@ -318,15 +342,15 @@ def test_check_uuid_value_error():
             }, ""
         )
     ])
-def test_set_excludes_flags(add_config, expected_excludes):
-    sync = setup_sync(additional_config=add_config)
+def test_set_excludes_flags(monkeypatch, add_config, expected_excludes):
+    sync = setup_sync(additional_config=add_config, monkeypatch=monkeypatch)
 
     # Test setting excludes
     sync.set_excludes_flags()
     assert sync.excludes == expected_excludes
 
 
-def test_sync():
+def test_sync(monkeypatch):
     # Add some logs
     pbs_logs_path = os.path.join(expt_archive_dir, 'pbs_logs')
     os.makedirs(pbs_logs_path)
@@ -359,7 +383,7 @@ def test_sync():
             "runlog": False
         }
     }
-    sync = setup_sync(additional_config)
+    sync = setup_sync(additional_config, monkeypatch, add_envt_vars={'PAYU_CURRENT_RUN': '4'})
 
     # Function to test
     sync.run()
@@ -392,13 +416,14 @@ def test_sync():
 
     # Test sync with remove synced files locally flag
     additional_config['sync']['remove_local_files'] = True
-    sync = setup_sync(additional_config)
+    sync = setup_sync(additional_config, monkeypatch)
     sync.run()
 
     # Check synced files are removed from local archive
     # Except for the protected paths (last output in this case)
     for output in ['output000', 'output001', 'output002', 'output003']:
-        file_path = os.path.join(expt_archive_dir, dir, f'test-{output}-file')
+        file_path = os.path.join(expt_archive_dir, output, f'test-{output}-file')
+        print(f"Checking {file_path} is removed")
         assert not os.path.exists(file_path)
 
     last_output_path = os.path.join(expt_archive_dir, 'output004')
@@ -407,7 +432,7 @@ def test_sync():
 
     # Test sync with remove synced dirs flag as well
     additional_config['sync']['remove_local_dirs'] = True
-    sync = setup_sync(additional_config)
+    sync = setup_sync(additional_config, monkeypatch)
     sync.run()
 
     # Assert synced output dirs removed (except for the last output)


### PR DESCRIPTION
Fixes issue #673. Related to draft PR - https://github.com/payu-org/payu/pull/709. Thanks so much @jo-basevi @Qian-HuiChen for your input on this and my apologies for not being able to create this pr earlier. **This is a draft PR for all the proposed changes, as it is not ready to be merged yet.** 

## **PR Description:** 
Currently, we have `sys.exit()` and `print()` statements for handling errors in payu. As mentioned in the #673 issue description, `sys.exit()` statements are hard to handle as they exit the program straight away. This PR is aiming to introduce a "bubbling up" approach for handling exception, as described in [this article](https://blog.miguelgrinberg.com/post/the-ultimate-guide-to-error-handling-in-python).

## **Key changes:**
- [x] **Centralised Error Hierarchy**: Added `payu/errors.py` which defines base `PayuError` class (for catching user errors) and other error classes are children from this parent class.  

- [x] **Bubbling up exceptions** - Replaced `sys.exit()` calls with `raise` statements. This avoids sudden exit from the program, and allows the exception to "bubble up" all the way to the main exception handler.
- [x] **Testing** - Not sure if this would be useful for testing purposes (very much down to be corrected) - perhaps with this we can write tests that verify specific errors are raised without crashing the whole program.
- [x] **Catch and recover** - For recoverable exceptions, in case we have any, we can specify what to do with exceptions handling, instead of `sys.exit()` calls.
- [x] **Standard vs Custom Python Exceptions** - Very much open to feedback on this. `errors.py` has all the custom Python exceptions, ex. `PayuConfigError`, `PayuGitError` etc. We can route the errors instantly based on the type of exception instead of having just one exception `PayuError` for catching all exceptions. These are intended to be not too specific to avoid overly many subclasses.

## **Questions:** 
1. Currently, a bit unclear if it is better to use `logging` module or print statements for the catch-all exception handler - `try-except block` in `cli.py`. Would appreciate any thoughts on this. I remember Jo said something about this.

2. All the custom exceptions come with `exit_code`. This could be useful to handle outputs based on just these codes, however, not sure if they are that useful in our case. Very happy to remove them otherwise.

## **Notes:** 
> `sys.exit()` statements are commented for now for reference. Would need to remove it before merging. 

> Reference: `gh` CLI

> Since this is a draft PR, @Qian-HuiChen pls feel free to check out to this branch in case that's easier for review, or adding more improvements. 

> @jo-basevi Very happy to create another pull request for the rest of the changes in PR - #709. Was a bit unsure if this PR is already too big.

> Opening up for suggestions. :) 

