### PR TITLE
cesm_cmeps driver: fix typo auxilary_input -> auxiliary_input

### DIFF
--- a/payu/models/cesm_cmeps.py
+++ b/payu/models/cesm_cmeps.py
@@ -97,7 +97,7 @@ class CesmCmeps(Model):
         ]
 
         self.input_dir = 'INPUT'
-        self.auxilary_input_dir = 'auxilary_input' # directory with extra input files in text format
+        self.auxiliary_input_dir = 'auxiliary_input' # directory with extra input files in text format
 
         self.realms = ["ocn", "ice", "wav", "atm", "rof", "cpl"]
         self.runconfig = None # nuopc.runconfig. Can't read this yet as paths haven't necessarily been set
@@ -148,7 +148,7 @@ class CesmCmeps(Model):
     def setup(self):
         super().setup()
 
-        self._setup_auxilary_input_dir()
+        self._setup_auxiliary_input_dir()
 
         # Read components from nuopc.runconfig
         self.get_components()
@@ -200,12 +200,12 @@ class CesmCmeps(Model):
                 # TODO: copied this from other models. Surely we want to exit here or something
                 print('payu: error: Unable to find mod_def.ww3 file in input directory')
 
-    def _setup_auxilary_input_dir(self):
+    def _setup_auxiliary_input_dir(self):
         # Special handling to also copy an extra folder for optional input files
         # e.g. mask_table, channel_list etc
-        src = os.path.join(self.control_path, self.auxilary_input_dir)
+        src = os.path.join(self.control_path, self.auxiliary_input_dir)
         if os.path.exists(src):
-            dest = os.path.join(self.work_path, self.auxilary_input_dir)
+            dest = os.path.join(self.work_path, self.auxiliary_input_dir)
             shutil.copytree(src, dest, symlinks=True)
 
     def _setup_checks(self):

--- a/test/models/access-om3/test_access_om3.py
+++ b/test/models/access-om3/test_access_om3.py
@@ -52,20 +52,20 @@ def cmeps_model(request):
 
 @pytest.fixture()
 def cmeps_model_opt_dir(cmeps_model):
-    # Create a auxilary_input_dir dir as well as normal cmeps_model
+    # Create a auxiliary_input_dir dir as well as normal cmeps_model
     model, expt = cmeps_model
 
     with cd(ctrldir):
-        os.makedirs(model.auxilary_input_dir)
+        os.makedirs(model.auxiliary_input_dir)
 
     yield cmeps_model
 
     with cd(ctrldir):
-        shutil.rmtree(model.auxilary_input_dir)
+        shutil.rmtree(model.auxiliary_input_dir)
 
     try:
         # delete the extra config dir from this modules work directory
-        shutil.rmtree(os.path.join(model.work_path,model.auxilary_input_dir))
+        shutil.rmtree(os.path.join(model.work_path,model.auxiliary_input_dir))
     except FileNotFoundError:
         pass
 
@@ -340,31 +340,31 @@ def test__setup_checks_bad_io_warn(cmeps_model, pio_numiotasks, pio_stride):
     ):
         model._setup_checks()
 
-# test auxilary_input directory is copied
+# test auxiliary_input directory is copied
 @pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("cmeps_model",[1], indirect=['cmeps_model'])
-def test_auxilary_input_dir(cmeps_model_opt_dir):
+def test_auxiliary_input_dir(cmeps_model_opt_dir):
 
     model, expt = cmeps_model_opt_dir
 
-    model._setup_auxilary_input_dir()
+    model._setup_auxiliary_input_dir()
 
     assert ( 
-        os.path.isdir(os.path.join(model.work_path,model.auxilary_input_dir)) 
-    ), "auxilary_input directory not copied into work directory from config directory"
+        os.path.isdir(os.path.join(model.work_path,model.auxiliary_input_dir)) 
+    ), "auxiliary_input directory not copied into work directory from config directory"
 
 # test extra config files directory isn't required
 @pytest.mark.filterwarnings("error")
 @pytest.mark.parametrize("cmeps_model",[1], indirect=['cmeps_model'])
-def test_auxilary_input_dir_not_required(cmeps_model):
+def test_auxiliary_input_dir_not_required(cmeps_model):
 
     model, expt = cmeps_model
 
-    model._setup_auxilary_input_dir()
+    model._setup_auxiliary_input_dir()
 
     assert (
-        os.path.isdir(os.path.join(model.work_path,model.auxilary_input_dir)) is False
-    ), "auxilary_input directory exists in work without it existing in config directory"
+        os.path.isdir(os.path.join(model.work_path,model.auxiliary_input_dir)) is False
+    ), "auxiliary_input directory exists in work without it existing in config directory"
 
 
 # test restart datetime pruning


### PR DESCRIPTION
Fixes typo in `cesm_cmeps` driver: `auxilary_input` -> `auxiliary_input`

Closes #745 