### PR TITLE
Replace `PyYAML` with `Ruamel.yaml` across payu

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -26,7 +26,7 @@ import warnings
 import pwd
 
 # Extensions
-import yaml
+from ruamel.yaml import YAML
 from packaging import version
 
 # Local
@@ -715,8 +715,10 @@ class Experiment(object):
             os.environ['PAYU_RUN_ID'] = str(self.run_id)
 
         # Dump out environment
+        yaml = YAML()
+        yaml.default_flow_style = False
         with open(self.env_fname, 'w') as file:
-            file.write(yaml.dump(dict(os.environ), default_flow_style=False))
+            yaml.dump(dict(os.environ), file)
 
         # Update run info file
         telemetry.update_run_job_file(

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -23,7 +23,8 @@ import stat
 import warnings
 
 # Extensions
-import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.constructor import DuplicateKeyError
 
 DEFAULT_CONFIG_FNAME = 'config.yaml'
 
@@ -36,6 +37,11 @@ EXTENSION_TO_INTERPRETER = {'.py': sys.executable,
                             '.sh': '/bin/bash',
                             '.csh': '/bin/tcsh'}
 
+duplicate_key_warning = """
+    ---------------------------
+    Duplicate key found in config file.
+    Payu will keep the first value for this key.
+    --------------------------- """
 
 def movetree(src, dst, symlinks=False):
     """
@@ -56,26 +62,6 @@ def movetree(src, dst, symlinks=False):
     shutil.rmtree(src)
 
 
-class DuplicateKeyWarnLoader(yaml.SafeLoader):
-    def construct_mapping(self, node, deep=False):
-        """Add warning for duplicate keys in yaml file, as currently
-        PyYAML overwrites duplicate keys even though in YAML, keys
-        are meant to be unique
-        """
-        mapping = {}
-        for key_node, value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)
-            value = self.construct_object(value_node, deep=deep)
-            if key in mapping:
-                warnings.warn(
-                    "Duplicate key found in config.yaml: "
-                    f"key '{key}' with value '{value}'. "
-                    f"This overwrites the original value: '{mapping[key]}'"
-                )
-            mapping[key] = value
-
-        return super().construct_mapping(node, deep)
-
 
 def read_config(config_fname=None):
     """Parse input configuration file and return a config dict."""
@@ -85,7 +71,22 @@ def read_config(config_fname=None):
 
     try:
         with open(config_fname, 'r') as config_file:
-            config = yaml.load(config_file, Loader=DuplicateKeyWarnLoader)
+
+            try:
+                # Attempt to load config with duplicate key checking first
+                yaml = YAML(typ='safe')
+                yaml.allow_duplicate_keys = False
+                config = yaml.load(config_file)
+
+            except DuplicateKeyError as e:
+                # Warn the user about duplicated keys,
+                # Second attempt to load config with duplicated key allowed.
+                warnings.warn("Details: " + str(e) + duplicate_key_warning, UserWarning)
+                yaml = YAML(typ='safe')
+                config_file.seek(0)
+                yaml.allow_duplicate_keys = True
+                config = yaml.load(config_file)
+                
 
         # NOTE: A YAML file with no content returns `None`
         if config is None:

--- a/payu/models/cable.py
+++ b/payu/models/cable.py
@@ -14,7 +14,9 @@ import shutil
 
 # Extensions
 import f90nml
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 # Local
 from payu.models.model import Model
@@ -113,7 +115,7 @@ class Cable(Model):
         self.cable_nml = f90nml.read(self.cable_nml_path)
         if self.prior_restart_path:
             with open(self.restart_calendar_path, 'r') as restart_file:
-                self.restart_info = yaml.safe_load(restart_file)
+                self.restart_info = yaml.load(restart_file)
         else:
             self.restart_info = {'year': self.cable_nml['cable']['ncciy']}
 
@@ -130,7 +132,7 @@ class Cable(Model):
         forcing_year_config_path = os.path.join(self.work_path, self.forcing_year_config)
         if os.path.exists(forcing_year_config_path):
             with open(forcing_year_config_path, 'r') as file:
-                conf = yaml.safe_load(file)
+                conf = yaml.load(file)
                 forcing_year_config = conf if conf else {}
             for var in self.met_forcing_vars:
                 path = _get_forcing_path(
@@ -152,7 +154,7 @@ class Cable(Model):
         with open(os.path.join(self.restart_path,
                   self.restart_calendar_file), 'w') as restart_file:
             restart = {'year': self.restart_info['year'] + 1}
-            restart_file.write(yaml.dump(restart, default_flow_style=False))
+            yaml.dump(restart, restart_file)
 
         super(Cable, self).archive()
 

--- a/payu/models/mitgcm.py
+++ b/payu/models/mitgcm.py
@@ -17,7 +17,9 @@ import subprocess as sp
 
 # Extensions
 import f90nml
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 # Local
 from payu.models.model import Model
@@ -131,7 +133,7 @@ class Mitgcm(Model):
             # Look for a restart file from a previous run
             if os.path.exists(restart_calendar_path):
                 with open(restart_calendar_path, 'r') as restart_file:
-                    restart_info = yaml.safe_load(restart_file)
+                    restart_info = yaml.load(restart_file)
                 t_start = float(restart_info['endtime'])
             else:
                 # Use same logic as MITgcm and assume
@@ -231,7 +233,7 @@ class Mitgcm(Model):
         with open(os.path.join(self.restart_path,
                   self.restart_calendar_file), 'w') as restart_file:
             restart = {'endtime': data_nml['parm03']['endTime']}
-            restart_file.write(yaml.dump(restart, default_flow_style=False))
+            yaml.dump(restart, restart_file)
 
         # Remove symbolic links to input or pickup files:
         for f in os.listdir(self.work_path):

--- a/payu/models/staged_cable.py
+++ b/payu/models/staged_cable.py
@@ -14,7 +14,8 @@ import itertools
 
 # Extensions
 import f90nml
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
 
 # Local
 from payu.models.model import Model
@@ -70,7 +71,7 @@ class StagedCable(Model):
 
         # Read the stage_config.yaml file
         with open('stage_config.yaml', 'r') as stage_conf_f:
-            self.stage_config = yaml.safe_load(stage_conf_f)
+            self.stage_config = yaml.load(stage_conf_f)
 
         # On the first run, we need to read the 'stage_config.yaml' file.
         cable_stages = self._prepare_configuration()
@@ -85,7 +86,7 @@ class StagedCable(Model):
     def _read_configuration_log(self):
         """Read the existing configuration log."""
         with open('configuration_log.yaml') as conf_log_file:
-            self.configuration_log = yaml.safe_load(conf_log_file)
+            self.configuration_log = yaml.load(conf_log_file)
 
     def _prepare_configuration(self):
         """Prepare the stages in the CABLE configuration."""

--- a/payu/models/um.py
+++ b/payu/models/um.py
@@ -18,7 +18,9 @@ import string
 
 # Extensions
 import f90nml
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 # Local
 from payu.fsops import make_symlink
@@ -86,8 +88,7 @@ class UnifiedModel(Model):
         # Save model time to restart next run
         with open(os.path.join(self.restart_path,
                   self.restart_calendar_file), 'w') as restart_file:
-            restart_file.write(yaml.dump({'end_date': end_date},
-                               default_flow_style=False))
+            yaml.dump({'end_date': end_date}, restart_file)
 
         end_date = date_to_um_dump_date(end_date)
 
@@ -131,7 +132,7 @@ class UnifiedModel(Model):
         # Set up environment variables needed to run UM.
         um_env_path = os.path.join(self.control_path, 'um_env.yaml')
         with open(um_env_path, 'r') as um_env_yaml:
-            um_env_vars = yaml.safe_load(um_env_yaml)
+            um_env_vars = yaml.load(um_env_yaml)
 
 
         # Stage the UM restart file.
@@ -219,7 +220,7 @@ class UnifiedModel(Model):
             )
 
         with open(restart_calendar_path, 'r') as calendar_file:
-            date_info = yaml.safe_load(calendar_file)
+            date_info = yaml.load(calendar_file)
 
         restart_date = date_info['end_date']
         if not isinstance(restart_date, datetime.date):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dynamic = ["version"]
 dependencies = [
     "f90nml >=0.16",
     "yamanifest >=0.3.4",
-    "PyYAML",
     "requests",
     "python-dateutil",
     "tenacity >=8.0.0",

--- a/test/common.py
+++ b/test/common.py
@@ -5,7 +5,9 @@ from pathlib import Path
 import re
 import shutil
 
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 # Namespace clash if import setup_cmd.runcmd as setup. For
 # consistency use payu_ prefix for all commands
@@ -94,7 +96,7 @@ def get_manifests(mfdir):
     for mf in ['exe', 'input', 'restart']:
         mfpath = Path(mfdir)/"{}.yaml".format(mf)
         with mfpath.open() as fh:
-            manifests[mfpath.name] = list(yaml.safe_load_all(fh))[1]
+            manifests[mfpath.name] = list(yaml.load_all(fh))[1]
     return manifests
 
 
@@ -138,8 +140,7 @@ def payu_setup(model_type=None,
 
 def write_config(config, path=config_path):
     with path.open('w') as file:
-        file.write(yaml.dump(config, default_flow_style=False,
-                   sort_keys=False))
+        yaml.dump(config, file)
 
 
 def make_exe(exe_name=None):
@@ -220,7 +221,7 @@ def remove_expt_archive_dirs(type='restart'):
 
 def write_metadata(metadata=metadata, path=metadata_path):
     with path.open('w') as file:
-        file.write(yaml.dump(metadata, default_flow_style=False))
+        yaml.dump(metadata, file)
 
 
 def make_all_files():

--- a/test/models/test_mitgcm.py
+++ b/test/models/test_mitgcm.py
@@ -6,7 +6,9 @@ import shutil
 
 import f90nml
 import pytest
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 import payu
 
@@ -192,7 +194,7 @@ def test_setup_restartdir(config, data):
     mitgcm_restart['endtime'] = 12000.
 
     with (restartdir / 'mitgcm.res.yaml').open('w') as file:
-        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+        yaml.dump(mitgcm_restart, file)
 
     manifests = get_manifests(ctrldir/'manifests')
     payu_setup(lab_path=str(labdir))
@@ -254,7 +256,7 @@ def test_setup_change_deltat_no_start_end(config, data, case):
     mitgcm_restart['endtime'] = 12000.
 
     with (restartdir / 'mitgcm.res.yaml').open('w') as file:
-        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+        yaml.dump(mitgcm_restart, file)
 
     if case['ntimesteps'] == 10:
         # This should throw an error, as it would overwrite the existing
@@ -324,7 +326,7 @@ def test_setup_change_deltat_no_ntimesteps(config, data, case):
     mitgcm_restart['endtime'] = 12000.
 
     with (restartdir / 'mitgcm.res.yaml').open('w') as file:
-        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+        yaml.dump(mitgcm_restart, file)
 
     if case['deltat'] == 2400.:
         # This should throw an error, as it would overwrite the existing
@@ -398,7 +400,7 @@ def test_setup_change_deltat(config, data, case):
     mitgcm_restart['endtime'] = 12000.
 
     with (restartdir / 'mitgcm.res.yaml').open('w') as file:
-        file.write(yaml.dump(mitgcm_restart, default_flow_style=False))
+        yaml.dump(mitgcm_restart, file)
 
     payu_setup(lab_path=str(labdir))
 

--- a/test/models/test_um.py
+++ b/test/models/test_um.py
@@ -5,7 +5,9 @@ import shutil
 import pytest
 import datetime
 import cftime
-import yaml
+from ruamel.yaml import YAML
+yaml = YAML()
+yaml.default_flow_style = False
 
 import payu
 
@@ -68,8 +70,7 @@ def make_atmosphere_restart_dir(date,
                                      date.hour,
                                      date.minute,
                                      date.second)
-        um_cal_file.write(yaml.dump({'end_date': date_out},
-                                    default_flow_style=False))
+        yaml.dump({'end_date': date_out}, um_cal_file)
 
 
 @pytest.mark.parametrize(

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pdb
 import pytest
 import shutil
-import yaml
 
 import payu
 import payu.models.test

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -15,6 +15,7 @@ import payu.laboratory
 import payu.envmod
 
 from .common import tmpdir, cd
+from payu.fsops import duplicate_key_warning
 
 
 sys.path.insert(1, '../')
@@ -327,12 +328,7 @@ def test_needs_shell(command, expected):
 
 
 def test_read_config_yaml_duplicate_key(setup_test_dir):
-    """The PyYAML library is used for reading config.yaml, but use ruamel yaml
-    is used in when modifying config.yaml as part of payu checkout
-    (ruamel is used to preserve comments and multi-line strings).
-    This led to bug #441, where pyyaml allowed duplicate keys but
-    ruamel.library raises an error
-    """
+    """ Test that a warning is raised when a duplicate key is found """
     # Create a yaml file with a duplicate key
     config_content = """
 pbs_flags: value1
@@ -343,10 +339,9 @@ pbs_flags: value2
         file.write(config_content)
 
     # Test read config passes without an error but a warning is raised
-    warn_msg = "Duplicate key found in config.yaml: key 'pbs_flags' with "
-    warn_msg += "value 'value2'. This overwrites the original value: 'value1'"
-    with pytest.warns(UserWarning, match=warn_msg):
-        payu.fsops.read_config(config_path)
+    with pytest.warns(UserWarning, match=duplicate_key_warning):
+        config = payu.fsops.read_config(config_path)
+        assert config['pbs_flags'] == 'value1'  # Check that the first value is used
 
     restart_path = tmpdir / "restarts"
 

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 
 import pdb
 import pytest
-import yaml
 
 import payu
 


### PR DESCRIPTION
This PR adapts `ruamel.yaml` across payu, replacing `PyYAML`.

`ruamel.yaml` reserves the formatting and comments in yaml files. By default, it does not allow duplicate keys. To handle duplicate keys in config files, payu use `allow_duplicate_keys == True` when reading configs.

Ref #441 and #480.