### PR TITLE
Fix missing warning in PBS.

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -33,11 +33,10 @@ from payu.telemetry import write_queued_job_file
 # Default configuration
 DEFAULT_CONFIG = 'config.yaml'
 
-# Pass the warning through the logger
-logging.captureWarnings(True)
-
 def parse():
     """Parse the command line inputs and execute the subcommand."""
+    # Pass the warning through the logger
+    logging.captureWarnings(True)
     setup_logger()
     parser = generate_parser(is_interactive = True)
 


### PR DESCRIPTION
Configure logging in PBS so warning appears in `std.err`.
Ref [comment](https://github.com/payu-org/payu/pull/713#discussion_r3285098967) .

The formatting of warning messages in PBS will be addressed in another PR.