### PR TITLE
Check user access to project before submitting PBS job.

### DIFF
--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -115,12 +115,11 @@ def _run_pbsnodes_json(timeout: int) -> Dict[str, Any]:
         ) from e
 
 
-def check_user_in_group(group_name: str) -> bool:
-    """Check if the current user is in a specific group."""
+def get_user_groups() -> list:
+    """Get the list of all groups the current user is in."""
     try:
         # get what groups the current user is in
-        user_groups = [grp.getgrgid(gid).gr_name for gid in os.getgroups()]
-        return group_name in user_groups
+        return [grp.getgrgid(gid).gr_name for gid in os.getgroups()]
     except Exception as e:
         # If the group doesn't exist, return False
         raise RuntimeError(f"Error checking group membership for current user: {e}")
@@ -289,10 +288,11 @@ class PBS(Scheduler):
         pbs_flags.append('-q {queue}'.format(queue=pbs_queue))
 
         pbs_project = pbs_config.get('project', os.environ['PROJECT'])
-        if check_user_in_group(pbs_project):
+        user_groups = get_user_groups()
+        if pbs_project in user_groups:
             pbs_flags.append('-P {project}'.format(project=pbs_project))
         else:
-            raise RuntimeError(f"payu: error: User is not in project group '{pbs_project}' specified in config")
+            raise RuntimeError(f"payu: error: User is not a member of the project '{pbs_project}' specified in config:project.\n")
 
         pbs_resources = ['walltime', 'ncpus', 'mem', 'jobfs']
 
@@ -381,6 +381,15 @@ class PBS(Scheduler):
 
             # Add the container launcher script path to storage flags
             storages.update(find_mounts(launcher_script, mounts))
+
+        # Check if user has access to all storages paths, and raise error if not
+        denied_storages = []
+        for storage in storages:
+            mount, project = storage.split(os.path.sep)
+            if project not in user_groups:
+                denied_storages.append(storage)
+        if len(denied_storages) > 0:
+            raise RuntimeError(f"payu: error: User is not a member of the following storage projects: {', '.join(denied_storages)}.\n")
 
         # Add storage flags. Note that these are sorted to get predictable
         # behaviour for testing

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -123,6 +123,16 @@ def get_user_groups() -> list:
     except Exception as e:
         # If the group doesn't exist, return False
         raise RuntimeError(f"Error checking group membership for current user: {e}")
+    
+def check_storage_access(storages: set, user_groups: list):
+    """Check if the user has access to all storage paths, and raise error if not."""
+    denied_storages = []
+    for storage in storages:
+        _, project = storage.split(os.path.sep)
+        if project not in user_groups:
+            denied_storages.append(storage)
+    if len(denied_storages) > 0:
+        raise RuntimeError(f"payu: error: User is not a member of the following required storage projects: {', '.join(denied_storages)}.\n")
 
 
 # TODO: This is a stub acting as a minimal port to a Scheduler class.
@@ -383,13 +393,7 @@ class PBS(Scheduler):
             storages.update(find_mounts(launcher_script, mounts))
 
         # Check if user has access to all storages paths, and raise error if not
-        denied_storages = []
-        for storage in storages:
-            mount, project = storage.split(os.path.sep)
-            if project not in user_groups:
-                denied_storages.append(storage)
-        if len(denied_storages) > 0:
-            raise RuntimeError(f"payu: error: User is not a member of the following storage projects: {', '.join(denied_storages)}.\n")
+        check_storage_access(storages, user_groups)
 
         # Add storage flags. Note that these are sorted to get predictable
         # behaviour for testing

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -14,6 +14,7 @@ import subprocess
 from typing import Any, Dict, Optional
 import warnings
 from collections import Counter
+import grp
 
 import json
 from tenacity import retry, stop_after_delay
@@ -112,6 +113,17 @@ def _run_pbsnodes_json(timeout: int) -> Dict[str, Any]:
             f"Failed to decode JSON output from pbsnodes command: {' '.join(cmd)}"
             f"\n Output: {error_msg}"
         ) from e
+
+
+def check_user_in_group(group_name: str) -> bool:
+    """Check if the current user is in a specific group."""
+    try:
+        # get what groups the current user is in
+        user_groups = [grp.getgrgid(gid).gr_name for gid in os.getgroups()]
+        return group_name in user_groups
+    except Exception as e:
+        # If the group doesn't exist, return False
+        raise RuntimeError(f"Error checking group membership for current user: {e}")
 
 
 # TODO: This is a stub acting as a minimal port to a Scheduler class.
@@ -277,7 +289,10 @@ class PBS(Scheduler):
         pbs_flags.append('-q {queue}'.format(queue=pbs_queue))
 
         pbs_project = pbs_config.get('project', os.environ['PROJECT'])
-        pbs_flags.append('-P {project}'.format(project=pbs_project))
+        if check_user_in_group(pbs_project):
+            pbs_flags.append('-P {project}'.format(project=pbs_project))
+        else:
+            raise RuntimeError(f"payu: error: User is not in project group '{pbs_project}' specified in config")
 
         pbs_resources = ['walltime', 'ncpus', 'mem', 'jobfs']
 

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -571,3 +571,24 @@ def test_get_user_groups_error(mock_getgrgid, mock_getgroups):
 
     with pytest.raises(RuntimeError, match=r"Error checking group membership for current user: 'Groupid not found'"):
         pbs.get_user_groups()
+
+
+@pytest.mark.parametrize(
+    "storages, user_groups, expected_denied",
+    [
+        ({"fdata/x00", "fdata/y00"}, ['x00', 'y00', 'z00'], []),  # All storages accessible
+        ({"fdata/x00", "fdata/a00"}, ['x00', 'y00', 'z00'], ["fdata/a00"]),  # One storage denied
+        ({"fdata/a00", "fdata/b00"}, ['x00', 'y00', 'z00'], ["fdata/a00", "fdata/b00"]),  # All storages denied
+    ]
+)
+def test_check_storage_access(storages, user_groups, expected_denied):
+    """Test that check_storage_access correctly identifies denied storages."""
+    if len(expected_denied) > 0:
+        with pytest.raises(RuntimeError, match="User is not a member of the following required storage projects") as exc_info:
+            pbs.check_storage_access(storages, user_groups)
+        for denied in expected_denied:
+            assert denied in str(exc_info.value)
+
+    else:
+        # Test with all storages accessible
+        pbs.check_storage_access(storages, user_groups)

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -358,8 +358,8 @@ def test_find_mounts():
 
     assert(pbs.find_mounts(paths, mounts) == set(['fdata/x00', ]))
 
-
-def test_run():
+@patch("payu.schedulers.pbs.check_user_in_group", return_value=True)
+def test_run(mock_check_user_in_group):
 
     # Use new mechanism to return a scheduler
     sched_name = config.get('scheduler', 'pbs')
@@ -460,6 +460,7 @@ def test_run():
 
 @patch("payu.schedulers.pbs.pbs_env_init", return_value=True)
 @patch("payu.schedulers.pbs.check_exe_path", side_effect=lambda x, y: y)
+@patch("payu.schedulers.pbs.check_user_in_group", return_value=True)
 @pytest.mark.parametrize(
     "env_exists,file_exists,file_exe,expected_cmd",
     [
@@ -474,7 +475,7 @@ def test_run():
     ],
 )
 def test_submit_launcher_script_setting(
-    mock_pbs_env_init, mock_check_exe_path,
+    mock_pbs_env_init, mock_check_exe_path, mock_check_user_in_group,
     env_exists, file_exists, file_exe, expected_cmd, tmp_path, monkeypatch
 ):
     config = {
@@ -546,3 +547,27 @@ def test_get_all_job_info(monkeypatch):
     monkeypatch.setattr(pbs, "get_job_info_json", lambda: fake_qstat)
     result = PBS().get_all_job_info()
     assert result == expected
+
+@patch('os.getgroups')
+@patch('grp.getgrgid')
+def test_check_user_in_group(mock_getgrgid, mock_getgroups):
+    """Test that check_user_in_group correctly identifies group membership."""
+    mock_getgroups.return_value = [1000, 1001, 1002]
+
+    # Create a mock for grp.getgrgid that returns {'gr_name': 'group{gid}'}
+    mock_getgrgid.side_effect = lambda gid: type('grp_struct', (object,), {'gr_name': f'group{gid}'})
+
+    assert pbs.check_user_in_group('group1000') == True
+    assert pbs.check_user_in_group('group1001') == True
+    assert pbs.check_user_in_group('group1002') == True
+    assert pbs.check_user_in_group('group9999') == False
+
+@patch('os.getgroups')
+@patch('grp.getgrgid')
+def test_check_user_in_group_error(mock_getgrgid, mock_getgroups):
+    """ Test that check_user_in_group handles errors from grp.getgrgid."""
+    mock_getgroups.return_value = [1000, 1001, 1002]
+    mock_getgrgid.side_effect = KeyError("Groupid not found")
+
+    with pytest.raises(RuntimeError, match=r"Error checking group membership for current user: 'Groupid not found'"):
+        pbs.check_user_in_group('group1000')

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -31,6 +31,8 @@ verbose = True
 
 config = copy.deepcopy(original_config)
 
+test_storage_groups = ['x00', 'xyz999', 'y00', 'c000', 'mm02', 'm000', 'mm01', 'a000', 'tm70', 'aa30']
+
 
 def _fake_pbsnodes_dict(nodes):
     """Build a pbsnodes -F json compatible payload."""
@@ -358,8 +360,8 @@ def test_find_mounts():
 
     assert(pbs.find_mounts(paths, mounts) == set(['fdata/x00', ]))
 
-@patch("payu.schedulers.pbs.check_user_in_group", return_value=True)
-def test_run(mock_check_user_in_group):
+@patch("payu.schedulers.pbs.get_user_groups", return_value=test_storage_groups)
+def test_run(mock_get_user_groups):
 
     # Use new mechanism to return a scheduler
     sched_name = config.get('scheduler', 'pbs')
@@ -460,7 +462,7 @@ def test_run(mock_check_user_in_group):
 
 @patch("payu.schedulers.pbs.pbs_env_init", return_value=True)
 @patch("payu.schedulers.pbs.check_exe_path", side_effect=lambda x, y: y)
-@patch("payu.schedulers.pbs.check_user_in_group", return_value=True)
+@patch("payu.schedulers.pbs.get_user_groups", return_value=test_storage_groups)
 @pytest.mark.parametrize(
     "env_exists,file_exists,file_exe,expected_cmd",
     [
@@ -475,7 +477,7 @@ def test_run(mock_check_user_in_group):
     ],
 )
 def test_submit_launcher_script_setting(
-    mock_pbs_env_init, mock_check_exe_path, mock_check_user_in_group,
+    mock_pbs_env_init, mock_check_exe_path, mock_get_user_groups,
     env_exists, file_exists, file_exe, expected_cmd, tmp_path, monkeypatch
 ):
     config = {
@@ -550,24 +552,22 @@ def test_get_all_job_info(monkeypatch):
 
 @patch('os.getgroups')
 @patch('grp.getgrgid')
-def test_check_user_in_group(mock_getgrgid, mock_getgroups):
-    """Test that check_user_in_group correctly identifies group membership."""
+def test_get_user_groups(mock_getgrgid, mock_getgroups):
+    """Test that get_user_groups returns the correct list of groups."""
     mock_getgroups.return_value = [1000, 1001, 1002]
 
     # Create a mock for grp.getgrgid that returns {'gr_name': 'group{gid}'}
     mock_getgrgid.side_effect = lambda gid: type('grp_struct', (object,), {'gr_name': f'group{gid}'})
 
-    assert pbs.check_user_in_group('group1000') == True
-    assert pbs.check_user_in_group('group1001') == True
-    assert pbs.check_user_in_group('group1002') == True
-    assert pbs.check_user_in_group('group9999') == False
+    assert pbs.get_user_groups() == ['group1000', 'group1001', 'group1002']
+
 
 @patch('os.getgroups')
 @patch('grp.getgrgid')
-def test_check_user_in_group_error(mock_getgrgid, mock_getgroups):
-    """ Test that check_user_in_group handles errors from grp.getgrgid."""
+def test_get_user_groups_error(mock_getgrgid, mock_getgroups):
+    """ Test that get_user_groups handles errors from grp.getgrgid."""
     mock_getgroups.return_value = [1000, 1001, 1002]
     mock_getgrgid.side_effect = KeyError("Groupid not found")
 
     with pytest.raises(RuntimeError, match=r"Error checking group membership for current user: 'Groupid not found'"):
-        pbs.check_user_in_group('group1000')
+        pbs.get_user_groups()


### PR DESCRIPTION
This PR adds a validation step before submitting PBS jobs: 
payu now checks whether the user has access to the project specified in `config.yaml`. If the user’s groups do not include the nominated project, payu will exit with an error immediately instead of submitting the PBS job.

Closes #669.