### PR TITLE
Use mpi4py.util.pool to check manifests.

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -126,7 +126,10 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     if not is_conda():
         # Setup Python dynamic library link
         lib_paths = sysconfig.get_config_vars('LIBDIR')
-        payu_env_vars['LD_LIBRARY_PATH'] = ':'.join(lib_paths)
+        
+        mpi_lib_path = get_mpi_lib_path()
+        payu_env_vars['LD_LIBRARY_PATH'] = ':'.join(lib_paths) + ':' + mpi_lib_path
+        print(f"Adding MPI library path to LD_LIBRARY_PATH: {mpi_lib_path}")
 
     if 'PYTHONPATH' in os.environ:
         payu_env_vars['PYTHONPATH'] = os.environ['PYTHONPATH']
@@ -206,3 +209,10 @@ def submit_job(script, config, vars=None):
     job_id = result.split()[-1]
 
     return job_id
+
+def get_mpi_lib_path():
+    """load openmpi module to check library paths for mpi4pi pool"""
+    result = subprocess.run("module show openmpi | grep PATH", shell=True, capture_output=True, text=True)
+    output = result.stdout.split()[2]
+    mpi_lib_path = output.replace('/bin', '/lib')
+    return mpi_lib_path #'/apps/openmpi/5.0.8/lib'

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -525,7 +525,7 @@ class Experiment(object):
         # Call the macro-model setup
         if len(self.models) > 1:
             self.model.setup()
-
+        
         self.manifest.check_manifests()
 
         # Copy manifests to work directory so they archived on completion

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -16,6 +16,7 @@ import sys
 import shutil
 import stat
 from pathlib import Path
+import time
 
 from yamanifest.manifest import Manifest as YaManifest
 
@@ -232,6 +233,19 @@ class PayuManifest(YaManifest):
             hashes.append(self.get(filepath, hashfn))
         return hashes
 
+def parallel_calculate_fast(manifest, previous_manifest, reproduce):
+        """
+        Wrapper for calculate_fast function for use with mpi4py Pool
+        """
+        manifest.calculate_fast(previous_manifest)
+
+        if reproduce:
+            manifest.check_reproduce(previous_manifest)
+
+        if (manifest.data != previous_manifest.data
+            or len(manifest) == 0):
+            print("Writing {}".format(manifest.path))
+            manifest.dump()
 
 class Manifest(object):
     """
@@ -328,20 +342,20 @@ class Manifest(object):
 
     def check_manifests(self):
         print("Checking exe, input and restart manifests")
+        task = []
         for mf in self.manifests:
-            # Calculate hashes in manifests
-            self.manifests[mf].calculate_fast(self.previous_manifests[mf])
+            self.manifests[mf].numproc = 1
+            task.append((self.manifests[mf], self.previous_manifests[mf], self.reproduce[mf]))
 
-            if self.reproduce[mf]:
-                # Compare manifest with previous manifest
-                self.manifests[mf].check_reproduce(self.previous_manifests[mf])
-
-        # Update manifests if there's any changes, or create file if empty
-        for mf in self.manifests:
-            if (self.manifests[mf].data != self.previous_manifests[mf].data
-                    or len(self.manifests[mf]) == 0):
-                print("Writing {}".format(self.manifests[mf].path))
-                self.manifests[mf].dump()
+        # Parallelise the calculation of fast hashes with multiprocessing Pool
+        start_time = time.perf_counter()
+        from mpi4py.util.pool import Pool
+        print("Calculating manifests in parallel with mpi4py Pool")
+        with Pool() as pool:
+            result = pool.starmap(parallel_calculate_fast, task)
+        
+        end_time = time.perf_counter()
+        print(f"Manifest check completed in {end_time - start_time:.2f} seconds")
 
     def copy_manifests(self, path):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
     "colorama",
     "filelock",
     "questionary",
-    "prompt_toolkit >=3.0.0"
+    "prompt_toolkit >=3.0.0",
+    "mpi4py",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR uses `mpi4py.util.pool` in `check_manifests` so multiple nodes will be used in calculating md5 hashes. It aims to shorten the time in `payu setup` when manifests files are very large.

Closes #720.