### PR TITLE
Renamed CD workflow

### DIFF
--- a/.github/workflows/deploy_payu_dev.yml
+++ b/.github/workflows/deploy_payu_dev.yml
@@ -20,5 +20,5 @@ jobs:
               gh workflow run \
                 --repo access-nri/containerised-environments-infra \
                 --ref main \
-                release_dev_env.yml \
+                release_dev_module.yml \
                 -f environment=payu


### PR DESCRIPTION
Renamed the workflow to release development payu module, according to the renaming of the workflow in [access-nri/containerised-environments-infra repository PR #74](https://github.com/ACCESS-NRI/containerised-environments-infra/pull/74).

> [!IMPORTANT]
> This PR should be merged only after the PR mentioned above is merged.