### PR TITLE
Test new containerised infra payu dev deployment

### DIFF
--- a/.github/workflows/deploy_payu_dev.yml
+++ b/.github/workflows/deploy_payu_dev.yml
@@ -13,12 +13,12 @@ jobs:
         name: Deploy payu dev containerised environment
         runs-on: ubuntu-latest
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CONTAINERISED_ENVS_INFRA_WORKFLOW_PAT }}
         steps:
-          - name: Deploy payu dev
+          - name: Deploy
             run: |
               gh workflow run \
                 --repo access-nri/containerised-environments-infra \
-                --ref main
+                --ref main \
                 release_dev_env.yml \
                 -f environment=payu

--- a/.github/workflows/deploy_payu_dev.yml
+++ b/.github/workflows/deploy_payu_dev.yml
@@ -1,6 +1,6 @@
 name: Deploy payu dev
 description: |
-  Deploy payu devevelopment containerised environment used by ACCESS-NRI-related workflows.
+  Deploy payu development containerised environment used by ACCESS-NRI-related workflows.
 
 on:
   push:

--- a/.github/workflows/deploy_payu_dev.yml
+++ b/.github/workflows/deploy_payu_dev.yml
@@ -1,0 +1,24 @@
+name: Deploy payu dev
+description: |
+  Deploy payu devevelopment containerised environment used by ACCESS-NRI-related workflows.
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+    deploy-access-nri-payu-dev:
+        name: Deploy payu dev containerised environment
+        runs-on: ubuntu-latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        steps:
+          - name: Deploy payu dev
+            run: |
+              gh workflow run \
+                --repo access-nri/containerised-environments-infra \
+                --ref main
+                release_dev_env.yml \
+                -f environment=payu


### PR DESCRIPTION
This PR adds a automatic deployments to `payu/dev` when new commits are pushed to `payu-org/payu`'s `master` branch. 

This is a change from before when no secrets were stored on this repository, and instead there was a daily check for new commits to trigger a new deploy `payu/dev`.

I've created a fine-grained PAT for the `containerised-environments-infra` repository with read-write access to Actions so it can trigger the workflow. From the docs, https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2026-03-10#repository-permissions-for-actions, we shouldn't be able to access any secrets from this repository, but it's good there will still be sign offs for any deployments to production.. 

Successful workflow: https://github.com/ACCESS-NRI/containerised-environments-infra/actions/runs/25844555511



