### PR TITLE
Remove killed job in payu status --update.

### DIFF
--- a/payu/status.py
+++ b/payu/status.py
@@ -297,13 +297,19 @@ def update_all_job_files(
 
         # Get job info from the scheduler data
         job_info = all_jobs.get(job_id)
-        exit_status = job_info.get("Jobs", {}).get(job_id, {}).get("Exit_status") if job_info else None
-        
-        if job_info and exit_status and stage == "queued":
+        if job_info:
+            job_info_dict = job_info.get("Jobs", {}).get(job_id, {})
+            exit_status = job_info_dict.get("Exit_status")
+            job_state = job_info_dict.get("job_state")
+        else:
+            exit_status = None
+            job_state = None
+
+        if exit_status and stage == "queued":
             # Job has exited, but is still marked as queued in the job file
             remove_job_file(file_path=job_file)
 
-        elif job_info and job_info.get("Jobs", {}).get(job_id, {}).get("job_state") == "F":
+        elif job_state == "F" and stage == "queued":
             # Job is killed or deleted but still exists in the job file
             remove_job_file(file_path=job_file)
 
@@ -322,12 +328,17 @@ def update_all_job_files(
                 data=update_data
             )
                 
-        elif run_status is None and stage != "queued":
-            # Run status isn't set, so job must have exited earlier
-            update_job_file(
-                file_path=job_file,
-                data={f"payu_{job_type}_status": 1}
-            )
+        else:
+            # Job not found in scheduler
+            if stage == "queued":
+                remove_job_file(file_path=job_file)
+
+            elif run_status is None:
+                # Run status isn't set, so job must have exited earlier
+                update_job_file(
+                    file_path=job_file,
+                    data={f"payu_{job_type}_status": 1}
+                )
             
 def print_line(label: str, key: Any, data: dict[str, Any], is_status: bool = False, description: str = "") -> None:
     """Print a line with label and value from the data, if it is defined. 

--- a/payu/status.py
+++ b/payu/status.py
@@ -302,6 +302,11 @@ def update_all_job_files(
         if job_info and exit_status and stage == "queued":
             # Job has exited, but is still marked as queued in the job file
             remove_job_file(file_path=job_file)
+
+        elif job_info and job_info.get("Jobs", {}).get(job_id, {}).get("job_state") == "F":
+            # Job is killed or deleted but still exists in the job file
+            remove_job_file(file_path=job_file)
+
         elif job_info:
             # Job is found in the scheduler, update the job file with the latest info
             update_data={
@@ -316,17 +321,13 @@ def update_all_job_files(
                 file_path=job_file,
                 data=update_data
             )
-            
-        else:
-            # Job not found in scheduler
-            if stage == "queued":
-                remove_job_file(file_path=job_file)
-            elif run_status is None:
-                # Run status isn't set, so job must have exited earlier
-                update_job_file(
-                    file_path=job_file,
-                    data={f"payu_{job_type}_status": 1}
-                )
+                
+        elif run_status is None and stage != "queued":
+            # Run status isn't set, so job must have exited earlier
+            update_job_file(
+                file_path=job_file,
+                data={f"payu_{job_type}_status": 1}
+            )
             
 def print_line(label: str, key: Any, data: dict[str, Any], is_status: bool = False, description: str = "") -> None:
     """Print a line with label and value from the data, if it is defined. 


### PR DESCRIPTION
This PR removes job files of killed jobs when `payu status --update` is used.

Closes #777 