### PR TITLE
Pytest fixture to create and clean tmp directory in unit test

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,49 @@
+import shutil
+import pytest
+from test.common import cd, tmpdir, ctrldir, labdir, workdir, make_inputs, make_exe, expt_workdir
+
+@pytest.fixture()
+def setup_test_dir():
+    """
+    A fixture that setup the test directories and files.
+    Yield to run the tests, and then clean up when exiting the tests.
+    """
+    try:
+        shutil.rmtree(tmpdir)
+    except FileNotFoundError:
+        pass
+
+    try:
+        tmpdir.mkdir()
+        labdir.mkdir()
+        ctrldir.mkdir()
+        workdir.mkdir()
+        make_inputs()
+        make_exe()
+    except Exception as e:
+        print(e)
+
+    # Run test
+    yield
+
+    # Teardown the tmp directory after tests have run
+    try:
+        shutil.rmtree(tmpdir)
+        print('[Cleanup] removing tmp directory')
+    except Exception as e:
+        print(e)
+
+@pytest.fixture()
+def empty_workdir(setup_test_dir):
+    """
+    A fixture that set up a clean work directory and symlink from
+    the control directory.
+    """
+    expt_workdir.mkdir(parents=True)
+    # Symlink must exist for setup to use correct locations
+    if workdir.exists():
+        shutil.rmtree(workdir)
+    workdir.symlink_to(expt_workdir)
+
+    yield expt_workdir
+    workdir.unlink()

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -17,7 +17,8 @@ MODEL = 'access-om3'
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
     """
-    Put any test-wide setup code in here, e.g. creating test files
+    Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     config = copy.deepcopy(config_orig)
     config['model'] = MODEL

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -14,40 +14,16 @@ from test.common import list_expt_archive_dirs, make_expt_archive_dir, remove_ex
 
 MODEL = 'access-om3'
 
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        workdir.mkdir()
-        # archive_dir.mkdir()
-        make_inputs()
-        make_exe()
-    except Exception as e:
-        print(e)
+    config = copy.deepcopy(config_orig)
+    config['model'] = MODEL
+    write_config(config)
 
 
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
 
 @pytest.fixture
 def cmeps_model(request):
@@ -363,7 +339,6 @@ def test__setup_checks_bad_io_warn(cmeps_model, pio_numiotasks, pio_stride):
     ):
         model._setup_checks()
 
-
 # test auxilary_input directory is copied
 @pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("cmeps_model",[1], indirect=['cmeps_model'])
@@ -434,6 +409,7 @@ def test_get_restart_datetime(cmeps_model_rest_dir, calendar, cmeps_calendar, ex
     parsed_run_dt = expt.model.get_restart_datetime(restart_path)
     assert parsed_run_dt == expected_cftime
 
+
 @pytest.mark.parametrize("cmeps_model",[1], indirect=['cmeps_model'])
 @pytest.mark.parametrize(
     "cmeps_model_rest_dir, calendar, cmeps_calendar, expected_cftime",
@@ -500,6 +476,7 @@ def test_collect_restart_files_mom_no_split(cmeps_model):
     res = model._collect_restart_files(pointer_files)
     assert {os.path.basename(f) for f in res} == set(expected_present)
 
+
 @pytest.mark.parametrize("cmeps_model",[1], indirect=['cmeps_model'])
 def test_collect_restart_files_mom_split(cmeps_model):
 
@@ -548,7 +525,6 @@ def test_collect_restart_files_mom_split(cmeps_model):
 
 @pytest.mark.parametrize("cmeps_model",[1], indirect=['cmeps_model'])
 def test_collect_restart_files_incorrect_parallel(cmeps_model):
-
     model, expt = cmeps_model
     _isolate_create_workdir(model, "incorrect_parallel")
 
@@ -628,7 +604,7 @@ def test_get_cur_expt_time_no_log(cmeps_model):
 @pytest.mark.parametrize("cmeps_model_log", ["This log file does not contain the model date.\n"], indirect = ['cmeps_model_log'])
 def test_get_cur_expt_time_no_date(cmeps_model_log):
     """ Test if get_cur_expt_time raise error if log file does not contain model date. """
-
+    
     model, expt = cmeps_model_log
 
     with pytest.raises(ValueError, match="Key string 'memory_write: model date' not found in"):

--- a/test/models/access-om3/test_runconfig.py
+++ b/test/models/access-om3/test_runconfig.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-import shutil
 
 from test.common import tmpdir
 from payu.models.cesm_cmeps import Runconfig
@@ -72,10 +71,8 @@ def test_runconfig_set_error(runconfig):
         runconfig.set("ALLCOMP_attributes", "DOES_NOT_EXIST", "value")
 
 
-def test_runconfig_set_write_get(runconfig):
+def test_runconfig_set_write_get(runconfig, setup_test_dir):
     """Test updating the values in a nuopc.runconfig file"""
-
-    tmpdir.mkdir()
 
     assert runconfig.get("CLOCK_attributes", "restart_n") == "1"
 
@@ -86,7 +83,3 @@ def test_runconfig_set_write_get(runconfig):
 
     runconfig_updated = Runconfig(runconfig_path_tmp)
     assert runconfig_updated.get("CLOCK_attributes", "restart_n") == "2"
-
-    os.remove(runconfig_path_tmp)
-
-    shutil.rmtree(tmpdir)

--- a/test/models/test_access.py
+++ b/test/models/test_access.py
@@ -31,7 +31,8 @@ SEC_PER_DAY = 24*60*60
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
     """
-    Put any test-wide setup code in here, e.g. creating test files
+    Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     archive_dir.mkdir()
     make_all_files()
@@ -125,8 +126,7 @@ def fake_cice_in(ice_control_directory):
 def restart_dir():
     # Create restart directory for ice timing tests
     restart_path = archive_dir / "restart"
-    # restart_path.mkdir()
-    os.makedirs(restart_path, exist_ok=True)
+    restart_path.mkdir(exist_ok=True)
 
     # Run test
     yield restart_path

--- a/test/models/test_access.py
+++ b/test/models/test_access.py
@@ -28,60 +28,14 @@ INPUT_ICE_FNAME = "input_ice.nml"
 RESTART_DATE_FNAME = "restart_date.nml"
 SEC_PER_DAY = 24*60*60
 
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
+    archive_dir.mkdir()
+    make_all_files()
 
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        archive_dir.mkdir()
-        make_all_files()
-    except Exception as e:
-        print(e)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
-
-
-@pytest.fixture(autouse=True)
-def empty_workdir():
-    """
-    Model setup tests require a clean work directory and symlink from
-    the control directory.
-    """
-    expt_workdir.mkdir(parents=True)
-    # Symlink must exist for setup to use correct locations
-    workdir.symlink_to(expt_workdir)
-
-    yield expt_workdir
-    try:
-        shutil.rmtree(expt_workdir)
-    except FileNotFoundError:
-        pass
-    workdir.unlink()
 
 @pytest.fixture
 def access_1year_config():
@@ -171,7 +125,8 @@ def fake_cice_in(ice_control_directory):
 def restart_dir():
     # Create restart directory for ice timing tests
     restart_path = archive_dir / "restart"
-    restart_path.mkdir()
+    # restart_path.mkdir()
+    os.makedirs(restart_path, exist_ok=True)
 
     # Run test
     yield restart_path
@@ -374,14 +329,6 @@ def test_access_cice_1year_runtimes(
 
 
 @pytest.fixture
-def remove_restart_dirs():
-    """Clear any restart directories created during a test"""
-    yield
-    # Teardown
-    remove_expt_archive_dirs(type="restart")
-
-
-@pytest.fixture
 def two_model_config():
     config = copy.deepcopy(config_orig)
     config["model"] = "access"
@@ -395,12 +342,8 @@ def two_model_config():
     # Run test
     yield
 
-    # Teardown
-    os.remove(config_path)
 
-
-def test_access_get_mom_restart_datetime(two_model_config,
-                                         remove_restart_dirs):
+def test_access_get_mom_restart_datetime(two_model_config):
     """
     Check that the restart datetime is read using the
     the mom submodel by default.
@@ -438,11 +381,8 @@ def um_only_config():
     # Run test
     yield
 
-    # Teardown
-    os.remove(config_path)
 
-
-def test_access_get_um_restart_datetime(um_only_config, remove_restart_dirs):
+def test_access_get_um_restart_datetime(um_only_config):
     """
     Check that the restart datetime can be read when only
     the UM submodel is present.

--- a/test/models/test_access_esm1p6.py
+++ b/test/models/test_access_esm1p6.py
@@ -19,6 +19,7 @@ from test.common import config_path
 def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     archive_dir.mkdir()
     make_all_files()

--- a/test/models/test_access_esm1p6.py
+++ b/test/models/test_access_esm1p6.py
@@ -15,62 +15,13 @@ from test.common import write_config
 from test.common import make_all_files
 from test.common import config_path
 
-verbose = True
-
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        archive_dir.mkdir()
-        make_all_files()
-    except Exception as e:
-        print(e)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
-
-
-@pytest.fixture(autouse=True)
-def empty_workdir():
-    """
-    Model setup tests require a clean work directory and symlink from
-    the control directory.
-    """
-    expt_workdir.mkdir(parents=True)
-    # Symlink must exist for setup to use correct locations
-    workdir.symlink_to(expt_workdir)
-
-    yield expt_workdir
-    try:
-        shutil.rmtree(expt_workdir)
-    except FileNotFoundError:
-        pass
-    workdir.unlink()
+    archive_dir.mkdir()
+    make_all_files()
 
 
 @pytest.fixture
@@ -88,8 +39,6 @@ def esm1p6_um_only_config():
     # Run test
     yield
 
-    # Teardown
-    os.remove(config_path)
 
 
 @pytest.fixture
@@ -110,8 +59,6 @@ def um_only_ctrl_dir():
     # Run test
     yield um_ctrl_dir
 
-    # Teardown
-    shutil.rmtree(um_ctrl_dir)
 
 
 def test_esm1p6_patch_optional_config_files(um_only_ctrl_dir,

--- a/test/models/test_access_om2.py
+++ b/test/models/test_access_om2.py
@@ -11,27 +11,12 @@ from test.common import make_inputs, make_exe
 
 MODEL = 'access-om2'
 
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        workdir.mkdir()
-        # archive_dir.mkdir()
-        make_inputs()
-        make_exe()
-    except Exception as e:
-        print(e)
+    pass
 
 
 def setup_config(ncpu):
@@ -42,10 +27,6 @@ def setup_config(ncpu):
     config['ncpus'] = ncpu
 
     write_config(config)
-
-def teardown_config():
-    # Teardown
-    os.remove(config_path)
 
 def test_get_cur_expt_time():
     """ Test if get_cur_expt_time correctly parses the model date from the log file. """
@@ -65,8 +46,6 @@ def test_get_cur_expt_time():
 
         assert cur_expt_time.isoformat() == "1900-01-31T00:00:00"
 
-    teardown_config()
-    os.remove(log_path)
 
 def test_get_cur_expt_time_no_log():
     """ Test if get_cur_expt_time returns None if log file is missing. """
@@ -83,7 +62,6 @@ def test_get_cur_expt_time_no_log():
         with pytest.raises(FileNotFoundError):
             cur_expt_time = model.get_cur_expt_time()
 
-    teardown_config()
 
 def test_get_cur_expt_time_no_date():
     """ Test if get_cur_expt_time raise an error if log file does not contain model date. """
@@ -102,6 +80,3 @@ def test_get_cur_expt_time_no_date():
         with pytest.raises(ValueError, match=f"Key 'cur_exp-datetime' not found in {log_path}"):
             cur_expt_time = model.get_cur_expt_time()
             assert cur_expt_time is None
-
-    teardown_config()
-    os.remove(log_path)

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -43,43 +43,14 @@ RESTART_NAME = "./RESTART/iced.r"
 ICED_RESTART_NAME = "iced.18510101"
 RESTART_POINTER_NAME = "ice.restart_file"
 
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        expt_archive_dir.mkdir(parents=True)
-        make_exe()
-        write_metadata()
-    except Exception as e:
-        print(e)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print("removing tmp")
-    except Exception as e:
-        print(e)
+    expt_archive_dir.mkdir(parents=True)
+    make_exe()
+    write_metadata()
 
 
 DEFAULT_CONFIG = {
@@ -119,20 +90,18 @@ def config(request):
 
 
 @pytest.fixture(autouse=True)
-def empty_workdir():
+def empty_workdir(setup_test_dir):
     """
     Model setup tests require a clean work directory and symlink from
     the control directory.
     """
     expt_workdir.mkdir(parents=True)
     # Symlink must exist for setup to use correct locations
+    if workdir.exists():
+        shutil.rmtree(workdir)
     workdir.symlink_to(expt_workdir)
 
     yield expt_workdir
-    try:
-        shutil.rmtree(expt_workdir)
-    except FileNotFoundError:
-        pass
     workdir.unlink()
 
 
@@ -207,15 +176,13 @@ def test_setup(config, cice_nml, cice_history_nml):
 
 
 @pytest.fixture
-def prior_restart_dir():
+def prior_restart_dir(setup_test_dir):
     """Create prior restart directory"""
     restart_path = RESTART_PATH
-    os.mkdir(restart_path)
+    os.makedirs(restart_path, exist_ok=True)
 
     yield restart_path
 
-    # Cleanup
-    shutil.rmtree(restart_path)
 
 
 @pytest.fixture(

--- a/test/models/test_cice.py
+++ b/test/models/test_cice.py
@@ -46,7 +46,8 @@ RESTART_POINTER_NAME = "ice.restart_file"
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
     """
-    Put any test-wide setup code in here, e.g. creating test files
+    Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     expt_archive_dir.mkdir(parents=True)
     make_exe()

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -62,33 +62,17 @@ CONFIG_WITH_RESTART = {
     "restart": str(RESTART_PATH)
 }
 
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        expt_archive_dir.mkdir(parents=True)
-        make_exe()
-        write_metadata()
-    except Exception as e:
-        print(e)
-
+    expt_archive_dir.mkdir(parents=True)
+    make_exe()
+    write_metadata()
 
 @pytest.fixture
-def config(request):
+def config(request, setup_test_dir):
     """
     Write a specified dictionary to config.yaml.
     Used to allow writing configs with and without
@@ -102,46 +86,8 @@ def config(request):
     os.remove(config_path)
 
 
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print("removing tmp")
-    except Exception as e:
-        print(e)
-
-
-@pytest.fixture(autouse=True)
-def teardown():
-    # Run test
-    yield
-
-    # Remove any created restart files
-    remove_expt_archive_dirs(type='restart')
-
-
-@pytest.fixture(autouse=True)
-def empty_workdir():
-    """
-    Model setup tests require a clean work directory and symlink from
-    the control directory.
-    """
-    expt_workdir.mkdir(parents=True)
-    # Symlink must exist for setup to use correct locations
-    workdir.symlink_to(expt_workdir)
-
-    yield expt_workdir
-    shutil.rmtree(expt_workdir)
-    workdir.unlink()
-
-
 @pytest.fixture
-def cice_config_files(request):
+def cice_config_files(request, setup_test_dir):
     cice_nml = request.param
 
     with cd(ctrldir):

--- a/test/models/test_cice5.py
+++ b/test/models/test_cice5.py
@@ -65,7 +65,8 @@ CONFIG_WITH_RESTART = {
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
     """
-    Put any test-wide setup code in here, e.g. creating test files
+    Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     expt_archive_dir.mkdir(parents=True)
     make_exe()

--- a/test/models/test_fms.py
+++ b/test/models/test_fms.py
@@ -135,36 +135,13 @@ otherwise.
 """
 MPPNC_FLAGS_MOM5 = MPPNC_FLAGS_UPSTREAM + ["-z"]
 
-def rmtmp():
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-
-def mktmp():
-    tmpdir.mkdir()
-
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
+    pass
 
-    rmtmp()
-    mktmp()
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    rmtmp()
 
 
 def make_tiles(begin, end, prefix='tile'):
@@ -184,86 +161,36 @@ def make_tiles(begin, end, prefix='tile'):
     return files
 
 
-def rm_tiles():
+@pytest.mark.parametrize("begin, end, prefix", [
+    (9900, 9999, 'tile'),
+    (9900, 10100, 'tile'),
+    (0, 99, 'tile'),
+    (999997, 1000010, 'tile')
+])
+def test_get_uncollated_files(begin, end, prefix):
 
-    for f in tmpdir.iterdir():
-        f.unlink()
-
-
-def test_get_uncollated_files():
-
-    files = make_tiles(9900, 9999)
-
-    mncfiles = get_uncollated_files(tmpdir)
-
-    assert len(mncfiles) == len(files)
-    assert all(a == b for a, b in zip(mncfiles, files))
-
-    files = make_tiles(9900, 10100)
+    files = make_tiles(begin, end, prefix)
 
     mncfiles = get_uncollated_files(tmpdir)
 
     assert len(mncfiles) == len(files)
     assert all(a == b for a, b in zip(mncfiles, files))
 
-    rm_tiles()
+@pytest.mark.parametrize("begin, end, prefix", [
+    (9900, 9999, 'tile.res'),
+    (9900, 10100, 'tile.res'),
+    (0, 99, 'tile.res'),
+    (999997, 1000010, 'tile.res')
+])
+def test_get_uncollated_restart_files(begin, end, prefix):
 
-    files = make_tiles(0, 99)
-
-    mncfiles = get_uncollated_files(tmpdir)
-
-    assert len(mncfiles) == len(files)
-    assert all(a == b for a, b in zip(mncfiles, files))
-
-    rm_tiles()
-
-    # Make sure still sorts once over the six-figure zero-padding
-    files = make_tiles(999997, 1000010)
+    files = make_tiles(begin, end, prefix)
 
     mncfiles = get_uncollated_files(tmpdir)
 
     assert len(mncfiles) == len(files)
     assert all(a == b for a, b in zip(mncfiles, files))
 
-
-def test_get_uncollated_restart_files():
-
-    rm_tiles()
-
-    prefix = "tile.res"
-
-    files = make_tiles(9900, 9999, prefix)
-
-    mncfiles = get_uncollated_files(tmpdir)
-
-    assert len(mncfiles) == len(files)
-    assert all(a == b for a, b in zip(mncfiles, files))
-
-    files = make_tiles(9900, 10100, prefix)
-
-    mncfiles = get_uncollated_files(tmpdir)
-
-    assert len(mncfiles) == len(files)
-    assert all(a == b for a, b in zip(mncfiles, files))
-
-    rm_tiles()
-
-    files = make_tiles(0, 99, prefix)
-
-    mncfiles = get_uncollated_files(tmpdir)
-
-    assert len(mncfiles) == len(files)
-    assert all(a == b for a, b in zip(mncfiles, files))
-
-    rm_tiles()
-
-    # Make sure still sorts once over the six-figure zero-padding
-    files = make_tiles(999997, 1000010, prefix)
-
-    mncfiles = get_uncollated_files(tmpdir)
-
-    assert len(mncfiles) == len(files)
-    assert all(a == b for a, b in zip(mncfiles, files))
     
 
 @pytest.mark.parametrize("help_text, expected_flags", [

--- a/test/models/test_mitgcm.py
+++ b/test/models/test_mitgcm.py
@@ -83,6 +83,8 @@ def make_config_files(data):
 
 @pytest.fixture
 def config(setup_test_dir):
+    """Write a config file into the control directory.
+    This will be automatically cleaned up by `setup_test_dir` fixture after tests."""
     config = copy.deepcopy(config_orig)
     config['model'] = 'mitgcm'
     write_config(config)

--- a/test/models/test_mitgcm.py
+++ b/test/models/test_mitgcm.py
@@ -25,7 +25,7 @@ from test.common import make_exe, make_inputs, make_restarts, make_all_files
 verbose = True
 
 # From tutorial_barotropic_gyre
-data = {
+data_orig = {
     "parm01": {
         "viscah": 400.0,
         "f0": 0.0001,
@@ -70,51 +70,27 @@ config = copy.deepcopy(config_orig)
 
 config['model'] = 'mitgcm'
 
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
+    pass
 
-def make_config_files():
+def make_config_files(data):
     """
     Create files required for test model
     """
 
     f90nml.namelist.Namelist(data).write(ctrldir/'data', force=True)
 
-
-def setup_module(module):
-    """
-    Put any test-wide setup code in here, e.g. creating test files
-    """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        make_all_files()
-    except Exception as e:
-        print(e)
-
+@pytest.fixture
+def config(setup_test_dir):
+    config = copy.deepcopy(config_orig)
+    config['model'] = 'mitgcm'
     write_config(config)
+    return config
 
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        # shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
+@pytest.fixture
+def data():
+    return copy.deepcopy(data_orig)
 
 
 def make_pickup_names(istep):
@@ -136,7 +112,7 @@ def test_make_pickup_names():
 # Unfortunate but there you go.
 
 
-def test_init():
+def test_init(config):
 
     # Initialise a payu laboratory
     with cd(ctrldir):
@@ -147,7 +123,7 @@ def test_init():
         assert((labdir / subdir).is_dir())
 
 
-def test_setup():
+def test_setup(config, data):
 
     # Create some input and executable files
     make_inputs()
@@ -156,7 +132,7 @@ def test_setup():
     bindir = labdir / 'bin'
     exe = config['exe']
 
-    make_config_files()
+    make_config_files(data)
 
     # Run setup
     payu_setup(lab_path=str(labdir))
@@ -201,17 +177,21 @@ def test_setup():
     assert(manifests == get_manifests(workdir/'manifests'))
 
 
-def test_setup_restartdir():
+def test_setup_restartdir(config, data):
 
     restartdir = labdir / 'archive' / 'restarts'
 
     # Set a restart directory in config
     config['restart'] = str(restartdir)
     write_config(config)
+    make_config_files(data)
 
     res_fnames = make_pickup_names(10)
 
     make_restarts(res_fnames)
+
+    # Run setup
+    payu_setup(lab_path=str(labdir))
 
     mitgcm_restart = {}
     mitgcm_restart['endtime'] = 12000.
@@ -234,137 +214,204 @@ def test_setup_restartdir():
     assert data_local['parm03']['endtime'] == 24000.
 
 
-def test_setup_change_deltat():
+@pytest.mark.parametrize(
+    "case",
+    [
+        {"deltat": 999,
+        "ntimesteps": 5,
+        "expected": {
+            "nIter0": 0,
+            "deltaT": 999.0,
+            "basetime": 12000.0,
+            "starttime": 12000.0,
+            "endtime": 16995.0,
+            "pickupsuff": "0000000010",},
+        },
+        {"deltat": 999,
+        "ntimesteps": 10,
+        "expected": {},
+        },
+    ],
+)
+def test_setup_change_deltat_no_start_end(config, data, case):
 
-    global data
+    restartdir = labdir / 'archive' / 'restarts'
 
-    # Halve deltat
-    data['parm03']['deltat'] = 600
+    # Set a restart directory in config
+    config['restart'] = str(restartdir)
+    write_config(config)
 
-    make_config_files()
+    # deltaT which is not a divisor. Set ntimesteps instead of
+    # start and end times
+    data['parm03']['deltat'] = case['deltat']
+    data['parm03']['ntimesteps'] = case['ntimesteps']
+
+    make_config_files(data)
+
+    res_fnames = make_pickup_names(10)
+
+    make_restarts(res_fnames)
+
+    # Run setup
+    payu_setup(lab_path=str(labdir))
+
+    mitgcm_restart = {}
+    mitgcm_restart['endtime'] = 12000.
+
+    with (restartdir / 'mitgcm.res.yaml').open('w') as file:
+        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+
+    if case['ntimesteps'] == 10:
+        # This should throw an error, as it would overwrite the existing
+        # pickup files in the work directory, as the nIter is the same
+        # matchstr = '.*not integer multiple.*'
+        matchstr = '.*Timestep at end identical to previous pickups.*'
+        with pytest.raises(SystemExit, match=matchstr) as setup_error:
+            payu_setup(lab_path=str(labdir))
+        assert setup_error.type == SystemExit
+        return
 
     payu_setup(lab_path=str(labdir))
 
     data_local = f90nml.read(workdir/'data')
 
-    # Time step has halved, so nIter0 is doubled
-    assert data_local['parm03']['nIter0'] == 20
-    assert data_local['parm03']['nTimeSteps'] == 10
-    assert data_local['parm03']['deltaT'] == 600.
-    assert data_local['parm03']['starttime'] == 12000.
-    assert data_local['parm03']['endtime'] == 18000.
+    assert data_local['parm03']['nIter0'] == case['expected']['nIter0']
+    assert data_local['parm03']['deltaT'] == case['expected']['deltaT']
+    assert data_local['parm03']['basetime'] == case['expected']['basetime']
+    assert data_local['parm03']['starttime'] == case['expected']['starttime']
+    assert data_local['parm03']['endtime'] == case['expected']['endtime']
+    assert data_local['parm03']['pickupsuff'] == case['expected']['pickupsuff']
 
-    # Double deltaT
-    data['parm03']['deltat'] = 2400.
 
-    make_config_files()
+@pytest.mark.parametrize(
+    "case",
+    [
+        {"deltat": 1200,
+        "expected": {"nIter0": 10,
+                    "deltaT": 1200.0,
+                    "starttime": 12000.0,
+                    "endtime": 24000.0,},
+        },
+        {"deltat": 600,
+        "expected": {"nIter0": 20,
+                    "deltaT": 600.0,
+                    "starttime": 12000.0,
+                    "endtime": 24000.0,},
+        },
+        {"deltat": 2400.0, #should raise error
+        "expected": {"nIter0": None,
+                    "deltaT": None,
+                    "starttime": None,
+                    "endtime": None,},
+        },
+    ],
+)
+def test_setup_change_deltat_no_ntimesteps(config, data, case):
+    restartdir = labdir / 'archive' / 'restarts'
 
-    payu_setup(lab_path=str(labdir))
+    # Set a restart directory in config
+    config['restart'] = str(restartdir)
+    write_config(config)
 
-    data_local = f90nml.read(workdir/'data')
-
-    # Time step has halved, so nIter0 is doubled
-    assert data_local['parm03']['nIter0'] == 5
-    assert data_local['parm03']['nTimeSteps'] == 10
-    assert data_local['parm03']['deltaT'] == 2400.
-    assert data_local['parm03']['starttime'] == 12000.
-    assert data_local['parm03']['endtime'] == 36000.
-
-    # Fractional deltaT
-    data['parm03']['deltat'] = 0.001
-    data['parm03']['ntimesteps'] = 12000000
-
-    make_config_files()
-
-    payu_setup(lab_path=str(labdir))
-
-    data_local = f90nml.read(workdir/'data')
-
-    # Time step has halved, so nIter0 is doubled
-    assert data_local['parm03']['nIter0'] == 12000000
-    assert data_local['parm03']['nTimeSteps'] == 12000000
-    assert data_local['parm03']['deltaT'] == 0.001
-    assert data_local['parm03']['starttime'] == 12000.
-    assert data_local['parm03']['endtime'] == 24000.
-
-    # Use start and end time instead of ntimesteps. Normal
-    # deltaT
-    data['parm03']['deltat'] = 1200.
+    data['parm03']['deltat'] = case['deltat']
     del data['parm03']['ntimesteps']
     data['parm03']['starttime'] = 0.
     data['parm03']['endtime'] = 12000.
 
-    make_config_files()
+    make_config_files(data)
+    res_fnames = make_pickup_names(10)
+    make_restarts(res_fnames)
+
+    # Run setup
+    payu_setup(lab_path=str(labdir))
+
+    mitgcm_restart = {}
+    mitgcm_restart['endtime'] = 12000.
+
+    with (restartdir / 'mitgcm.res.yaml').open('w') as file:
+        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+
+    if case['deltat'] == 2400.:
+        # This should throw an error, as it would overwrite the existing
+        # pickup files in the work directory, as the nIter is the same
+        matchstr = '.*Timestep at end identical to previous pickups.*'
+        with pytest.raises(SystemExit, match=matchstr) as setup_error:
+            payu_setup(lab_path=str(labdir))
+        assert setup_error.type == SystemExit
+        return
 
     payu_setup(lab_path=str(labdir))
 
     data_local = f90nml.read(workdir/'data')
 
-    # Time step normal so nIter0 is 10, but no ntimesteps,
-    # instead startime and endtime have been altered
-    assert data_local['parm03']['nIter0'] == 10
-    assert data_local['parm03']['deltaT'] == 1200.
-    assert data_local['parm03']['starttime'] == 12000.
-    assert data_local['parm03']['endtime'] == 24000.
+    assert data_local['parm03']['nIter0'] == case['expected']['nIter0']
+    assert data_local['parm03']['deltaT'] == case['expected']['deltaT']
+    assert data_local['parm03']['starttime'] == case['expected']['starttime']
+    assert data_local['parm03']['endtime'] == case['expected']['endtime']
 
-    # Halve deltaT
-    data['parm03']['deltat'] = 600
 
-    make_config_files()
+@pytest.mark.parametrize(
+    "case",
+    [
+        {"deltat": 600,
+        "ntimesteps": 10,
+        "expected": {"nIter0": 20,
+                    "nTimeSteps": 10,
+                    "deltaT": 600.0,
+                    "starttime": 12000.0,
+                    "endtime": 18000.0,},
+        },
+        {"deltat": 2400,
+        "ntimesteps": 10,
+        "expected": {"nIter0": 5,
+                    "nTimeSteps": 10,
+                    "deltaT": 2400.0,
+                    "starttime": 12000.0,
+                    "endtime": 36000.0,},
+        },
+        {"deltat": 0.001,
+        "ntimesteps": 12000000,
+        "expected": {"nIter0": 12000000,
+                    "nTimeSteps": 12000000,
+                    "deltaT": 0.001,
+                    "starttime": 12000.0,
+                    "endtime": 24000.0,},
+        },
+    ],
+)
+def test_setup_change_deltat(config, data, case):
+
+    restartdir = labdir / 'archive' / 'restarts'
+
+    # Set a restart directory in config
+    config['restart'] = str(restartdir)
+    write_config(config)
+
+    # Halve deltat
+    data['parm03']['deltat'] = case['deltat']
+    data['parm03']['ntimesteps'] = case['ntimesteps']
+    make_config_files(data)
+
+    res_fnames = make_pickup_names(10)
+
+    make_restarts(res_fnames)
+
+    # Run setup
+    payu_setup(lab_path=str(labdir))
+
+    mitgcm_restart = {}
+    mitgcm_restart['endtime'] = 12000.
+
+    with (restartdir / 'mitgcm.res.yaml').open('w') as file:
+        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
 
     payu_setup(lab_path=str(labdir))
 
     data_local = f90nml.read(workdir/'data')
 
     # Time step has halved, so nIter0 is doubled
-    assert data_local['parm03']['nIter0'] == 20
-    assert data_local['parm03']['deltaT'] == 600.
-    assert data_local['parm03']['starttime'] == 12000.
-    assert data_local['parm03']['endtime'] == 24000.
-
-    # Double deltaT
-    data['parm03']['deltat'] = 2400.
-
-    make_config_files()
-
-    # This should throw an error, as it would overwrite the existing
-    # pickup files in the work directory, as the nIter is the same
-    matchstr = '.*Timestep at end identical to previous pickups.*'
-    with pytest.raises(SystemExit, match=matchstr) as setup_error:
-        payu_setup(lab_path=str(labdir))
-    assert setup_error.type == SystemExit
-
-    # deltaT which is not a divisor. Set ntimesteps instead of
-    # start and end times
-    data['parm03']['deltat'] = 999.
-    data['parm03']['ntimesteps'] = 5.
-    del data['parm03']['starttime']
-    del data['parm03']['endtime']
-
-    make_config_files()
-
-    payu_setup(lab_path=str(labdir))
-
-    data_local = f90nml.read(workdir/'data')
-
-    # Time step has halved, so nIter0 is doubled
-    assert data_local['parm03']['nIter0'] == 0
-    assert data_local['parm03']['deltaT'] == 999.
-    assert data_local['parm03']['basetime'] == 12000.
-    assert data_local['parm03']['starttime'] == 12000.
-    assert data_local['parm03']['endtime'] == 16995.
-    assert data_local['parm03']['pickupsuff'] == '0000000010'
-
-    # Make same number of timesteps as previous, which should throw
-    # an error
-    data['parm03']['ntimesteps'] = 10.
-
-    make_config_files()
-
-    # This should throw an error, as it would overwrite the existing
-    # pickup files in the work directory, as the nIter is the same
-    # matchstr = '.*not integer multiple.*'
-    matchstr = '.*Timestep at end identical to previous pickups.*'
-    with pytest.raises(SystemExit, match=matchstr) as setup_error:
-        payu_setup(lab_path=str(labdir))
-    assert setup_error.type == SystemExit
+    assert data_local['parm03']['nIter0'] == case['expected']['nIter0']
+    assert data_local['parm03']['nTimeSteps'] == case['expected']['nTimeSteps']
+    assert data_local['parm03']['deltaT'] == case['expected']['deltaT']
+    assert data_local['parm03']['starttime'] == case['expected']['starttime']
+    assert data_local['parm03']['endtime'] == case['expected']['endtime']

--- a/test/models/test_mitgcm.py
+++ b/test/models/test_mitgcm.py
@@ -103,13 +103,6 @@ def test_make_pickup_names():
     assert(make_pickup_names(10) == ['pickup.0000000010.001.001.data',
                                      'pickup.0000000010.001.001.meta'])
 
-# These are integration tests. They have an undesirable dependence on each
-# other. It would be possible to make them independent, but then they'd
-# be reproducing previous "tests", like init. So this design is deliberate
-# but compromised. It means when running an error in one test can cascade
-# and cause other tests to fail.
-#
-# Unfortunate but there you go.
 
 
 def test_init(config):

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from pathlib import Path
+import pytest
 
 import pytest
 import f90nml
@@ -13,33 +14,10 @@ from test.common import write_config, write_metadata
 from test.common import make_random_file, make_inputs, make_exe
 from test.test_git_utils import create_new_repo
 
-verbose = True
 
-
-def setup_module(module):
-    """
-    Put any test-wide setup code in here, e.g. creating test files
-    """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        expt_workdir.mkdir(parents=True)
-        make_inputs()
-        make_exe()
-        write_metadata()
-    except Exception as e:
-        print(e)
-
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
+    write_metadata()
     config = {
             'laboratory': 'lab',
             'jobname': 'testrun',
@@ -51,27 +29,6 @@ def setup_module(module):
             }
     }
     write_config(config)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
-
-
-@pytest.fixture(autouse=True)
-def teardown():
-    # Run test
-    yield
-
 
 @pytest.mark.parametrize(
     "input_nml, expected_files_added",
@@ -332,7 +289,7 @@ def test_get_cur_expt_time():
 
     # Write a calendar into ocean_solo.res
     ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
-    os.makedirs(expt.restart_path, exist_ok=True)
+    os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
     with open(ocean_solo_path, 'w') as f:
         f.write("2\n")  # Use Julian calendar
 
@@ -372,7 +329,7 @@ def test_get_cur_expt_time_missing_files(missing_file):
 
     # Write a calendar into ocean_solo.res
     ocean_solo_path = os.path.join(expt.work_path, 'INPUT', 'ocean_solo.res')
-    os.makedirs(expt.restart_path, exist_ok=True)
+    os.makedirs(os.path.dirname(ocean_solo_path), exist_ok=True)
     with open(ocean_solo_path, 'w') as f:
         f.write("2\n")  # Use Julian calendar
 

--- a/test/models/test_mom6.py
+++ b/test/models/test_mom6.py
@@ -17,6 +17,9 @@ from test.test_git_utils import create_new_repo
 
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
+    """Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
+    """
     write_metadata()
     config = {
             'laboratory': 'lab',

--- a/test/models/test_mom_mixin.py
+++ b/test/models/test_mom_mixin.py
@@ -26,7 +26,8 @@ config = copy.deepcopy(config_orig)
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
     """
-    Put any test-wide setup code in here, e.g. creating test files
+    Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     # Create all files
     make_all_files()

--- a/test/models/test_mom_mixin.py
+++ b/test/models/test_mom_mixin.py
@@ -23,46 +23,17 @@ verbose = True
 # Global config
 config = copy.deepcopy(config_orig)
 
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        make_all_files()
-    except Exception as e:
-        print(e)
-
+    # Create all files
+    make_all_files()
     # Write config
     test_config = config
     test_config['model'] = 'mom'
     write_config(test_config)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
 
 
 @pytest.fixture(autouse=True)
@@ -158,6 +129,8 @@ def convert_date_string_to_array(dt_string):
         cftime.datetime(9999, 12, 30, calendar="360_day")
     ])
 def test_mom_get_restart_datetime(run_dt):
+    config['model'] = 'mom'
+    write_config(config)
     # Create 1 mom restart directory
     start_dt = cftime.datetime(1900, 1, 1, calendar=run_dt.calendar)
     make_ocean_restart_dir(start_dt, run_dt)
@@ -188,6 +161,8 @@ def test_mom_bad_get_restart_datetime(run_dt, expected_error):
     """
     Test that get_restart_datetime fails when reading invalid dates.
     """
+    config['model'] = 'mom'
+    write_config(config)
     # Create 1 mom restart directory
     start_dt = DateTuple(1900, 1, 1, 0, 0, 0, run_dt.calendar)
     make_ocean_restart_dir(start_dt, run_dt)

--- a/test/models/test_staged_cable.py
+++ b/test/models/test_staged_cable.py
@@ -13,29 +13,9 @@ from test.common import make_random_file, make_inputs, make_exe
 
 verbose = True
 
-
-def setup_module(module):
-    """
-    Put any test-wide setup code in here, e.g. creating test files
-    """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        expt_workdir.mkdir(parents=True)
-        archive_dir.mkdir()
-    except Exception as e:
-        print(e)
-
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
+    archive_dir.mkdir()
     config = {
         'laboratory': 'lab',
         'jobname': 'testrun',
@@ -98,19 +78,6 @@ def setup_module(module):
 
     with open(ctrldir / 'stage_1/cable.nml', 'w') as patch_nml_f:
         f90nml.write(patch_nml, patch_nml_f)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-    except Exception as e:
-        print(e)
 
 
 def test_staged_cable():

--- a/test/models/test_um.py
+++ b/test/models/test_um.py
@@ -28,7 +28,8 @@ UM_RES_FILE = "um.res.yaml"
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
     """
-    Put any test-wide setup code in here, e.g. creating test files
+    Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     make_all_files()
 

--- a/test/models/test_um.py
+++ b/test/models/test_um.py
@@ -25,45 +25,17 @@ config = copy.deepcopy(config_orig)
 
 UM_RES_FILE = "um.res.yaml"
 
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        make_all_files()
-    except Exception as e:
-        print(e)
+    make_all_files()
 
     # Write config
     test_config = config
     test_config['model'] = 'um'
     write_config(test_config)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
 
 
 @pytest.fixture(autouse=True)
@@ -121,6 +93,10 @@ def test_um_get_restart_datetime(date):
     Check the UM driver correctly reads restart dates as cftime
     objects.
     """
+        # Write config
+    test_config = config
+    test_config['model'] = 'um'
+    write_config(test_config)
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
         expt = payu.experiment.Experiment(lab, reproduce=False)
@@ -133,6 +109,10 @@ def test_um_get_restart_datetime(date):
 
 def test_convert_timestep():
     """ Test with an invalid log file"""
+    # Write config
+    test_config = config
+    test_config['model'] = 'um'
+    write_config(test_config)
     # Initialise ESM1.6
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))

--- a/test/test_fsops.py
+++ b/test/test_fsops.py
@@ -1,13 +1,63 @@
 import json
 import pytest
 import os
+import shutil
 from unittest.mock import patch
+from pathlib import Path
 
 # import payu packages
-from payu.fsops import atomic_write_file
+from payu.fsops import atomic_write_file, movetree
 
 # import some common variables for testing
-from .common import tmpdir
+from .common import tmpdir, testdir, make_all_files
+
+def scantree(path):
+    """
+    Recursively yield DirEntry objects for given directory.
+    https://stackoverflow.com/a/33135143/4727812
+    """
+    for entry in os.scandir(path):
+        if entry.is_dir(follow_symlinks=False):
+            yield from scantree(entry.path)
+        else:
+            yield entry
+
+def savetree(path):
+    """
+    Save a directory tree to a dict
+    """
+    result = {}
+    for entry in scantree(path):
+        result[entry.name] = (Path(entry.path).relative_to(path),
+                              entry.stat().st_size)
+    return(result)
+
+def test_movetree():
+    tmptwo = testdir / 'tmp2'
+    try:
+        shutil.rmtree(tmptwo)
+    except FileNotFoundError:
+        pass
+
+    make_all_files()
+
+    treeinfo = savetree(tmpdir)
+
+    tmp_inode = tmpdir.stat().st_ino
+
+    movetree(tmpdir, tmptwo)
+
+    # Ensure src directory removed
+    assert(not tmpdir.exists())
+
+    # Ensure dst directory has new inode number
+    assert(tmp_inode != tmptwo.stat().st_ino)
+
+    # Ensure directory tree faithfully moved
+    assert(treeinfo == savetree(tmptwo))
+
+    # Move tmp2 back to tmp
+    shutil.move(tmptwo, tmpdir)
 
 def test_atomic_write_file_new_content():
     """Test that atomic_write_file write expected content into designated file

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -21,22 +21,6 @@ from .common import make_exe, make_inputs, make_restarts, make_all_files
 sys.path.insert(1, '../')
 verbose = False
 
-tmptwo = testdir / 'tmp2'
-
-@pytest.fixture(autouse=True)
-def setup_module(setup_test_dir):
-    """
-    Put any test-wide setup code in here, e.g. creating test files
-    """
-    yield
-
-    try:
-        shutil.rmtree(tmptwo)
-        print('removing tmp2')
-    except Exception as e:
-        print(e)
-
-
 def scantree(path):
     """
     Recursively yield DirEntry objects for given directory.
@@ -58,29 +42,6 @@ def savetree(path):
         result[entry.name] = (Path(entry.path).relative_to(path),
                               entry.stat().st_size)
     return(result)
-
-
-def test_movetree():
-
-    make_all_files()
-
-    treeinfo = savetree(tmpdir)
-
-    tmp_inode = tmpdir.stat().st_ino
-
-    payu.fsops.movetree(tmpdir, tmptwo)
-
-    # Ensure src directory removed
-    assert(not tmpdir.exists())
-
-    # Ensure dst directory has new inode number
-    assert(tmp_inode != tmptwo.stat().st_ino)
-
-    # Ensure directory tree faithfully moved
-    assert(treeinfo == savetree(tmptwo))
-
-    # Move tmp2 back to tmp
-    shutil.move(tmptwo, tmpdir)
 
 
 def test_read_config():

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -23,38 +23,14 @@ verbose = False
 
 tmptwo = testdir / 'tmp2'
 
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
+    yield
 
     try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-    except Exception as e:
-        print(e)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
         shutil.rmtree(tmptwo)
         print('removing tmp2')
     except Exception as e:

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -14,34 +14,11 @@ import payu.fsops
 import payu.laboratory
 import payu.envmod
 
-from .common import testdir, tmpdir, ctrldir, labdir, workdir, cd
-from .common import make_exe, make_inputs, make_restarts, make_all_files
+from .common import tmpdir, cd
 
 
 sys.path.insert(1, '../')
 verbose = False
-
-def scantree(path):
-    """
-    Recursively yield DirEntry objects for given directory.
-    https://stackoverflow.com/a/33135143/4727812
-    """
-    for entry in os.scandir(path):
-        if entry.is_dir(follow_symlinks=False):
-            yield from scantree(entry.path)
-        else:
-            yield entry
-
-
-def savetree(path):
-    """
-    Save a directory tree to a dict
-    """
-    result = {}
-    for entry in scantree(path):
-        result[entry.name] = (Path(entry.path).relative_to(path),
-                              entry.stat().st_size)
-    return(result)
 
 
 def test_read_config():

--- a/test/test_prune_restarts.py
+++ b/test/test_prune_restarts.py
@@ -22,7 +22,8 @@ config = copy.deepcopy(config_orig)
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
     """
-    Put any test-wide setup code in here, e.g. creating test files
+    Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     make_all_files()
 

--- a/test/test_prune_restarts.py
+++ b/test/test_prune_restarts.py
@@ -19,41 +19,12 @@ verbose = True
 # Global config
 config = copy.deepcopy(config_orig)
 
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        make_all_files()
-    except Exception as e:
-        print(e)
-
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
+    make_all_files()
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -24,28 +24,14 @@ config.pop('metadata')
 pytestmark = pytest.mark.filterwarnings(
     "ignore::payu.git_utils.PayuGitWarning")
 
-
-def setup_module(module):
+@pytest.fixture(autouse=True)
+def setup_module(setup_test_dir, empty_workdir):
     """
     Put any test-wide setup code in here, e.g. creating test files
     """
-    if verbose:
-        print("setup_module      module:%s" % module.__name__)
-
-    # Should be taken care of by teardown, in case remnants lying around
-    try:
-        shutil.rmtree(tmpdir)
-    except FileNotFoundError:
-        pass
-
-    try:
-        tmpdir.mkdir()
-        labdir.mkdir()
-        ctrldir.mkdir()
-        make_all_files()
-        write_metadata()
-    except Exception as e:
-        print(e)
+    make_all_files()
+    write_metadata()
+    write_config(config)
 
     # Create 5 restarts and outputs
     for dir_type in ['restart', 'output']:
@@ -53,19 +39,6 @@ def setup_module(module):
             path = make_expt_archive_dir(type=dir_type, index=i)
             make_random_file(os.path.join(path, f'test-{dir_type}00{i}-file'))
 
-
-def teardown_module(module):
-    """
-    Put any test-wide teardown code in here, e.g. removing test outputs
-    """
-    if verbose:
-        print("teardown_module   module:%s" % module.__name__)
-
-    try:
-        shutil.rmtree(tmpdir)
-        print('removing tmp')
-    except Exception as e:
-        print(e)
 
 
 def setup_sync(additional_config, add_envt_vars=None):

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -27,7 +27,8 @@ pytestmark = pytest.mark.filterwarnings(
 @pytest.fixture(autouse=True)
 def setup_module(setup_test_dir, empty_workdir):
     """
-    Put any test-wide setup code in here, e.g. creating test files
+    Put any test-wide setup code in here, e.g. creating test files.
+    Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     make_all_files()
     write_metadata()


### PR DESCRIPTION
Use a fixture (`setup_test_dir`) to create tmp directories and ensure clean up after test for model drivers. This guarantees test isolation and ensures that all temporary directories are removed regardless of whether tests pass or fail.

Closes #736.