### PR TITLE
Add payu_jobs as protected in sync.

### DIFF
--- a/payu/sync.py
+++ b/payu/sync.py
@@ -232,15 +232,14 @@ class SyncToRemoteArchive():
 
     def build_cmd(self, source_path):
         """Given a source path to sync, return a rsync command"""
-        if source_path.protected:
+        cmd = self.base_rsync_cmd  
+        if not source_path.protected:
             # No local delete option for protected paths
-            cmd = f'{self.base_rsync_cmd} {self.excludes} '
-        elif source_path.is_log_file:
-            cmd = f'{self.base_rsync_cmd} {self.remove_files} '
-        else:
-            cmd = f'{self.base_rsync_cmd} {self.excludes} {self.remove_files} '
+            cmd += f' {self.remove_files}'
+        if not source_path.is_log_file:
+            cmd += f' {self.excludes}'
 
-        cmd += f'{source_path.path} {self.destination_path}'
+        cmd += f' {source_path.path} {self.destination_path}'
         return cmd
 
     def run_cmd(self, source_path):
@@ -313,7 +312,8 @@ class SyncToRemoteArchive():
         job_file_path = os.path.join(self.expt.archive_path, 'payu_jobs')
         if os.path.isdir(job_file_path):
             self.source_paths.append(SourcePath(path=job_file_path,
-                                                protected=True))
+                                                protected=True,
+                                                is_log_file=True))
 
         # Add metadata path to protected paths, if it exists
         metadata_path = os.path.join(self.expt.archive_path, METADATA_FILENAME)

--- a/payu/sync.py
+++ b/payu/sync.py
@@ -302,12 +302,18 @@ class SyncToRemoteArchive():
         self.add_outputs_to_sync()
         self.add_restarts_to_sync()
 
-        # Add pbs, error, and payu job logs to paths
-        for log_type in ['error_logs', 'pbs_logs', 'payu_jobs']:
+        # Add pbs and error logs to paths
+        for log_type in ['error_logs', 'pbs_logs']:
             log_path = os.path.join(self.expt.archive_path, log_type)
             if os.path.isdir(log_path):
                 self.source_paths.append(SourcePath(path=log_path,
                                                     is_log_file=True))
+                
+        # Add payu_jobs to protected paths
+        job_file_path = os.path.join(self.expt.archive_path, 'payu_jobs')
+        if os.path.isdir(job_file_path):
+            self.source_paths.append(SourcePath(path=job_file_path,
+                                                protected=True))
 
         # Add metadata path to protected paths, if it exists
         metadata_path = os.path.join(self.expt.archive_path, METADATA_FILENAME)

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -1,3 +1,4 @@
+import json
 import os
 import copy
 import shutil
@@ -359,6 +360,14 @@ def test_sync(monkeypatch):
     with open(os.path.join(pbs_logs_path, log_filename), 'w') as f:
         f.write(test_log_content)
 
+    # Add some job files
+    payu_jobs_path = os.path.join(expt_archive_dir, 'payu_jobs')
+    os.makedirs(payu_jobs_path)
+    job_filename = 'test-id.json'
+    job_content = {"job_id": "test-id"}
+    with open(os.path.join(payu_jobs_path, job_filename), 'w') as f:
+        json.dump(job_content, f)
+
     # Add nested directories to output000
     nested_output_dirs = os.path.join('output000', 'submodel', 'test_sub-dir')
     nested_output_path = os.path.join(expt_archive_dir, nested_output_dirs)
@@ -390,7 +399,7 @@ def test_sync(monkeypatch):
 
     expected_dirs_synced = {'output000', 'output001', 'output002',
                             'output003', 'output004',
-                            'pbs_logs', 'metadata.yaml'}
+                            'payu_jobs', 'pbs_logs', 'metadata.yaml'}
 
     # Test output is moved to remote dir
     assert set(os.listdir(remote_archive)) == expected_dirs_synced
@@ -401,6 +410,13 @@ def test_sync(monkeypatch):
 
     with open(remote_log_path, 'r') as f:
         assert test_log_content == f.read()
+
+    # Test payu_jobs are copied
+    remote_job_path = os.path.join(remote_archive, 'payu_jobs', job_filename)
+    assert os.path.exists(remote_job_path)
+
+    with open(remote_job_path, 'r') as f:
+        assert json.load(f) == job_content
 
     # Check nested output dirs are synced
     assert os.path.exists(os.path.join(remote_archive, nested_output_dirs))
@@ -440,3 +456,6 @@ def test_sync(monkeypatch):
     for output in ['output000', 'output001', 'output002', 'output003']:
         assert output not in local_archive_dirs
     assert 'output004' in local_archive_dirs
+
+    # Assert that payu_jobs are not removed since they are protected
+    assert 'payu_jobs' in local_archive_dirs

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -459,3 +459,40 @@ def test_sync(monkeypatch):
 
     # Assert that payu_jobs are not removed since they are protected
     assert 'payu_jobs' in local_archive_dirs
+
+def test_sync_jobs_file_with_excludes(monkeypatch):
+    """Test job files are synced even when excludes are set to exclude *.json files"""
+    # Add some job files
+    payu_jobs_path = os.path.join(expt_archive_dir, 'payu_jobs')
+    os.makedirs(payu_jobs_path)
+    job_filename = 'test-id.json'
+    job_content = {"job_id": "test-id"}
+    with open(os.path.join(payu_jobs_path, job_filename), 'w') as f:
+        json.dump(job_content, f)
+
+    # Add a json file to the output dir that should be excluded
+    output_json_file = os.path.join(expt_archive_dir, 'output000', 'test_output.json')
+    with open(output_json_file, 'w') as f:
+        json.dump({"test": "output"}, f)
+
+    # Remote archive path
+    remote_archive = tmpdir / 'remote'
+
+    additional_config = {
+        "sync": {
+            "path": str(remote_archive),
+            "exclude": ["*.json"]
+        }
+    }
+    sync = setup_sync(additional_config, monkeypatch, add_envt_vars={'PAYU_CURRENT_RUN': '4'})
+
+    # Function to test
+    sync.run()
+
+    # Test json output is not synced due to excludes
+    assert not os.path.exists(os.path.join(remote_archive, 'output000', 'test_output.json'))
+
+    # Test payu_jobs are still copied
+    remote_job_path = os.path.join(remote_archive, 'payu_jobs', job_filename)
+    with open(remote_job_path, 'r') as f:
+        assert json.load(f) == job_content


### PR DESCRIPTION
Previously, `payu sync` can come across to delete running job files if `remove_local_dirs` is set to `true`, and sync job happens after the next run started.

This PR adds `payu_jobs/` as a protected directory when syncing, so job files will not be removed locally even when 
```
sync:
    remove_local_dirs: true
```
Closes #760.