### PR TITLE
Add option to specify experiment name prefix.

### DIFF
--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -143,9 +143,6 @@ class Metadata:
 
     def new_experiment_name(self) -> str:
         """Generate a new experiment name"""
-        # Get expt prefix from config
-        expt_name_prefix = self.config.get("experiment_name_prefix", None)
-
         if self.branch is None:
             self.branch = self.repo.get_branch_name()
 
@@ -157,8 +154,8 @@ class Metadata:
         suffix += f'-{truncated_uuid}'
 
         # If experiment name prefix is configured and not empty, expt name is prefix-branch-UUID
-        if expt_name_prefix:
-            return expt_name_prefix + suffix
+        if self.expt_name_prefix and self.expt_name_prefix.strip():
+            return self.expt_name_prefix + suffix
         # Otherwise, expt name is ctrl_dir_name-branch-UUID
         else:
             return self.control_path.name + suffix
@@ -170,7 +167,14 @@ class Metadata:
         sub-directories in the Laboratory"""
         # Experiment name configuration - this overrides experiment name
         self.experiment_name = self.config.get("experiment", None)
-        if self.experiment_name is not None:
+        self.expt_name_prefix = self.config.get("experiment_prefix", None)
+
+        if self.experiment_name is not None and self.experiment_name.strip():
+            # Check if experiment prefix is also configured and warn that it will be ignored
+            if self.expt_name_prefix and self.expt_name_prefix.strip():
+                warnings.warn("Both experiment name and prefix are configured in config.yaml.\n"
+                            "Only the experiment name will be used, while the experiment prefix is ignored.",
+                            UserWarning)
             print(f"Experiment name is configured in config.yaml: ",
                   self.experiment_name)
             return

--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -143,6 +143,9 @@ class Metadata:
 
     def new_experiment_name(self) -> str:
         """Generate a new experiment name"""
+        # Get expt prefix from config
+        expt_name_prefix = self.config.get("experiment_name_prefix", None)
+
         if self.branch is None:
             self.branch = self.repo.get_branch_name()
 
@@ -153,7 +156,12 @@ class Metadata:
         truncated_uuid = self.uuid[:TRUNCATED_UUID_LENGTH]
         suffix += f'-{truncated_uuid}'
 
-        return self.control_path.name + suffix
+        # If experiment name prefix is configured and not empty, expt name is prefix-branch-UUID
+        if expt_name_prefix:
+            return expt_name_prefix + suffix
+        # Otherwise, expt name is ctrl_dir_name-branch-UUID
+        else:
+            return self.control_path.name + suffix
 
     def set_experiment_name(self,
                             is_new_experiment: bool = False,

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -348,6 +348,33 @@ def test_new_experiment_name(branch, expected_name):
     assert experiment == expected_name
 
 
+@pytest.mark.parametrize(
+    "expt_name_prefix, branch, expected_name",
+    [
+        (None, "branch", "ctrl-branch-cb793e91"),
+        ("", "branch", "ctrl-branch-cb793e91"),
+        ("imprefix", None, "imprefix-cb793e91"),
+        ("hiprefix", "branch", "hiprefix-branch-cb793e91"),
+        ("ohprefix", "master", "ohprefix-cb793e91"),
+    ]
+)
+def test_new_experiment_name_with_prefix(expt_name_prefix, branch, expected_name):
+    """ Test experiment name is prefix with branch and UUID suffix"""
+    # Setup config
+    test_config = config.copy()
+    test_config['experiment_name_prefix'] = expt_name_prefix
+    write_config(test_config)
+    with cd(ctrldir):
+        metadata = Metadata(archive_dir)
+
+    metadata.uuid = "cb793e91-6168-4ed2-a70c-f6f9ccf1659b"
+
+    with patch('payu.metadata.GitRepository.get_branch_name') as mock_branch:
+        mock_branch.return_value = branch
+        experiment = metadata.new_experiment_name()
+
+    assert experiment == expected_name
+
 def test_metadata_enable_false():
     # Set metadata to false in config file
     test_config = copy.deepcopy(config)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -340,6 +340,7 @@ def test_new_experiment_name(branch, expected_name):
         metadata = Metadata(archive_dir)
 
     metadata.uuid = "cb793e91-6168-4ed2-a70c-f6f9ccf1659b"
+    metadata.expt_name_prefix = None
 
     with patch('payu.metadata.GitRepository.get_branch_name') as mock_branch:
         mock_branch.return_value = branch
@@ -352,7 +353,7 @@ def test_new_experiment_name(branch, expected_name):
     "expt_name_prefix, branch, expected_name",
     [
         (None, "branch", "ctrl-branch-cb793e91"),
-        ("", "branch", "ctrl-branch-cb793e91"),
+        (" ", "branch", "ctrl-branch-cb793e91"),
         ("imprefix", None, "imprefix-cb793e91"),
         ("hiprefix", "branch", "hiprefix-branch-cb793e91"),
         ("ohprefix", "master", "ohprefix-cb793e91"),
@@ -362,7 +363,7 @@ def test_new_experiment_name_with_prefix(expt_name_prefix, branch, expected_name
     """ Test experiment name is prefix with branch and UUID suffix"""
     # Setup config
     test_config = config.copy()
-    test_config['experiment_name_prefix'] = expt_name_prefix
+    test_config['experiment_prefix'] = expt_name_prefix
     write_config(test_config)
     with cd(ctrldir):
         metadata = Metadata(archive_dir)
@@ -371,9 +372,29 @@ def test_new_experiment_name_with_prefix(expt_name_prefix, branch, expected_name
 
     with patch('payu.metadata.GitRepository.get_branch_name') as mock_branch:
         mock_branch.return_value = branch
+        metadata.expt_name_prefix = metadata.config.get("experiment_prefix", None)
         experiment = metadata.new_experiment_name()
 
     assert experiment == expected_name
+
+
+def test_experiment_name_with_prefix_and_experiment():
+    """Test when both experiment name and prefix are set, a warning is raised and
+    new_experiment_name() is not called, experiment name is used directly."""
+    # Setup config
+    test_config = config.copy()
+    test_config['experiment_prefix'] = "IAMprefix"
+    test_config['experiment'] = "IAMexpt"
+    write_config(test_config)
+    with cd(ctrldir):
+        metadata = Metadata(archive_dir)
+
+    with patch.object(metadata, 'new_experiment_name') as mock_new_experiment_name:
+        with pytest.warns(UserWarning, match="Both experiment name and prefix are configured in config.yaml.\n"):
+            metadata.set_experiment_name()
+
+        mock_new_experiment_name.assert_not_called()
+
 
 def test_metadata_enable_false():
     # Set metadata to false in config file


### PR DESCRIPTION
This PR adds an option for user to specify `experiment_prefix` in the `config.yaml`.

- When `experiment_prefix` is configured and not empty, the experiment name is set to `${prefix}-{branch}-{UUID}`. In this case, control directory name is not included in the experiment name.
- When `experiment_prefix` is not configured, the experiment name remains as `${ctrl_dir_name}-{branch}-{UUID}`. 

The logic of prioritising `experiment` in the `config.yaml` remains unchanged, i.e., once `experiment` is configured and not empty, the experiment name will be the exact same as the configuration.

Closes #746 