### PR TITLE
Update usage of payu status in doc.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -298,6 +298,14 @@ To monitor the status of running and finished payu run jobs, run::
 
    payu status
 
+To keep updated with the latest status, use `watch`::
+
+   watch -n {refresh_interval} payu status
+
+e.g., to refresh every 30 seconds::
+
+   watch -n 30 payu status
+
 By default, this displays information about the latest run number.
 This includes:
 
@@ -315,6 +323,19 @@ This includes:
    * ``model-run`` - Model is running
 
    * ``archive`` - Model run has finished, and payu is archiving the output
+
+* Total queue time for running or completed jobs. 
+  To update the current queue time for a queuing job, use::
+
+   payu status --update
+
+* Current model time for running experiments or finished model time for completed experiments.
+  This feature is implemented in models: 
+   * ACCESS-OM2
+   * ACCESS-OM3
+   * ACCESS-ESM1.5
+   * ACCESS-ESM1.6
+   * MOM6
 
 * Exit status of the payu run (if available). This is set at the end of a payu
   run so may not reflect the exit status of the scheduler job, e.g., if

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -298,20 +298,16 @@ To monitor the status of running and finished payu run jobs, run::
 
    payu status
 
-To keep updated with payu job status, use ``watch``::
+To refresh the payu status automatically, use ``watch``::
 
-   watch -n {refresh_interval_in_seconds} payu status
+   watch -n ${refresh_interval_sec} payu status
 
-e.g., to refresh every 30 seconds::
+e.g., ``watch -n 30 payu status`` refreshes every 30 seconds. Alternatively, you can use a simple loop::
 
-   watch -n 30 payu status
-
-Alternatively, you can use a simple loop::
-
-   while true; do payu status; sleep {refresh_interval_in_seconds}; done
+   while true; do payu status; sleep ${refresh_interval_sec}; done
 
 This keeps a history of payu status in the terminal and is helpful to track changes.
-Please note that ``payu status``` reads information from job files rather than calling ``qstat`` each time it runs.
+Please note that ``payu status`` reads information from job files rather than calling ``qstat`` each time it runs.
 This allows it to be refreshed frequently with minimal impact on the scheduler.
 By default, this displays information about the latest run number.
 This includes:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -329,8 +329,8 @@ This includes:
 
    payu status --update
 
-* Current model time for running experiments or finished model time for completed experiments.
-  This feature is implemented in models: 
+* Current model time for running experiments or finished model time for completed experiments,
+  e.g., 1953-10-23T04:00:00. This feature is implemented in models: 
    * ACCESS-OM2
    * ACCESS-OM3
    * ACCESS-ESM1.5

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -298,14 +298,21 @@ To monitor the status of running and finished payu run jobs, run::
 
    payu status
 
-To keep updated with the latest status, use `watch`::
+To keep updated with payu job status, use ``watch``::
 
-   watch -n {refresh_interval} payu status
+   watch -n {refresh_interval_in_seconds} payu status
 
 e.g., to refresh every 30 seconds::
 
    watch -n 30 payu status
 
+Alternatively, you can use a simple loop::
+
+   while true; do payu status; sleep {refresh_interval_in_seconds}; done
+
+This keeps a history of payu status in the terminal and is helpful to track changes.
+Please note that ``payu status``` reads information from job files rather than calling ``qstat`` each time it runs.
+This allows it to be refreshed frequently with minimal impact on the scheduler.
 By default, this displays information about the latest run number.
 This includes:
 
@@ -329,8 +336,12 @@ This includes:
 
    payu status --update
 
-* Current model time for running experiments or finished model time for completed experiments,
-  e.g., 1953-10-23T04:00:00. This feature is implemented in models: 
+  Please use ``--update`` with caution, as it calls ``qstat`` each time it runs and 
+  may be considered attacks in quick succession. We recommend a minimal refresh interval of 60 seconds.
+
+
+* Current model time for running experiments or finished model time for completed experiments (e.g., 1953-10-23T04:00:00). 
+  This feature is implemented in models: 
    * ACCESS-OM2
    * ACCESS-OM3
    * ACCESS-ESM1.5


### PR DESCRIPTION
Closes #733.

This PR updates the documentation of `payu status` , including 
- its usage with `watch`
- displayed queue time
- displayed current experiment time.