### PR TITLE
Pass current run number to payu sync command.

### DIFF
--- a/payu/branch.py
+++ b/payu/branch.py
@@ -17,7 +17,7 @@ import sys
 from ruamel.yaml import YAML, CommentedMap, constructor
 import git
 
-from payu.fsops import read_config, DEFAULT_CONFIG_FNAME, list_archive_dirs
+from payu.fsops import read_config, DEFAULT_CONFIG_FNAME, list_sorted_archive_dirs
 from payu.laboratory import Laboratory
 from payu.metadata import Metadata, UUID_FIELD, METADATA_FILENAME
 from payu.git_utils import GitRepository, git_clone, PayuBranchError
@@ -85,7 +85,7 @@ def check_restart(restart_path: Path,
 
     # Check for pre-existing restarts in archive
     if archive_path and archive_path.exists():
-        if len(list_archive_dirs(archive_path, dir_type="restart")) > 0:
+        if len(list_sorted_archive_dirs(archive_path, dir_type="restart")) > 0:
             warnings.warn((
                 f"Pre-existing restarts found in archive: {archive_path}."
                 f"Skipping adding 'restart: {restart_path}' to config file"))

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -1020,9 +1020,10 @@ class Experiment(object):
         sync_config = self.config.get('sync', {})
         syncing = sync_config.get('enable', False)
         if syncing:
-            cmd = '{python} {payu} sync'.format(
+            cmd = '{python} {payu} sync -i {expt}'.format(
                 python=sys.executable,
-                payu=self.payu_path
+                payu=self.payu_path,
+                expt=self.counter
             )
 
             if self.postscript:

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -32,7 +32,7 @@ from packaging import version
 # Local
 from payu import envmod
 from payu.fsops import make_symlink, read_config, movetree
-from payu.fsops import list_archive_dirs
+from payu.fsops import list_sorted_archive_dirs
 from payu.fsops import run_script_command
 from payu.fsops import needs_subprocess_shell
 from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
@@ -258,7 +258,7 @@ class Experiment(object):
         """Given a output directory type (output or restart),
         return the maximum index of output directories found"""
         try:
-            output_dirs = list_archive_dirs(archive_path=self.archive_path,
+            output_dirs = list_sorted_archive_dirs(archive_path=self.archive_path,
                                             dir_type=output_type)
         except FileNotFoundError:
             # Archive path does not exist yet
@@ -1157,7 +1157,7 @@ class Experiment(object):
             return []
 
         # Sorted list of restart directories in archive
-        restarts = list_archive_dirs(archive_path=self.archive_path,
+        restarts = list_sorted_archive_dirs(archive_path=self.archive_path,
                                      dir_type='restart')
         restart_indices = {}
         for restart in restarts:

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -239,7 +239,7 @@ def required_libs(bin_path):
     return parse_ldd_output(ldd_out)
 
 
-def list_archive_dirs(archive_path: Union[Path, str],
+def list_sorted_archive_dirs(archive_path: Union[Path, str],
                       dir_type: str = "output") -> List[str]:
     """Return a sorted list of restart or output directories in archive"""
     naming_pattern = re.compile(fr"^{dir_type}[0-9][0-9][0-9]+$")

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -253,7 +253,7 @@ def list_archive_dirs(archive_path: Union[Path, str],
         if real_path.is_dir() and naming_pattern.match(path.name):
             dirs.append(path.name)
 
-    dirs.sort(key=lambda d: int(d.lstrip(dir_type)))
+    dirs.sort(key=lambda d: int(d.removeprefix(dir_type)))
     return dirs
 
 

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -14,16 +14,17 @@ from payu import fsops
 title = 'sync'
 parameters = {'description': 'Sync model output to a remote directory'}
 
-arguments = [args.model, args.config, args.laboratory, args.dir_path,
+arguments = [args.model, args.config, args.initial, args.laboratory, args.dir_path,
              args.sync_restarts, args.sync_ignore_last]
 
 
-def runcmd(model_type, config_path, lab_path, dir_path, sync_restarts,
+def runcmd(model_type, config_path, init_run, lab_path, dir_path, sync_restarts,
            sync_ignore_last):
 
     pbs_config = fsops.read_config(config_path)
 
-    pbs_vars = cli.set_env_vars(lab_path=lab_path,
+    pbs_vars = cli.set_env_vars(init_run=init_run,
+                                lab_path=lab_path,
                                 dir_path=dir_path,
                                 sync_restarts=sync_restarts,
                                 sync_ignore_last=sync_ignore_last)
@@ -69,7 +70,8 @@ def runscript():
 
     run_args = parser.parse_args()
 
-    pbs_vars = cli.set_env_vars(lab_path=run_args.lab_path,
+    pbs_vars = cli.set_env_vars(init_run=run_args.init_run,
+                                lab_path=run_args.lab_path,
                                 dir_path=run_args.dir_path,
                                 sync_restarts=run_args.sync_restarts,
                                 sync_ignore_last=run_args.sync_ignore_last)

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -16,7 +16,7 @@ import time
 
 
 # Local
-from payu.fsops import list_archive_dirs
+from payu.fsops import list_sorted_archive_dirs
 from payu.metadata import METADATA_FILENAME, UUID_FIELD
 
 DEST_NOT_CONFIGURED_MSG ="""
@@ -55,15 +55,12 @@ def filter_previous_runs(all_dir, prefix):
               "Syncing all runs in archive.")
         return all_dir
 
-    # Sort the dicectories from lowest to highest based on the suffix number
-    sorted_dir = sorted(all_dir, key=lambda d: int(d.removeprefix(prefix)))
-
-    for i in range(len(sorted_dir)-1, -1, -1):
-        suffix = sorted_dir[i].removeprefix(prefix)
+    for i in range(len(all_dir)-1, -1, -1):
+        suffix = all_dir[i].removeprefix(prefix)
 
         # Only include suffix that is less than or equal to the current run
         if int(suffix) <= int(current_run):
-            return sorted_dir[0:i+1]
+            return all_dir[0:i+1]
 
     # Return empty list if no directories are <= current run
     return []
@@ -87,7 +84,7 @@ class SyncToRemoteArchive():
     def add_outputs_to_sync(self):
         """Add paths of outputs in archive to sync. The last output is
         protected"""
-        all_outputs = list_archive_dirs(archive_path=self.expt.archive_path,
+        all_outputs = list_sorted_archive_dirs(archive_path=self.expt.archive_path,
                                     dir_type='output')
         outputs = filter_previous_runs(all_outputs, prefix='output')
         outputs = [os.path.join(self.expt.archive_path, output)
@@ -111,7 +108,7 @@ class SyncToRemoteArchive():
             return
 
         # Get sorted list of restarts in archive
-        all_restarts = list_archive_dirs(archive_path=self.expt.archive_path,
+        all_restarts = list_sorted_archive_dirs(archive_path=self.expt.archive_path,
                                      dir_type='restart')
         restarts = filter_previous_runs(all_restarts, prefix='restart')
         restarts = [os.path.join(self.expt.archive_path, restart)

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -5,7 +5,7 @@
 """
 
 # Standard
-import getpass
+import warnings
 import glob
 import os
 import shutil
@@ -42,6 +42,25 @@ class SourcePath():
         self.path = path
         self.is_log_file = is_log_file
 
+def filter_previous_runs(all_dir, prefix=None):
+    """Given a list of directories of all runs (e.g., ['output001', 'output002']), 
+    filter to only include dir that is less than or equal to current run."""
+    if all_dir == []:
+        return []
+
+    current_run = os.environ.get('PAYU_CURRENT_RUN')
+    if current_run is None:
+        warnings.warn("PAYU_CURRENT_RUN environment variable not set. "
+              "Syncing all runs in archive.")
+        return all_dir
+
+    filter_dir = []
+    for directory in all_dir:
+        suffix = directory.replace(prefix, '') if prefix else directory
+        if int(suffix) <= int(current_run):
+            filter_dir.append(directory)
+
+    return filter_dir
 
 class SyncToRemoteArchive():
     """Class used for archiving experiment outputs to a remote directory"""
@@ -62,8 +81,9 @@ class SyncToRemoteArchive():
     def add_outputs_to_sync(self):
         """Add paths of outputs in archive to sync. The last output is
         protected"""
-        outputs = list_archive_dirs(archive_path=self.expt.archive_path,
+        all_outputs = list_archive_dirs(archive_path=self.expt.archive_path,
                                     dir_type='output')
+        outputs = filter_previous_runs(all_outputs, prefix='output')
         outputs = [os.path.join(self.expt.archive_path, output)
                    for output in outputs]
         if len(outputs) > 0:
@@ -85,8 +105,9 @@ class SyncToRemoteArchive():
             return
 
         # Get sorted list of restarts in archive
-        restarts = list_archive_dirs(archive_path=self.expt.archive_path,
+        all_restarts = list_archive_dirs(archive_path=self.expt.archive_path,
                                      dir_type='restart')
+        restarts = filter_previous_runs(all_restarts, prefix='restart')
         restarts = [os.path.join(self.expt.archive_path, restart)
                     for restart in restarts]
         if restarts == []:

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 from ruamel.yaml import YAML
 from pathlib import Path
+import time
 
 
 # Local
@@ -54,13 +55,18 @@ def filter_previous_runs(all_dir, prefix=None):
               "Syncing all runs in archive.")
         return all_dir
 
-    filter_dir = []
-    for directory in all_dir:
+    # Sort the dicectories from highest to lowest
+    sorted_dir = sorted(all_dir)[::-1]
+    for i in range(len(sorted_dir)):
+        directory = sorted_dir[i]
         suffix = directory.replace(prefix, '') if prefix else directory
-        if int(suffix) <= int(current_run):
-            filter_dir.append(directory)
 
-    return filter_dir
+        # Only include directories that are less than or equal to the current run
+        if int(suffix) <= int(current_run):
+            return sorted_dir[i:]
+
+    # Return empty list if no directories are <= current run
+    return []
 
 class SyncToRemoteArchive():
     """Class used for archiving experiment outputs to a remote directory"""

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -43,7 +43,7 @@ class SourcePath():
         self.path = path
         self.is_log_file = is_log_file
 
-def filter_previous_runs(all_dir, prefix=None):
+def filter_previous_runs(all_dir, prefix):
     """Given a list of directories of all runs (e.g., ['output001', 'output002']), 
     filter to only include dir that is less than or equal to current run."""
     if all_dir == []:
@@ -55,15 +55,15 @@ def filter_previous_runs(all_dir, prefix=None):
               "Syncing all runs in archive.")
         return all_dir
 
-    # Sort the dicectories from highest to lowest
-    sorted_dir = sorted(all_dir)[::-1]
-    for i in range(len(sorted_dir)):
-        directory = sorted_dir[i]
-        suffix = directory.replace(prefix, '') if prefix else directory
+    # Sort the dicectories from lowest to highest based on the suffix number
+    sorted_dir = sorted(all_dir, key=lambda d: int(d.removeprefix(prefix)))
 
-        # Only include directories that are less than or equal to the current run
+    for i in range(len(sorted_dir)-1, -1, -1):
+        suffix = sorted_dir[i].removeprefix(prefix)
+
+        # Only include suffix that is less than or equal to the current run
         if int(suffix) <= int(current_run):
-            return sorted_dir[i:][::-1]
+            return sorted_dir[0:i+1]
 
     # Return empty list if no directories are <= current run
     return []

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -63,7 +63,7 @@ def filter_previous_runs(all_dir, prefix=None):
 
         # Only include directories that are less than or equal to the current run
         if int(suffix) <= int(current_run):
-            return sorted_dir[i:]
+            return sorted_dir[i:][::-1]
 
     # Return empty list if no directories are <= current run
     return []
@@ -247,7 +247,7 @@ class SyncToRemoteArchive():
     def run_cmd(self, source_path):
         """Given an source path, build and run rsync command"""
         cmd = self.build_cmd(source_path)
-        print(cmd)
+        print(f"Running command: {cmd}")
         try:
             subprocess.check_call(cmd, shell=True)
         except subprocess.CalledProcessError as e:

--- a/test/test_fsops.py
+++ b/test/test_fsops.py
@@ -6,10 +6,10 @@ from unittest.mock import patch
 from pathlib import Path
 
 # import payu packages
-from payu.fsops import atomic_write_file, movetree, list_archive_dirs
+from payu.fsops import atomic_write_file, movetree, list_sorted_archive_dirs
 
 # import some common variables for testing
-from .common import tmpdir, testdir, archive_dir, make_all_files
+from .common import tmpdir, testdir, labdir, archive_dir, make_all_files
 
 def scantree(path):
     """
@@ -131,19 +131,36 @@ def test_atomic_write_file_disrupt_dump(monkeypatch):
         content_after_error = json.load(f)
     assert content_after_error == content
 
-def test_list_archive_dirs(setup_test_dir):
-    """Test that list_archive_dirs returns expected directories."""
+
+def test_list_sorted_archive_dirs(setup_test_dir):
+    """Test that list_sorted_archive_dirs correctly lists and sorts directory names."""
+    # Create archive directories - mix of valid/invalid names
+    archive_dirs = [
+        'output000', 'output1001', 'output023', 'output404',
+        'output', 'Output001', 'output44', # not valid output dir
+        'Restart', 'restart2', 'restart', 'restart55', # not valid restart dir
+        'restart102932', 'restart021', 'restart009', 'restart606'
+    ]
+
     os.makedirs(archive_dir, exist_ok=True)
+    for dir in archive_dirs:
+        (archive_dir / dir).mkdir(parents=True)
 
-    # Create some directories and files in the archive directory
-    for n in [1001, 997, 999, 1002, 998, 1000]:
-        (archive_dir / f"output{n}").mkdir()
-        (archive_dir / f"restart{n}").mkdir()
+    # Add some files
+    (archive_dir / 'restart005').touch()
+    (archive_dir / 'output005').touch()
 
-    # Create a file that match the prefix but is not a directory
-    (archive_dir / f"output{n}.txt").touch()
+    # Add a restart symlink
+    archive_dir2 = labdir / 'archive2'
+    source_path = archive_dir2 / 'restart999'
+    source_path.mkdir(parents=True)
+    (archive_dir / 'restart23042').symlink_to(source_path)
 
-    result = list_archive_dirs(archive_dir, "output")
+    # Test list output dirs and with string archive path
+    outputs = list_sorted_archive_dirs(str(archive_dir), dir_type="output")
+    assert outputs == ['output000', 'output023', 'output404', 'output1001']
 
-    # Check that only directories with the prefix are returned and sorted correctly
-    assert result == [f"output{n}" for n in range(997, 1003)]
+    # Test list restarts
+    restarts = list_sorted_archive_dirs(archive_dir, dir_type="restart")
+    assert restarts == ['restart009', 'restart021', 'restart606',
+                        'restart23042', 'restart102932']

--- a/test/test_fsops.py
+++ b/test/test_fsops.py
@@ -6,10 +6,10 @@ from unittest.mock import patch
 from pathlib import Path
 
 # import payu packages
-from payu.fsops import atomic_write_file, movetree
+from payu.fsops import atomic_write_file, movetree, list_archive_dirs
 
 # import some common variables for testing
-from .common import tmpdir, testdir, make_all_files
+from .common import tmpdir, testdir, archive_dir, make_all_files
 
 def scantree(path):
     """
@@ -131,3 +131,19 @@ def test_atomic_write_file_disrupt_dump(monkeypatch):
         content_after_error = json.load(f)
     assert content_after_error == content
 
+def test_list_archive_dirs(setup_test_dir):
+    """Test that list_archive_dirs returns expected directories."""
+    os.makedirs(archive_dir, exist_ok=True)
+
+    # Create some directories and files in the archive directory
+    for n in [1001, 997, 999, 1002, 998, 1000]:
+        (archive_dir / f"output{n}").mkdir()
+        (archive_dir / f"restart{n}").mkdir()
+
+    # Create a file that match the prefix but is not a directory
+    (archive_dir / f"output{n}.txt").touch()
+
+    result = list_archive_dirs(archive_dir, "output")
+
+    # Check that only directories with the prefix are returned and sorted correctly
+    assert result == [f"output{n}" for n in range(997, 1003)]

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -165,42 +165,6 @@ def test_lib_update_if_nci_module_not_required():
     assert (result == '')
 
 
-def test_list_archive_dirs():
-    # Create archive directories - mix of valid/invalid names
-    archive_dirs = [
-        'output000', 'output1001', 'output023',
-        'output', 'Output001', 'output1',
-        'Restart', 'restart2', 'restart',
-        'restart102932', 'restart021', 'restart001',
-    ]
-    tmp_archive = tmpdir / 'test_archive'
-    for dir in archive_dirs:
-        (tmp_archive / dir).mkdir(parents=True)
-
-    # Add some files
-    (tmp_archive / 'restart005').touch()
-    (tmp_archive / 'output005').touch()
-
-    # Add a restart symlink
-    tmp_archive_2 = tmpdir / 'test_archive_2'
-    source_path = tmp_archive_2 / 'restart999'
-    source_path.mkdir(parents=True)
-    (tmp_archive / 'restart23042').symlink_to(source_path)
-
-    # Test list output dirs and with string archive path
-    outputs = payu.fsops.list_archive_dirs(str(tmp_archive), dir_type="output")
-    assert outputs == ['output000', 'output023', 'output1001']
-
-    # Test list restarts
-    restarts = payu.fsops.list_archive_dirs(tmp_archive, dir_type="restart")
-    assert restarts == ['restart001', 'restart021',
-                        'restart23042', 'restart102932']
-
-    # Clean up test archive
-    shutil.rmtree(tmp_archive)
-    shutil.rmtree(tmp_archive_2)
-
-
 def test_env_with_python_path_is_first():
     """Test that python directory is at the front of PATH env var"""
     env = payu.fsops.env_with_python_path()
@@ -362,7 +326,7 @@ def test_needs_shell(command, expected):
     assert payu.fsops.needs_subprocess_shell(command) == expected
 
 
-def test_read_config_yaml_duplicate_key():
+def test_read_config_yaml_duplicate_key(setup_test_dir):
     """The PyYAML library is used for reading config.yaml, but use ruamel yaml
     is used in when modifying config.yaml as part of payu checkout
     (ruamel is used to preserve comments and multi-line strings).

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -92,7 +92,7 @@ def test_filter_previous_runs(monkeypatch):
     # Set current run to 3
     monkeypatch.setenv("PAYU_CURRENT_RUN", "999")
 
-    all_dirs = ['output1001', 'output997', 'output999', 'output1002', 'output998']
+    all_dirs = ['output997', 'output998', 'output999', 'output1001', 'output1002']
     prefix = 'output'
     
     expected = ['output997', 'output998', 'output999']
@@ -106,7 +106,7 @@ def test_filter_previous_runs_no_current_run(monkeypatch):
     
     monkeypatch.delenv("PAYU_CURRENT_RUN", raising=False)
 
-    all_dirs = ['output1001', 'output997', 'output999', 'output1002', 'output998']
+    all_dirs = ['output997', 'output998', 'output999', 'output1001', 'output1002']
     prefix = 'output'
 
     result = payu.sync.filter_previous_runs(all_dirs, prefix=prefix)

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -21,18 +21,15 @@ config = copy.deepcopy(config_orig)
 
 # Enable metadata
 config.pop('metadata')
-pytestmark = pytest.mark.filterwarnings(
-    "ignore::payu.git_utils.PayuGitWarning")
 
 @pytest.fixture(autouse=True)
-def setup_module(setup_test_dir, empty_workdir):
+def setup_module(setup_test_dir):
     """
     Put any test-wide setup code in here, e.g. creating test files.
     Files created here will be automatically cleaned up by `setup_test_dir` fixture after tests.
     """
     make_all_files()
     write_metadata()
-    write_config(config)
 
     # Create 5 restarts and outputs
     for dir_type in ['restart', 'output']:
@@ -40,11 +37,17 @@ def setup_module(setup_test_dir, empty_workdir):
             path = make_expt_archive_dir(type=dir_type, index=i)
             make_random_file(os.path.join(path, f'test-{dir_type}00{i}-file'))
 
+    yield
 
 
-def setup_sync(additional_config, add_envt_vars=None):
+def setup_sync(additional_config, monkeypatch, add_envt_vars=None):
     """Given additional configuration and envt_vars, return initialised
     class used to build/run rsync commands"""
+
+    # Clean up all environment variables that may affect sync
+    for var in ['PAYU_CURRENT_RUN', 'PAYU_SYNC_IGNORE_LAST', 'PAYU_SYNC_RESTARTS']:
+        monkeypatch.delenv(var, raising=False)
+
     # Set experiment config
     test_config = copy.deepcopy(config)
     test_config.update(additional_config)
@@ -58,7 +61,7 @@ def setup_sync(additional_config, add_envt_vars=None):
     # Set enviroment vars
     if add_envt_vars is not None:
         for var, value in add_envt_vars.items():
-            os.environ[var] = value
+            monkeypatch.setenv(var, value)
 
     return payu.sync.SyncToRemoteArchive(experiment)
 
@@ -83,6 +86,32 @@ def assert_expected_archive_paths(source_paths,
     assert protected_dirs == expected_protected_dirs
 
 
+def test_filter_previous_runs(monkeypatch):
+    """Test filter_previous_runs pick up runs <= the current run."""
+
+    # Set current run to 3
+    monkeypatch.setenv("PAYU_CURRENT_RUN", "3")
+
+    all_dirs = ['output001', 'output002', 'output003', 'output004', 'output005']
+    prefix = 'output'
+    
+    expected = ['output001', 'output002', 'output003']
+    result = payu.sync.filter_previous_runs(all_dirs, prefix=prefix)
+    
+    assert result == expected
+
+
+def test_filter_previous_runs_no_current_run(monkeypatch):
+    """Test filter_previous_runs returns all dirs when PAYU_CURRENT_RUN is not set."""
+    
+    monkeypatch.delenv("PAYU_CURRENT_RUN", raising=False)
+
+    all_dirs = ['output001', 'output002', 'output003', 'output004', 'output005']
+    prefix = 'output'
+
+    assert payu.sync.filter_previous_runs(all_dirs, prefix=prefix) == all_dirs
+
+
 @pytest.mark.parametrize(
     "envt_vars, expected_outputs, expected_protected_outputs",
     [
@@ -95,9 +124,9 @@ def assert_expected_archive_paths(source_paths,
             ['output000', 'output001', 'output002', 'output003'], []
         ),
     ])
-def test_add_outputs_to_sync(envt_vars, expected_outputs,
+def test_add_outputs_to_sync(monkeypatch, envt_vars, expected_outputs,
                              expected_protected_outputs):
-    sync = setup_sync(additional_config={}, add_envt_vars=envt_vars)
+    sync = setup_sync(additional_config={}, monkeypatch=monkeypatch, add_envt_vars=envt_vars)
 
     # Test function
     sync.add_outputs_to_sync()
@@ -106,10 +135,6 @@ def test_add_outputs_to_sync(envt_vars, expected_outputs,
     assert_expected_archive_paths(sync.source_paths,
                                   expected_outputs,
                                   expected_protected_outputs)
-
-    # Tidy up test - Remove any added enviroment variables
-    for envt_var in envt_vars.keys():
-        del os.environ[envt_var]
 
 
 @pytest.mark.parametrize(
@@ -148,9 +173,9 @@ def test_add_outputs_to_sync(envt_vars, expected_outputs,
             ['restart003', 'restart004']
         ),
     ])
-def test_restarts_to_sync(add_config, envt_vars,
+def test_restarts_to_sync(monkeypatch,add_config, envt_vars,
                           expected_restarts, expected_protected_restarts):
-    sync = setup_sync(add_config, envt_vars)
+    sync = setup_sync(add_config, monkeypatch, envt_vars)
 
     # Test function
     sync.add_restarts_to_sync()
@@ -159,10 +184,6 @@ def test_restarts_to_sync(add_config, envt_vars,
     assert_expected_archive_paths(sync.source_paths,
                                   expected_restarts,
                                   expected_protected_restarts)
-
-    # Tidy up test - Remove any added enviroment variables
-    for envt_var in envt_vars.keys():
-        del os.environ[envt_var]
 
 
 @pytest.mark.parametrize(
@@ -190,20 +211,21 @@ def test_restarts_to_sync(add_config, envt_vars,
     ]
 )
 
-def test_set_destination_path(config_sync_path, expected_sync_dest):
+def test_set_destination_path(monkeypatch, config_sync_path, expected_sync_dest):
     """Test setting destination path with different combinations of
     base_path, path, url and user"""
     additional_config = config_sync_path
-    sync = setup_sync(additional_config=additional_config)
+    sync = setup_sync(additional_config=additional_config, monkeypatch=monkeypatch)
     sync.expt.name = "expt_name"
 
     # Test destination_path
     sync.set_destination_path()
     assert sync.destination_path == expected_sync_dest
 
-def test_set_destination_path_value_error():
+
+def test_set_destination_path_value_error(monkeypatch):
     """Test value error raised when path is not set"""
-    sync = setup_sync(additional_config={})
+    sync = setup_sync(additional_config={}, monkeypatch=monkeypatch)
     with pytest.raises(ValueError, match="payu: error: Sync path is not defined."):
         sync.set_destination_path()
 
@@ -227,8 +249,7 @@ def test_set_destination_path_value_error():
             tmpdir / "diff_sync_dir" / "metadata.yaml")
     ]
 )
-
-def test_check_uuid(existing_metadata, path_for_sync, path_for_metadata):
+def test_check_uuid(monkeypatch, existing_metadata, path_for_sync, path_for_metadata):
     """Test check_uuid pass when UUIDs match, no UUID and no metadata.yaml"""
     # First, make sure the sync dir and metadata.yaml path exist
     path_for_sync.mkdir(parents=True, exist_ok=True)
@@ -242,13 +263,13 @@ def test_check_uuid(existing_metadata, path_for_sync, path_for_metadata):
             "path": str(path_for_sync),
         }
     }
-    sync = setup_sync(additional_config=additional_config)
+    sync = setup_sync(additional_config=additional_config, monkeypatch=monkeypatch)
 
     # Test destination_path
     sync.set_destination_path()
     assert sync.destination_path == str(path_for_sync)
 
-def test_check_uuid_value_error():
+def test_check_uuid_value_error(monkeypatch):
     """Test check_uuid raises ValueError when UUIDs do not match"""
     # First, set up a metadata.yaml with `different-UUID` in the destination sync path
     sync_dir = tmpdir / "sync_dir"
@@ -263,7 +284,7 @@ def test_check_uuid_value_error():
             "path": str(sync_dir),
         }
     }
-    sync = setup_sync(additional_config=additional_config)
+    sync = setup_sync(additional_config=additional_config, monkeypatch=monkeypatch)
 
     # Test check_uuid raises ValueError
     with pytest.raises(ValueError, match="payu: error: Mismatched experiment UUIDs in sync destination."):
@@ -318,15 +339,15 @@ def test_check_uuid_value_error():
             }, ""
         )
     ])
-def test_set_excludes_flags(add_config, expected_excludes):
-    sync = setup_sync(additional_config=add_config)
+def test_set_excludes_flags(monkeypatch, add_config, expected_excludes):
+    sync = setup_sync(additional_config=add_config, monkeypatch=monkeypatch)
 
     # Test setting excludes
     sync.set_excludes_flags()
     assert sync.excludes == expected_excludes
 
 
-def test_sync():
+def test_sync(monkeypatch):
     # Add some logs
     pbs_logs_path = os.path.join(expt_archive_dir, 'pbs_logs')
     os.makedirs(pbs_logs_path)
@@ -359,7 +380,7 @@ def test_sync():
             "runlog": False
         }
     }
-    sync = setup_sync(additional_config)
+    sync = setup_sync(additional_config, monkeypatch, add_envt_vars={'PAYU_CURRENT_RUN': '4'})
 
     # Function to test
     sync.run()
@@ -392,13 +413,14 @@ def test_sync():
 
     # Test sync with remove synced files locally flag
     additional_config['sync']['remove_local_files'] = True
-    sync = setup_sync(additional_config)
+    sync = setup_sync(additional_config, monkeypatch)
     sync.run()
 
     # Check synced files are removed from local archive
     # Except for the protected paths (last output in this case)
     for output in ['output000', 'output001', 'output002', 'output003']:
-        file_path = os.path.join(expt_archive_dir, dir, f'test-{output}-file')
+        file_path = os.path.join(expt_archive_dir, output, f'test-{output}-file')
+        print(f"Checking {file_path} is removed")
         assert not os.path.exists(file_path)
 
     last_output_path = os.path.join(expt_archive_dir, 'output004')
@@ -407,7 +429,7 @@ def test_sync():
 
     # Test sync with remove synced dirs flag as well
     additional_config['sync']['remove_local_dirs'] = True
-    sync = setup_sync(additional_config)
+    sync = setup_sync(additional_config, monkeypatch)
     sync.run()
 
     # Assert synced output dirs removed (except for the last output)

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -90,12 +90,12 @@ def test_filter_previous_runs(monkeypatch):
     """Test filter_previous_runs pick up runs <= the current run."""
 
     # Set current run to 3
-    monkeypatch.setenv("PAYU_CURRENT_RUN", "3")
+    monkeypatch.setenv("PAYU_CURRENT_RUN", "999")
 
-    all_dirs = ['output001', 'output002', 'output003', 'output004', 'output005']
+    all_dirs = ['output1001', 'output997', 'output999', 'output1002', 'output998']
     prefix = 'output'
     
-    expected = ['output001', 'output002', 'output003']
+    expected = ['output997', 'output998', 'output999']
     result = payu.sync.filter_previous_runs(all_dirs, prefix=prefix)
     
     assert result == expected
@@ -106,10 +106,11 @@ def test_filter_previous_runs_no_current_run(monkeypatch):
     
     monkeypatch.delenv("PAYU_CURRENT_RUN", raising=False)
 
-    all_dirs = ['output001', 'output002', 'output003', 'output004', 'output005']
+    all_dirs = ['output1001', 'output997', 'output999', 'output1002', 'output998']
     prefix = 'output'
 
-    assert payu.sync.filter_previous_runs(all_dirs, prefix=prefix) == all_dirs
+    result = payu.sync.filter_previous_runs(all_dirs, prefix=prefix)
+    assert result == all_dirs
 
 
 @pytest.mark.parametrize(

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -87,8 +87,10 @@ def assert_expected_archive_paths(source_paths,
 
 
 def test_filter_previous_runs(monkeypatch):
-    """Test filter_previous_runs pick up runs <= the current run."""
-
+    """
+    Test filter_previous_runs pick up runs <= the current run.
+    filter_previous_runs expects to have sorted directories from lowest to highest as inputs.
+    """
     # Set current run to 3
     monkeypatch.setenv("PAYU_CURRENT_RUN", "999")
 


### PR DESCRIPTION
This PR pass the current run number to `payu sync` command. In this case, restart and output greater than the current run will not be sync.

Close #732.