### PR TITLE
Add informative error message to cli.submit_job and lab.init

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -219,7 +219,20 @@ def submit_job(script, config, vars=None, expt=None, current_run=None, type=None
     cmd = sched.submit(script, config, vars)
     print(cmd)
 
-    result = subprocess.run(shlex.split(cmd), capture_output=True, check=True)
+    try:
+        result = subprocess.run(shlex.split(cmd), capture_output=True, check=True)
+
+    except subprocess.CalledProcessError as e:
+        error_msg = ("Error occurred while submitting job.\n")
+
+        if e.returncode:
+            error_msg += f"Exit code: {e.returncode}\n"
+        if e.stdout:
+            error_msg += f"STDOUT: {e.stdout.decode('utf8')}\n"
+        if e.stderr:
+            error_msg += f"STDERR: {e.stderr.decode('utf8')}"
+
+        raise RuntimeError(error_msg)
 
     # Decode stdout and extract the job ID which is last for both PBS and Slurm
     result = result.stdout.decode("utf8").strip()

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -220,7 +220,7 @@ def submit_job(script, config, vars=None, expt=None, current_run=None, type=None
     print(cmd)
 
     try:
-        result = subprocess.run(shlex.split(cmd), capture_output=True, check=True)
+        result = subprocess.run(shlex.split(cmd), capture_output=True, check=True, text=True)
 
     except subprocess.CalledProcessError as e:
         error_msg = ("Error occurred while submitting job.\n")
@@ -228,14 +228,14 @@ def submit_job(script, config, vars=None, expt=None, current_run=None, type=None
         if e.returncode:
             error_msg += f"Exit code: {e.returncode}\n"
         if e.stdout:
-            error_msg += f"STDOUT: {e.stdout.decode('utf8')}\n"
+            error_msg += f"STDOUT: {e.stdout}\n"
         if e.stderr:
-            error_msg += f"STDERR: {e.stderr.decode('utf8')}"
+            error_msg += f"STDERR: {e.stderr}"
 
         raise RuntimeError(error_msg)
 
     # Decode stdout and extract the job ID which is last for both PBS and Slurm
-    result = result.stdout.decode("utf8").strip()
+    result = result.stdout.strip()
     print(result)
     job_id = result.split()[-1]
 

--- a/payu/laboratory.py
+++ b/payu/laboratory.py
@@ -38,7 +38,8 @@ class Laboratory(object):
             model_type = config.get('model')
 
         if not model_type:
-            raise ValueError('Cannot determine model type.')
+            raise ValueError("Cannot determine model type.\n"
+                             "Please ensure payu is running from an experiment control directory containing a config file.")
 
         self.model_type = model_type
 

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -5,6 +5,7 @@
 """
 
 # Standard library
+import math
 import os
 from pathlib import Path
 import re
@@ -251,6 +252,37 @@ class PBS(Scheduler):
             )
 
     @staticmethod
+    def mem_string_to_gb(size_str: str):
+        """
+        Convert size string to gigabytes.
+        Input size is expressed as:
+            integer[suffix]
+        where suffix can be one of "b", "kb", "mb", "gb", "tb", "pb",
+        """
+        size_str = size_str.lower()
+        suffixes = {
+            "kb": 1/(1024**2),
+            "mb": 1/1024,
+            "gb": 1,
+            "tb": 1024,
+            "pb": 1024**2,
+            "b": 1/(1024**3),
+        }
+
+        for suffix, multiplier in suffixes.items():
+            if size_str.endswith(suffix):
+                # Remove the suffix and convert to float
+                size_str = size_str[: -len(suffix)]
+                return float(size_str) * multiplier
+
+        # If no suffix is found, assume it's in bytes
+        warnings.warn(
+            f"Memory string '{size_str}' has no unit suffix, assuming bytes.\n "
+            "It is recommended to specify units explicitly (e.g. '100GB')."
+        )
+        return float(size_str)/(1024**3)
+    
+    @staticmethod
     def _mem_convert_kb_to_gb(mem_kb: str) -> int:
         s = str(mem_kb).strip().lower()
         if not s.endswith("kb"):
@@ -289,26 +321,21 @@ class PBS(Scheduler):
         queue: the queue name
         n_cpus: the number of CPUs requested.
         """
-        # Change the unit of memory to GB
-        if pbs_mem.lower().endswith("tb"):
-            req_mem_gb = float(pbs_mem[:-2]) * 1024
-        elif pbs_mem.lower().endswith("gb"):
-            req_mem_gb = float(pbs_mem[:-2])
-        elif pbs_mem.lower().endswith("mb"):
-            req_mem_gb = float(pbs_mem[:-2]) / 1024
-        else:
-            raise ValueError(f"Memory string '{pbs_mem}' has invalid format, must end with TB, GB, or MB.")
+        try:
+            req_mem_gb = cls.mem_string_to_gb(pbs_mem)
+        except ValueError:
+            raise ValueError(f"Memory string '{pbs_mem}' has invalid format, must end with PB, TB, GB, MB, KB, B, or no unit.")
         
         # Get the node shape for the queue
         cpu_per_node, mem_per_node = cls.get_queue_node_shape(queue)
         
-        # Calculate the requested memory per node
-        req_mem_per_node = req_mem_gb / n_cpus * cpu_per_node
+        # Calculate the requested memory per node, node number is rounded up
+        req_mem_per_node = req_mem_gb / math.ceil(n_cpus / cpu_per_node)
 
         if req_mem_per_node > mem_per_node:
             raise ValueError(
-                f"You have requested more memory of {pbs_mem} ({req_mem_per_node:.2f} GB per node) "
-                f"than the limit of {mem_per_node:.2f} GB per node for queue '{queue}'."
+                f"You have requested more memory of {pbs_mem} (i.e., {req_mem_per_node:.2f}GB per node) "
+                f"than the limit of {mem_per_node:.2f}GB per node for queue '{queue}'."
             )
 
     def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None):

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -279,6 +279,38 @@ class PBS(Scheduler):
 
         return Counter(ncpus).most_common(1)[0][0], Counter(mem).most_common(1)[0][0]
 
+    @classmethod
+    def validate_memory_with_queue_limits(cls, pbs_mem: str, queue: str, n_cpus: int):
+        """
+        Validate the requested memory against the queue limits.
+        ----
+        Parameters:
+        pbs_mem: requested memory string from the config.
+        queue: the queue name
+        n_cpus: the number of CPUs requested.
+        """
+        # Change the unit of memory to GB
+        if pbs_mem.lower().endswith("tb"):
+            req_mem_gb = float(pbs_mem[:-2]) * 1024
+        elif pbs_mem.lower().endswith("gb"):
+            req_mem_gb = float(pbs_mem[:-2])
+        elif pbs_mem.lower().endswith("mb"):
+            req_mem_gb = float(pbs_mem[:-2]) / 1024
+        else:
+            raise ValueError(f"Memory string '{pbs_mem}' has invalid format, must end with TB, GB, or MB.")
+        
+        # Get the node shape for the queue
+        cpu_per_node, mem_per_node = cls.get_queue_node_shape(queue)
+        
+        # Calculate the requested memory per node
+        req_mem_per_node = req_mem_gb / n_cpus * cpu_per_node
+
+        if req_mem_per_node > mem_per_node:
+            raise ValueError(
+                f"You have requested more memory of {pbs_mem} ({req_mem_per_node:.2f} GB per node) "
+                f"than the limit of {mem_per_node:.2f} GB per node for queue '{queue}'."
+            )
+
     def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None):
         """Prepare a correct PBS command string"""
 

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 import re
 import sys
-import shlex
+from pint import UnitRegistry
 import subprocess
 from typing import Any, Dict, Optional
 import warnings
@@ -30,6 +30,8 @@ from payu.schedulers.scheduler import Scheduler
 PBSNODE_TIMEOUT = 60
 LOCK_TIMEOUT = 5
 LOCK_LIFETIME = 8
+
+ureg = UnitRegistry()
 
 def get_pbsnodes_cache_path() -> Path:
     """Get the path of pbsnodes.json cache file, 
@@ -261,26 +263,26 @@ class PBS(Scheduler):
         """
         size_str = size_str.lower()
         suffixes = {
-            "kb": 1/(1024**2),
-            "mb": 1/1024,
-            "gb": 1,
-            "tb": 1024,
-            "pb": 1024**2,
-            "b": 1/(1024**3),
+            "kb": ureg.kibibyte,
+            "mb": ureg.mebibyte,
+            "gb": ureg.gibibyte,
+            "tb": ureg.tebibyte,
+            "pb": ureg.pebibyte,
+            "b": ureg.byte,
         }
 
-        for suffix, multiplier in suffixes.items():
+        for suffix, unit in suffixes.items():
             if size_str.endswith(suffix):
                 # Remove the suffix and convert to float
                 size_str = size_str[: -len(suffix)]
-                return float(size_str) * multiplier
+                return (float(size_str) * unit).to(ureg.gibibyte).magnitude
 
         # If no suffix is found, assume it's in bytes
         warnings.warn(
             f"Memory string '{size_str}' has no unit suffix, assuming bytes.\n "
             "It is recommended to specify units explicitly (e.g. '100GB')."
         )
-        return float(size_str)/(1024**3)
+        return (float(size_str) * ureg.byte).to(ureg.gibibyte).magnitude
     
     @staticmethod
     def _mem_convert_kb_to_gb(mem_kb: str) -> int:

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -156,9 +156,17 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
     else:
         raise ValueError("Walltime must be specified in the configuration for scheduler jobs.")
 
-    # Set memory to use the complete node if unspecified
     pbs_mem = pbs_config.get('mem')
-    if not pbs_mem:
+    if pbs_mem:
+        # Validate the memory request
+        if expt.scheduler_name == "pbs":
+            PBS.validate_memory_with_queue_limits(pbs_mem, queue, n_cpus)
+        if expt.scheduler_name == "slurm":
+            # TODO for non-PBS schedulers, such as Sotonix slurm setup on Pawsey
+            pass
+    else:
+        # If memory is not specified,
+        # Get full node memory if requesting more than a node, otherwise scale with CPU request
         if n_cpus > max_cpus_per_node:
             pbs_mem = (n_cpus // max_cpus_per_node) * max_ram_per_node
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "colorama",
     "filelock",
     "questionary",
-    "prompt_toolkit >=3.0.0"
+    "pint",
 ]
 
 [project.optional-dependencies]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,19 +1,14 @@
+import subprocess
+
 import pytest
 import shlex
 import sys
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import warnings
 import logging
 
 import payu
 import payu.cli
-
-from .common import cd, make_random_file, get_manifests
-from .common import tmpdir, ctrldir, labdir, workdir
-from .common import sweep_work, payu_init, payu_setup
-from .common import config as config_orig
-from .common import write_config
-from .common import make_exe, make_inputs, make_restarts, make_all_files
 
 verbose = True
 ORIGINAL_WARNING = warnings.formatwarning
@@ -463,3 +458,29 @@ def test__parse_runscript_error():
     """Test that the _parse_runscript raise an error when command is not found."""
     with pytest.raises(ImportError, match="payu: error: Unknown runscript command payu-invalid"):
         payu.cli._parse_runscript("invalid")
+
+        
+def test_submit_job_error_msg():
+    """Test that informative error message is raised when job submission fails."""
+    # Set up a mock scheduler that returns a submission command
+    mock_sched = MagicMock()
+    mock_sched.submit.return_value = "qsub submit_script.sh"
+    mock_sched_type = MagicMock(return_value=mock_sched)
+    mock_index = {'PBS': mock_sched_type}
+
+    # Set up a failing subprocess.run
+    mock_sprun = MagicMock()
+    mock_sprun.side_effect = subprocess.CalledProcessError(
+        returncode=32, 
+        cmd="qsub submit_script.sh", 
+        output=b"Submission failed", 
+        stderr=b"Error details here")
+
+    with patch("payu.cli.scheduler_index", mock_index), \
+         patch("subprocess.run", mock_sprun):
+        with pytest.raises(RuntimeError) as exc_info:
+            payu.cli.submit_job(config={"scheduler": "PBS"}, script="submit_script.sh")
+            assert "Error occurred while submitting job." in str(exc_info.value)
+            assert "Exit code: 32" in str(exc_info.value)
+            assert "STDOUT: Submission failed" in str(exc_info.value)
+            assert "STDERR: Error details here" in str(exc_info.value)

--- a/test/test_payu.py
+++ b/test/test_payu.py
@@ -138,6 +138,12 @@ def test_lab_new():
     lab = payu.laboratory.Laboratory('model')
     sys.stdout = sys.__stdout__
 
+def test_lab_no_model():
+    """Test that lab raises an error if model type cannot be determined"""
+    error_msg = "Cannot determine model type.\nPlease ensure payu is running from an experiment control directory containing a config file."
+    with pytest.raises(ValueError, match=error_msg):
+        payu.laboratory.Laboratory()
+
 
 def test_parse_ldd_output():
     ldd_output_path = os.path.join('test', 'resources', 'sample_ldd_output.txt')

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -592,3 +592,40 @@ def test_check_storage_access(storages, user_groups, expected_denied):
     else:
         # Test with all storages accessible
         pbs.check_storage_access(storages, user_groups)
+
+
+@pytest.mark.parametrize(
+    "pbs_mem, queue, n_cpus, raise_error",
+    [   
+        ("1TB", "normalsr", 48, True),  # Exceeds max memory for normalsr
+        ("1300GB", "normalsr", 48, True),  # Exceeds max memory for normalsr
+        ("100GB", "normalsr", 48, False),  # Valid memory
+        ("100MB", "normalsr", 48, False),  # Valid memory
+        ("0.1TB", "normalsr", 48, False),  # Valid memory
+    ]
+)
+@patch("payu.schedulers.pbs.PBS.get_queue_node_shape", return_value=(48, 192))
+def test_validate_memory_with_queue_limits(mock_get_queue_node_shape, pbs_mem, queue, n_cpus, raise_error):
+    """Test that an error is raised if the memory request exceeds queue limits."""
+    if raise_error:
+        with pytest.raises(ValueError, match=fr"You have requested more memory of {pbs_mem}"):
+            PBS.validate_memory_with_queue_limits(pbs_mem, queue, n_cpus)
+    else:
+        # Test with valid memory request
+        PBS.validate_memory_with_queue_limits(pbs_mem, queue, n_cpus)
+
+
+@pytest.mark.parametrize(
+    "pbs_mem",
+    [   
+        ("100"),  # Missing unit
+        ("100GBs"),  # Invalid unit
+        ("100 G"),  # Invalid format with space
+        ("100KB"), # Not acceptable unit
+    ]
+)
+@patch("payu.schedulers.pbs.PBS.get_queue_node_shape", return_value=(48, 192))
+def test_validate_memory_with_queue_limits_format(mock_get_queue_node_shape, pbs_mem):
+    """Test that an error is raised if the memory string format is invalid."""
+    with pytest.raises(ValueError, match=fr"Memory string '{pbs_mem}' has invalid format, must end with TB, GB, or MB."):
+        PBS.validate_memory_with_queue_limits(pbs_mem, "normalsr", 48) 

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -602,6 +602,11 @@ def test_check_storage_access(storages, user_groups, expected_denied):
         ("100GB", "normalsr", 48, False),  # Valid memory
         ("100MB", "normalsr", 48, False),  # Valid memory
         ("0.1TB", "normalsr", 48, False),  # Valid memory
+        ("100000", "normalsr", 48, False),  # Valid memory
+        ("192GB", "normalsr", 48, False),  # Exactly at the limit for normalsr
+        ("192GB", "normalsr", 20, False),  # Valid memory when requiring fewer CPUs than a node
+        ("200GB", "normalsr", 55, False),  # n_cpus exceeds cpus_per_node, but memory is less than 2 nodes
+        ("400GB", "normalsr", 55, True),  # n_cpus exceeds cpus_per_node and memory is over 2 nodes
     ]
 )
 @patch("payu.schedulers.pbs.PBS.get_queue_node_shape", return_value=(48, 192))
@@ -610,6 +615,10 @@ def test_validate_memory_with_queue_limits(mock_get_queue_node_shape, pbs_mem, q
     if raise_error:
         with pytest.raises(ValueError, match=fr"You have requested more memory of {pbs_mem}"):
             PBS.validate_memory_with_queue_limits(pbs_mem, queue, n_cpus)
+    elif pbs_mem == "100000":
+        # Test with no unit suffix - should warn and assume bytes
+        with pytest.warns(UserWarning, match=fr"Memory string '{pbs_mem}' has no unit suffix, assuming bytes."):
+             PBS.validate_memory_with_queue_limits(pbs_mem, queue, n_cpus)
     else:
         # Test with valid memory request
         PBS.validate_memory_with_queue_limits(pbs_mem, queue, n_cpus)
@@ -618,14 +627,13 @@ def test_validate_memory_with_queue_limits(mock_get_queue_node_shape, pbs_mem, q
 @pytest.mark.parametrize(
     "pbs_mem",
     [   
-        ("100"),  # Missing unit
         ("100GBs"),  # Invalid unit
         ("100 G"),  # Invalid format with space
-        ("100KB"), # Not acceptable unit
+        ("100BB"), # Not acceptable unit
     ]
 )
 @patch("payu.schedulers.pbs.PBS.get_queue_node_shape", return_value=(48, 192))
 def test_validate_memory_with_queue_limits_format(mock_get_queue_node_shape, pbs_mem):
     """Test that an error is raised if the memory string format is invalid."""
-    with pytest.raises(ValueError, match=fr"Memory string '{pbs_mem}' has invalid format, must end with TB, GB, or MB."):
+    with pytest.raises(ValueError, match=fr"Memory string '{pbs_mem}' has invalid format, must end with PB, TB, GB, MB, KB, B, or no unit."):
         PBS.validate_memory_with_queue_limits(pbs_mem, "normalsr", 48) 


### PR DESCRIPTION
This PR updates the error message to be more informative in the following two cases:

- Job submission failure (qsub): Captures exceptions from the subprocess and prints the error output to the user.
- Model type detection failure: This usually happens when payu is run outside a control directory and the configuration file is missing.

Thanks @chrisb13 for raising these issues.