### PR TITLE
Raise error when archive not found unless `--new-uuid` is specified.

### DIFF
--- a/payu/branch.py
+++ b/payu/branch.py
@@ -143,8 +143,7 @@ def checkout_branch(branch_name: str,
                     control_path: Optional[Path] = None,
                     model_type: Optional[str] = None,
                     lab_path: Optional[Path] = None,
-                    parent_experiment: Optional[str] = None,
-                    new_uuid: bool = False) -> None:
+                    parent_experiment: Optional[str] = None) -> None:
     """Checkout branch, setup metadata and add symlinks
 
     Parameters
@@ -216,8 +215,7 @@ def checkout_branch(branch_name: str,
     # Setup Metadata
     is_new_experiment = is_new_experiment or is_new_branch
     metadata.setup(keep_uuid=keep_uuid,
-                   is_new_experiment=is_new_experiment,
-                   new_uuid=new_uuid)
+                   is_new_experiment=is_new_experiment)
 
     # Gets valid prior restart path
     prior_restart_path = None
@@ -347,8 +345,7 @@ def clone(repository: str,
                             model_type=model_type,
                             lab_path=lab_path,
                             parent_experiment=parent_experiment,
-                            start_point=start_point,
-                            new_uuid=True)
+                            start_point=start_point)
         else:
             # Checkout branch
             if branch is None:

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -143,7 +143,8 @@ def checkout_branch(branch_name: str,
                     control_path: Optional[Path] = None,
                     model_type: Optional[str] = None,
                     lab_path: Optional[Path] = None,
-                    parent_experiment: Optional[str] = None) -> None:
+                    parent_experiment: Optional[str] = None,
+                    new_uuid: bool = False) -> None:
     """Checkout branch, setup metadata and add symlinks
 
     Parameters
@@ -215,7 +216,8 @@ def checkout_branch(branch_name: str,
     # Setup Metadata
     is_new_experiment = is_new_experiment or is_new_branch
     metadata.setup(keep_uuid=keep_uuid,
-                   is_new_experiment=is_new_experiment)
+                   is_new_experiment=is_new_experiment,
+                   new_uuid=new_uuid)
 
     # Gets valid prior restart path
     prior_restart_path = None
@@ -345,7 +347,8 @@ def clone(repository: str,
                             model_type=model_type,
                             lab_path=lab_path,
                             parent_experiment=parent_experiment,
-                            start_point=start_point)
+                            start_point=start_point,
+                            new_uuid=True)
         else:
             # Checkout branch
             if branch is None:

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -73,7 +73,7 @@ def timeit(time_name):
 
 
 class Experiment(object):
-    def __init__(self, lab, reproduce=False, force=False, metadata_off=False, config_path=None, new_uuid=False):
+    def __init__(self, lab, reproduce=False, force=False, metadata_off=False, config_path=None, is_new_experiment=False):
         self.init_timings()
         self.lab = lab
         # Check laboratory directories are writable
@@ -87,7 +87,7 @@ class Experiment(object):
 
         # Initialise experiment metadata - uuid and experiment name
         self.metadata = Metadata(Path(lab.archive_path), disabled=metadata_off, config_path=config_path)
-        self.metadata.setup(new_uuid=new_uuid)
+        self.metadata.setup(is_new_experiment=is_new_experiment)
 
         # TODO: replace with dict, check versions via key-value pairs
         self.modules = set()

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -73,7 +73,7 @@ def timeit(time_name):
 
 
 class Experiment(object):
-    def __init__(self, lab, reproduce=False, force=False, metadata_off=False, config_path=None):
+    def __init__(self, lab, reproduce=False, force=False, metadata_off=False, config_path=None, new_uuid=False):
         self.init_timings()
         self.lab = lab
         # Check laboratory directories are writable
@@ -87,7 +87,7 @@ class Experiment(object):
 
         # Initialise experiment metadata - uuid and experiment name
         self.metadata = Metadata(Path(lab.archive_path), disabled=metadata_off, config_path=config_path)
-        self.metadata.setup()
+        self.metadata.setup(new_uuid=new_uuid)
 
         # TODO: replace with dict, check versions via key-value pairs
         self.modules = set()

--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -42,6 +42,10 @@ SCHEMA_COMMIT_HASH = "cff183437134592723b09af6620e5cb190abeb22"
 SCHEMA_URL = f"https://raw.githubusercontent.com/ACCESS-NRI/schema/{SCHEMA_COMMIT_HASH}/au.org.access-nri/model/output/experiment-metadata/{SCHEMA_VERSION}.json"
 placeholder_text = "__REPLACE_ME__"
 
+no_archive_msg = """No pre-existing archive is found for this experiment.
+Payu will generate a new experiment UUID and create a new archive directory.
+To proceed, please rerun the command with the --new-uuid flag."""
+
 class MetadataWarning(Warning):
     pass
 
@@ -111,7 +115,8 @@ class Metadata:
 
     def setup(self,
               is_new_experiment: bool = False,
-              keep_uuid: bool = False) -> None:
+              keep_uuid: bool = False,
+              new_uuid: bool = False) -> None:
         """Set UUID and experiment name.
 
         Parameters:
@@ -120,6 +125,8 @@ class Metadata:
             is_new_experiment: bool, default False
                 If not keep_uuid, generate a new UUID and a branch-uuid aware
                 experiment name. This is set in payu.branch.checkout_branch.
+            new_uuid: bool, default False
+                User confirm to generate a new UUID.
         Return: None
 
         Note: Experiment name is the name used for the work and archive
@@ -131,7 +138,8 @@ class Metadata:
 
         elif self.uuid is not None and (keep_uuid or not is_new_experiment):
             self.set_experiment_name(keep_uuid=keep_uuid,
-                                     is_new_experiment=is_new_experiment)
+                                     is_new_experiment=is_new_experiment,
+                                     new_uuid=new_uuid)
         else:
             # Generate new UUID
             if self.uuid is None and not is_new_experiment:
@@ -162,7 +170,8 @@ class Metadata:
 
     def set_experiment_name(self,
                             is_new_experiment: bool = False,
-                            keep_uuid: bool = False) -> None:
+                            keep_uuid: bool = False,
+                            new_uuid: bool = False) -> None:
         """Set experiment name - this is used for work and archive
         sub-directories in the Laboratory"""
         # Experiment name configuration - this overrides experiment name
@@ -200,13 +209,17 @@ class Metadata:
         elif keep_uuid:
             # Use same experiment UUID and use branch-UUID name for archive
             self.experiment_name = branch_uuid_experiment_name
-        else:
+        elif new_uuid:
             # No archive exists - Detecting new experiment
             warnings.warn(
                 "No pre-existing archive found. Generating a new uuid",
                 MetadataWarning
             )
             self.set_new_uuid(is_new_experiment=True)
+        else:
+            # No archive exists and user did not specify a new or old UUID
+            raise RuntimeError(f"{no_archive_msg}")
+            
 
     def has_archive(self, experiment_name: str) -> bool:
         """Return True if archive under the experiment name exists and
@@ -231,7 +244,7 @@ class Metadata:
         """Generate a new uuid and set experiment name"""
         self.uuid_updated = True
         self.uuid = generate_uuid()
-        self.set_experiment_name(is_new_experiment=is_new_experiment)
+        self.set_experiment_name(is_new_experiment=is_new_experiment, new_uuid=True)
 
         # If experiment name does not include UUID, leave it unchanged
         if self.experiment_name.endswith(self.uuid[:TRUNCATED_UUID_LENGTH]):

--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -44,8 +44,8 @@ SCHEMA_URL = f"https://raw.githubusercontent.com/ACCESS-NRI/schema/{SCHEMA_COMMI
 placeholder_text = "__REPLACE_ME__"
 
 no_archive_msg = """
-Payu will generate a new experiment UUID and create a new archive directory.
-To proceed, please rerun `payu setup` or `payu run or `payu checkout`` with the --new-uuid flag."""
+Payu needs to generate an experiment UUID and create a new archive directory.
+To proceed, please rerun `payu setup` or `payu run or `payu checkout`` with the `--new-uuid` flag."""
 
 class MetadataWarning(Warning):
     pass
@@ -139,12 +139,9 @@ class Metadata:
                                      is_new_experiment=is_new_experiment)
         else:
             # Generate new UUID
-            if self.uuid is None and not is_new_experiment:
-                warnings.warn("No experiment uuid found in metadata. "
-                              "Generating a new uuid", MetadataWarning)
-                self.set_new_uuid(is_new_experiment=True)
-            else:
-                self.set_new_uuid(is_new_experiment=is_new_experiment)
+            # In older version of payu, there is no UUID in archive name, so self.uuid is None but is_new_experiment could be False.
+            # In this case, we still want to pass is_new_experiment = False.
+            self.set_new_uuid(is_new_experiment=is_new_experiment)
             print("Generated new experiment uuid: ", self.uuid)
 
         self.archive_path = self.lab_archive_path / self.experiment_name
@@ -210,7 +207,7 @@ class Metadata:
             self.experiment_name = branch_uuid_experiment_name
         else:
             # No archive exists and user did not specify a new UUID
-            raise errors.PayuBranchError(f"Current archive path is not found: {self.lab_archive_path}."
+            raise errors.PayuRuntimeError(f"No archive matching current branch found in: {self.lab_archive_path}."
                                          f"{no_archive_msg}"
                                )
             

--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -21,6 +21,7 @@ from ruamel.yaml.comments import CommentedMap
 
 from payu.fsops import read_config
 from payu.git_utils import GitRepository
+import payu.errors as errors
 
 # A truncated uuid is used for branch-uuid aware experiment names
 TRUNCATED_UUID_LENGTH = 8
@@ -42,9 +43,9 @@ SCHEMA_COMMIT_HASH = "cff183437134592723b09af6620e5cb190abeb22"
 SCHEMA_URL = f"https://raw.githubusercontent.com/ACCESS-NRI/schema/{SCHEMA_COMMIT_HASH}/au.org.access-nri/model/output/experiment-metadata/{SCHEMA_VERSION}.json"
 placeholder_text = "__REPLACE_ME__"
 
-no_archive_msg = """No pre-existing archive is found for this experiment.
+no_archive_msg = """
 Payu will generate a new experiment UUID and create a new archive directory.
-To proceed, please rerun the command with the --new-uuid flag."""
+To proceed, please rerun `payu setup` or `payu run or `payu checkout`` with the --new-uuid flag."""
 
 class MetadataWarning(Warning):
     pass
@@ -115,8 +116,7 @@ class Metadata:
 
     def setup(self,
               is_new_experiment: bool = False,
-              keep_uuid: bool = False,
-              new_uuid: bool = False) -> None:
+              keep_uuid: bool = False) -> None:
         """Set UUID and experiment name.
 
         Parameters:
@@ -125,8 +125,6 @@ class Metadata:
             is_new_experiment: bool, default False
                 If not keep_uuid, generate a new UUID and a branch-uuid aware
                 experiment name. This is set in payu.branch.checkout_branch.
-            new_uuid: bool, default False
-                User confirm to generate a new UUID.
         Return: None
 
         Note: Experiment name is the name used for the work and archive
@@ -138,14 +136,16 @@ class Metadata:
 
         elif self.uuid is not None and (keep_uuid or not is_new_experiment):
             self.set_experiment_name(keep_uuid=keep_uuid,
-                                     is_new_experiment=is_new_experiment,
-                                     new_uuid=new_uuid)
+                                     is_new_experiment=is_new_experiment)
         else:
             # Generate new UUID
             if self.uuid is None and not is_new_experiment:
                 warnings.warn("No experiment uuid found in metadata. "
                               "Generating a new uuid", MetadataWarning)
-            self.set_new_uuid(is_new_experiment=is_new_experiment)
+                self.set_new_uuid(is_new_experiment=True)
+            else:
+                self.set_new_uuid(is_new_experiment=is_new_experiment)
+            print("Generated new experiment uuid: ", self.uuid)
 
         self.archive_path = self.lab_archive_path / self.experiment_name
 
@@ -170,8 +170,7 @@ class Metadata:
 
     def set_experiment_name(self,
                             is_new_experiment: bool = False,
-                            keep_uuid: bool = False,
-                            new_uuid: bool = False) -> None:
+                            keep_uuid: bool = False) -> None:
         """Set experiment name - this is used for work and archive
         sub-directories in the Laboratory"""
         # Experiment name configuration - this overrides experiment name
@@ -209,16 +208,11 @@ class Metadata:
         elif keep_uuid:
             # Use same experiment UUID and use branch-UUID name for archive
             self.experiment_name = branch_uuid_experiment_name
-        elif new_uuid:
-            # No archive exists - Detecting new experiment
-            warnings.warn(
-                "No pre-existing archive found. Generating a new uuid",
-                MetadataWarning
-            )
-            self.set_new_uuid(is_new_experiment=True)
         else:
-            # No archive exists and user did not specify a new or old UUID
-            raise RuntimeError(f"{no_archive_msg}")
+            # No archive exists and user did not specify a new UUID
+            raise errors.PayuBranchError(f"Current archive path is not found: {self.lab_archive_path}."
+                                         f"{no_archive_msg}"
+                               )
             
 
     def has_archive(self, experiment_name: str) -> bool:
@@ -244,7 +238,7 @@ class Metadata:
         """Generate a new uuid and set experiment name"""
         self.uuid_updated = True
         self.uuid = generate_uuid()
-        self.set_experiment_name(is_new_experiment=is_new_experiment, new_uuid=True)
+        self.set_experiment_name(is_new_experiment=is_new_experiment)
 
         # If experiment name does not include UUID, leave it unchanged
         if self.experiment_name.endswith(self.uuid[:TRUNCATED_UUID_LENGTH]):
@@ -259,6 +253,7 @@ class Metadata:
                 # Generate a new id and experiment name
                 self.uuid = generate_uuid()
                 self.set_experiment_name(is_new_experiment=is_new_experiment)
+
 
     def write_metadata(self,
                        restart_path: Optional[Union[Path, str]] = None,
@@ -373,7 +368,9 @@ class Metadata:
 
     def copy_to_archive(self) -> None:
         """Copy metadata file to archive"""
-        os.makedirs(self.archive_path, exist_ok=True)
+        if not self.archive_path.exists():
+            print(f"Creating archive directory: {self.archive_path}")
+            os.makedirs(self.archive_path)
         shutil.copy(self.filepath, self.archive_path / METADATA_FILENAME)
         # Note: The existence of an archive is used for determining
         # experiment names and whether to generate a new UUID

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -182,6 +182,17 @@ keep_uuid = {
     }
 }
 
+# Confirm use a new uuid flag
+new_uuid = {
+    'flags': ('--new-uuid',),
+    'parameters': {
+        'action':   'store_true',
+        'default':  False,
+        'dest': 'new_uuid',
+        'help': 'Generate a new experiment uuid'
+    }
+}
+
 # Clone branch
 clone_branch = {
     'flags': ('--branch', '-B'),

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -183,13 +183,13 @@ keep_uuid = {
 }
 
 # Confirm use a new uuid flag
-new_uuid = {
+is_new_experiment = {
     'flags': ('--new-uuid',),
     'parameters': {
         'action':   'store_true',
         'default':  False,
-        'dest': 'new_uuid',
-        'help': 'Generate a new experiment uuid'
+        'dest': 'is_new_experiment',
+        'help': 'Generate a new uuid and archive directory for this experiment.'
     }
 }
 

--- a/payu/subcommands/checkout_cmd.py
+++ b/payu/subcommands/checkout_cmd.py
@@ -32,7 +32,7 @@ parameters = {
 
 arguments = [args.model, args.config, args.laboratory, args.new_branch,
              args.branch_name, args.start_point, args.restart_path,
-             args.keep_uuid, args.parent_experiment]
+             args.keep_uuid, args.parent_experiment, args.is_new_experiment]
 
 
 def transform_strings_to_path(path_str=None):
@@ -41,7 +41,7 @@ def transform_strings_to_path(path_str=None):
 
 def runcmd(model_type, config_path, lab_path, new_branch,
            branch_name, start_point,
-           restart_path, keep_uuid, parent_experiment):
+           restart_path, keep_uuid, parent_experiment, is_new_experiment=False):
     """Execute the command."""
     config_path = transform_strings_to_path(config_path)
     lab_path = transform_strings_to_path(lab_path)
@@ -56,7 +56,8 @@ def runcmd(model_type, config_path, lab_path, new_branch,
                     model_type=model_type,
                     keep_uuid=keep_uuid,
                     parent_experiment=parent_experiment,
-                    new_uuid=True)
+                    is_new_experiment=is_new_experiment # Result from --new-uuid flag
+    )
 
 
 runscript = runcmd

--- a/payu/subcommands/checkout_cmd.py
+++ b/payu/subcommands/checkout_cmd.py
@@ -55,7 +55,8 @@ def runcmd(model_type, config_path, lab_path, new_branch,
                     lab_path=lab_path,
                     model_type=model_type,
                     keep_uuid=keep_uuid,
-                    parent_experiment=parent_experiment)
+                    parent_experiment=parent_experiment,
+                    new_uuid=True)
 
 
 runscript = runcmd

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -22,7 +22,7 @@ parameters = {'description': 'Run the model experiment'}
 
 arguments = [args.model, args.config, args.initial, args.nruns,
              args.laboratory, args.reproduce, args.force,
-             args.force_prune_restarts]
+             args.force_prune_restarts, args.new_uuid]
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,8 @@ def validate_platform_node(platform, queue, get_queue_node_shape):
 
 
 def runcmd(model_type, config_path, init_run, n_runs, lab_path,
-           reproduce=False, force=False, force_prune_restarts=False):
+           reproduce=False, force=False, force_prune_restarts=False,
+            new_uuid=False):
     # Get job submission configuration
     pbs_config = fsops.read_config(config_path)
     pbs_vars = cli.set_env_vars(init_run=init_run,
@@ -61,7 +62,7 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
     # Run experiment initialisation to update metadata,
     # and determine the run counter and uuid before job submission
     lab = Laboratory(model_type, config_path, lab_path)
-    expt = Experiment(lab, reproduce=reproduce, force=force)
+    expt = Experiment(lab, reproduce=reproduce, force=force, new_uuid=new_uuid)
 
     # Set the queue
     # NOTE: Maybe force all jobs on the normal queue
@@ -191,7 +192,7 @@ def runscript(**run_args):
     lab = Laboratory(run_args.model_type, run_args.config_path,
                      run_args.lab_path)
 
-    expt = Experiment(lab, reproduce=run_args.reproduce, force=run_args.force)
+    expt = Experiment(lab, reproduce=run_args.reproduce, force=run_args.force, new_uuid=run_args.new_uuid)
 
     n_runs_per_submit = expt.config.get('runspersub', 1)
     subrun = 1

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -22,7 +22,7 @@ parameters = {'description': 'Run the model experiment'}
 
 arguments = [args.model, args.config, args.initial, args.nruns,
              args.laboratory, args.reproduce, args.force,
-             args.force_prune_restarts, args.new_uuid]
+             args.force_prune_restarts, args.is_new_experiment]
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ def validate_platform_node(platform, queue, get_queue_node_shape):
 
 def runcmd(model_type, config_path, init_run, n_runs, lab_path,
            reproduce=False, force=False, force_prune_restarts=False,
-            new_uuid=False):
+           is_new_experiment=False):
     # Get job submission configuration
     pbs_config = fsops.read_config(config_path)
     pbs_vars = cli.set_env_vars(init_run=init_run,
@@ -62,7 +62,7 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
     # Run experiment initialisation to update metadata,
     # and determine the run counter and uuid before job submission
     lab = Laboratory(model_type, config_path, lab_path)
-    expt = Experiment(lab, reproduce=reproduce, force=force, new_uuid=new_uuid)
+    expt = Experiment(lab, reproduce=reproduce, force=force, is_new_experiment=is_new_experiment)
 
     # Set the queue
     # NOTE: Maybe force all jobs on the normal queue
@@ -192,7 +192,7 @@ def runscript(**run_args):
     lab = Laboratory(run_args.model_type, run_args.config_path,
                      run_args.lab_path)
 
-    expt = Experiment(lab, reproduce=run_args.reproduce, force=run_args.force, new_uuid=run_args.new_uuid)
+    expt = Experiment(lab, reproduce=run_args.reproduce, force=run_args.force, is_new_experiment=run_args.is_new_experiment)
 
     n_runs_per_submit = expt.config.get('runspersub', 1)
     subrun = 1

--- a/payu/subcommands/setup_cmd.py
+++ b/payu/subcommands/setup_cmd.py
@@ -14,15 +14,17 @@ arguments = [
     args.reproduce,
     args.force,
     args.metadata_off,
+    args.new_uuid,
 ]
 
 
 def runcmd(model_type, config_path, lab_path,
-           reproduce=False, force=False, metadata_off=False):
+           reproduce=False, force=False, metadata_off=False, new_uuid=False):
 
     lab = Laboratory(model_type, config_path, lab_path)
     expt = Experiment(lab, reproduce=reproduce, force=force,
-                      metadata_off=metadata_off)
+                      metadata_off=metadata_off,
+                      new_uuid=new_uuid)
 
     expt.setup()
 

--- a/payu/subcommands/setup_cmd.py
+++ b/payu/subcommands/setup_cmd.py
@@ -14,17 +14,17 @@ arguments = [
     args.reproduce,
     args.force,
     args.metadata_off,
-    args.new_uuid,
+    args.is_new_experiment,
 ]
 
 
 def runcmd(model_type, config_path, lab_path,
-           reproduce=False, force=False, metadata_off=False, new_uuid=False):
+           reproduce=False, force=False, metadata_off=False, is_new_experiment=False):
 
     lab = Laboratory(model_type, config_path, lab_path)
     expt = Experiment(lab, reproduce=reproduce, force=force,
                       metadata_off=metadata_off,
-                      new_uuid=new_uuid)
+                      is_new_experiment=is_new_experiment)
 
     expt.setup()
 

--- a/payu/subcommands/status_cmd.py
+++ b/payu/subcommands/status_cmd.py
@@ -37,12 +37,8 @@ def runcmd(lab_path, config_path, json_output,
         # Determine archive path
         lab = Laboratory(config_path=config_path, lab_path=lab_path)
         warnings.filterwarnings("error", category=MetadataWarning)
-        try:
-            expt = Experiment(lab, config_path=config_path)
-        except MetadataWarning:
-            raise errors.PayuRuntimeError(
-                "Metadata is not setup - can't determine archive path"
-            )
+        
+        expt = Experiment(lab, config_path=config_path)
 
         archive_path = Path(expt.archive_path)
         control_path = Path(expt.control_path)

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, MagicMock
 
 from payu.branch import add_restart_to_config, check_restart, switch_symlink
 from payu.branch import checkout_branch, clone, list_branches, DEFAULT_PARENT_STRING
-from payu.metadata import MetadataWarning, UUID_FIELD
+from payu.metadata import MetadataWarning, no_archive_msg
 from payu.fsops import read_config
 from payu.subcommands import clone_cmd
 import payu.errors as errors
@@ -374,19 +374,17 @@ def test_checkout_existing_branch_with_no_metadata(mock_uuid):
     # Mock uuid1 value
     uuid1 = "574ea2c9-2379-4484-86b4-1d1a0f820773"
     mock_uuid.return_value = uuid1
-    expected_no_uuid_msg = (
-        "No experiment uuid found in metadata. Generating a new uuid"
-    )
-    expected_no_archive_msg = (
-        "No pre-existing archive found. Generating a new uuid"
-    )
 
     with cd(ctrldir):
-        # Test checkout existing branch with no existing metadata
-        with pytest.warns(MetadataWarning, match=expected_no_uuid_msg):
-            with pytest.warns(MetadataWarning, match=expected_no_archive_msg):
-                checkout_branch(branch_name="Branch1",
+        # Test checkout existing branch with no existing metadata or archive, expected to fail
+        with pytest.raises(errors.PayuRuntimeError, match=no_archive_msg):
+            checkout_branch(branch_name="Branch1",
                                 lab_path=labdir)
+            
+        # Test checkout existing branch with no existing archive with `--new-uuid` flag, expected to succeed
+        checkout_branch(is_new_experiment=True,
+                        branch_name="Branch1",
+                        lab_path=labdir)
 
     # Check metadata was created and commited
     branch1_experiment_name = f"{ctrldir_basename}-Branch1-574ea2c9"
@@ -417,9 +415,8 @@ def test_checkout_branch_with_no_metadata_and_with_legacy_archive(mock_uuid):
     with cd(ctrldir):
         # Test checkout existing branch (with no existing metadata)
         # and with pre-existing archive
-        with pytest.warns(MetadataWarning, match=expected_no_uuid_msg):
-            checkout_branch(branch_name="Branch1",
-                            lab_path=labdir)
+        checkout_branch(branch_name="Branch1",
+                        lab_path=labdir)
 
     # Check metadata was created and commited - with legacy experiment name
     branch1_experiment_name = ctrldir_basename

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -60,7 +60,7 @@ def test_parse_setup(parser):
     assert args.pop('reproduce') is False
     assert args.pop('force') is False
     assert args.pop('metadata_off') is False
-    assert args.pop('new_uuid') is False
+    assert args.pop('is_new_experiment') is False
 
     assert len(args) == 0
 
@@ -86,7 +86,7 @@ def test_parse_setup(parser):
     assert args.pop('reproduce') is True
     assert args.pop('force') is True
     assert args.pop('metadata_off') is True
-    assert args.pop('new_uuid') is True
+    assert args.pop('is_new_experiment') is True
 
     assert len(args) == 0
 
@@ -109,7 +109,7 @@ def test_parse_setup(parser):
     assert args.pop('reproduce') is True
     assert args.pop('force') is True
     assert args.pop('metadata_off') is True
-    assert args.pop('new_uuid') is False
+    assert args.pop('is_new_experiment') is False
 
     assert len(args) == 0
 
@@ -130,7 +130,7 @@ def test_parse_run(parser):
     assert args.pop('init_run') is None
     assert args.pop('n_runs') is None
     assert args.pop('force_prune_restarts') is False
-    assert args.pop('new_uuid') is False
+    assert args.pop('is_new_experiment') is False
 
     assert len(args) == 0
 
@@ -160,7 +160,7 @@ def test_parse_run(parser):
     assert args.pop('init_run') == '99'
     assert args.pop('n_runs') == '999'
     assert args.pop('force_prune_restarts') is True
-    assert args.pop('new_uuid') is True
+    assert args.pop('is_new_experiment') is True
     assert len(args) == 0
 
     # Test short options
@@ -187,7 +187,7 @@ def test_parse_run(parser):
     assert args.pop('init_run') == '99'
     assert args.pop('n_runs') == '999'
     assert args.pop('force_prune_restarts') is True
-    assert args.pop('new_uuid') is False
+    assert args.pop('is_new_experiment') is False
 
     assert len(args) == 0
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -60,6 +60,7 @@ def test_parse_setup(parser):
     assert args.pop('reproduce') is False
     assert args.pop('force') is False
     assert args.pop('metadata_off') is False
+    assert args.pop('new_uuid') is False
 
     assert len(args) == 0
 
@@ -71,7 +72,8 @@ def test_parse_setup(parser):
                     "--laboratory path/to/lab "
                     "--force "
                     "--reproduce "
-                    "--metadata-off"
+                    "--metadata-off "
+                    "--new-uuid"
                 )
 
     run_cmd, args = parse_args(parser, long_cmd)
@@ -84,6 +86,7 @@ def test_parse_setup(parser):
     assert args.pop('reproduce') is True
     assert args.pop('force') is True
     assert args.pop('metadata_off') is True
+    assert args.pop('new_uuid') is True
 
     assert len(args) == 0
 
@@ -106,6 +109,7 @@ def test_parse_setup(parser):
     assert args.pop('reproduce') is True
     assert args.pop('force') is True
     assert args.pop('metadata_off') is True
+    assert args.pop('new_uuid') is False
 
     assert len(args) == 0
 
@@ -126,6 +130,7 @@ def test_parse_run(parser):
     assert args.pop('init_run') is None
     assert args.pop('n_runs') is None
     assert args.pop('force_prune_restarts') is False
+    assert args.pop('new_uuid') is False
 
     assert len(args) == 0
 
@@ -139,7 +144,9 @@ def test_parse_run(parser):
             "--initial 99 "
             "--nruns 999 "
             "--reproduce "
-            "--force-prune-restarts")
+            "--force-prune-restarts "
+            "--new-uuid"
+            )
 
     run_cmd, args = parse_args(parser, long_cmd)
 
@@ -153,7 +160,7 @@ def test_parse_run(parser):
     assert args.pop('init_run') == '99'
     assert args.pop('n_runs') == '999'
     assert args.pop('force_prune_restarts') is True
-
+    assert args.pop('new_uuid') is True
     assert len(args) == 0
 
     # Test short options
@@ -180,6 +187,7 @@ def test_parse_run(parser):
     assert args.pop('init_run') == '99'
     assert args.pop('n_runs') == '999'
     assert args.pop('force_prune_restarts') is True
+    assert args.pop('new_uuid') is False
 
     assert len(args) == 0
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, Mock
 from ruamel.yaml import YAML
 import jsonschema
 
-from payu.metadata import Metadata, MetadataWarning, SCHEMA_VERSION, placeholder_text
+from payu.metadata import Metadata, MetadataWarning, SCHEMA_VERSION, placeholder_text, no_archive_msg
 
 from test.common import cd
 from test.common import tmpdir, ctrldir, labdir, archive_dir
@@ -394,6 +394,31 @@ def test_experiment_name_with_prefix_and_experiment():
             metadata.set_experiment_name()
 
         mock_new_experiment_name.assert_not_called()
+
+
+def test_set_experiment_name_archive_not_found():
+    """Test that when no archive found, the user is prompted to confirm before generating a new UUID."""
+    # Setup config
+    write_config(config)
+    with cd(ctrldir):
+        metadata = Metadata(archive_dir)
+        
+    with patch.object(metadata, 'has_archive') as mock_has_archive, \
+        patch.object(metadata, 'new_experiment_name') as mock_new_experiment_name:
+
+        # Simulate no archive found
+        mock_has_archive.return_value = False  
+
+        # Simulate new experiment name generation
+        mock_new_experiment_name.return_value = "mock_experiment_name"
+
+        # Assert error raised when user did not specify to generate a new UUID
+        with pytest.raises(RuntimeError, match=f"{no_archive_msg}"):
+            metadata.set_experiment_name(is_new_experiment=False)
+
+        # Assert that only warning is raised when user specified to generate a new UUID
+        with pytest.warns(MetadataWarning, match="No pre-existing archive found. Generating a new uuid"):
+            metadata.set_experiment_name(is_new_experiment=False, new_uuid=True)
 
 
 def test_metadata_enable_false():

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -180,55 +180,49 @@ def test_update_file(mock_repo, uuid, experiment_name,
 
 @pytest.mark.parametrize(
     "uuid_exists, keep_uuid, is_new_experiment, "
-    "branch_uuid_archive_exists, legacy_archive_exists, catch_warning,"
+    "branch_uuid_archive_exists, legacy_archive_exists,"
     "expected_uuid, expected_name",
     [
         # Keep UUID on new experiment - UUID Exists - no archives exist
         (
-            True, True, True, False, False, False,
+            True, True, True, False, False,
             "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", "ctrl-mock_branch-3d18b3b6"
         ),
         # Keep UUID on new experiment - UUID Exists - legacy archive exists
         (
-            True, True, True, False, True, False,
+            True, True, True, False, True,
             "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", "ctrl-mock_branch-3d18b3b6"
         ),
         # Keep UUID on not new experiment - UUID Exists -legacy archive exists
         (
-            True, True, False, False, True, False,
+            True, True, False, False, True,
             "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", "ctrl"
         ),
         # Keep UUID on not new experiment - No UUID - no archives exist
         (
-            False, True, True, False, False, False,
+            False, True, True, False, False, 
             "cb793e91-6168-4ed2-a70c-f6f9ccf1659b", "ctrl-mock_branch-cb793e91"
         ),
         # Experiment setup - No UUID - legacy archive exists
         (
-            False, False, False, False, True, True,
+            False, False, False, False, True, 
             "cb793e91-6168-4ed2-a70c-f6f9ccf1659b", "ctrl"
-        ),
-        # Experiment setup - No UUID - no archive exists
-        (
-            False, False, False, False, False, True,
-            "cb793e91-6168-4ed2-a70c-f6f9ccf1659b", "ctrl-mock_branch-cb793e91"
         ),
         # Experiment setup - Existing UUID - legacy archive exists
         (
-            True, False, False, False, True, False,
+            True, False, False, False, True,
             "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", "ctrl"
         ),
         # Experiment setup - Existing UUID - new archive exists
         (
-            True, False, False, True, True, False,
+            True, False, False, True, True, 
             "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136", "ctrl-mock_branch-3d18b3b6"
         ),
     ]
 )
 def test_set_experiment_and_uuid(uuid_exists, keep_uuid, is_new_experiment,
                                  branch_uuid_archive_exists,
-                                 legacy_archive_exists, catch_warning,
-                                 expected_uuid, expected_name):
+                                 legacy_archive_exists, expected_uuid, expected_name):
     # Setup config and metadata
     write_config(config)
     with cd(ctrldir):
@@ -251,13 +245,7 @@ def test_set_experiment_and_uuid(uuid_exists, keep_uuid, is_new_experiment,
         mock_branch.return_value = "mock_branch"
         mock_uuid.return_value = "cb793e91-6168-4ed2-a70c-f6f9ccf1659b"
 
-        if catch_warning:
-            # Test warning raised
-            with pytest.warns(MetadataWarning):
-                metadata.setup(is_new_experiment=is_new_experiment,
-                               keep_uuid=keep_uuid)
-        else:
-            metadata.setup(is_new_experiment=is_new_experiment,
+        metadata.setup(is_new_experiment=is_new_experiment,
                            keep_uuid=keep_uuid)
 
     assert metadata.experiment_name == expected_name
@@ -414,7 +402,7 @@ def test_set_experiment_name_archive_not_found():
         mock_new_experiment_name.return_value = "mock_experiment_name"
 
         # Assert error raised when user did not specify to generate a new UUID
-        with pytest.raises(errors.PayuBranchError, match=f"{no_archive_msg}"):
+        with pytest.raises(errors.PayuRuntimeError, match=f"{no_archive_msg}"):
             metadata.set_experiment_name(is_new_experiment=False)
 
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -9,6 +9,7 @@ from ruamel.yaml import YAML
 import jsonschema
 
 from payu.metadata import Metadata, MetadataWarning, SCHEMA_VERSION, placeholder_text, no_archive_msg
+import payu.errors as errors
 
 from test.common import cd
 from test.common import tmpdir, ctrldir, labdir, archive_dir
@@ -413,12 +414,9 @@ def test_set_experiment_name_archive_not_found():
         mock_new_experiment_name.return_value = "mock_experiment_name"
 
         # Assert error raised when user did not specify to generate a new UUID
-        with pytest.raises(RuntimeError, match=f"{no_archive_msg}"):
+        with pytest.raises(errors.PayuBranchError, match=f"{no_archive_msg}"):
             metadata.set_experiment_name(is_new_experiment=False)
 
-        # Assert that only warning is raised when user specified to generate a new UUID
-        with pytest.warns(MetadataWarning, match="No pre-existing archive found. Generating a new uuid"):
-            metadata.set_experiment_name(is_new_experiment=False, new_uuid=True)
 
 
 def test_metadata_enable_false():

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -24,6 +24,7 @@ from payu.experiment import Experiment
 from payu.subcommands.status_cmd import runcmd
 from payu.git_utils import PayuGitWarning
 import payu.errors as errors
+from payu.metadata import no_archive_msg
 
 def test_find_file_match(tmp_path):
     test_file = tmp_path / "job_name.o146702704"
@@ -662,7 +663,7 @@ def test_status_cmd_no_metadata(tmp_path):
         json.dump({'model': 'test'}, f)
 
     with pytest.warns(PayuGitWarning):
-        with pytest.raises(errors.PayuRuntimeError, match="Metadata is not setup"):
+        with pytest.raises(errors.PayuRuntimeError, match=no_archive_msg):
             runcmd(
                 lab_path=str(lab_path),
                 config_path=str(config_path),
@@ -1032,31 +1033,6 @@ def test_collect_expt_paths(tmp_path, sync_path):
     else:
         assert expt_paths['sync_path'] == "Unconfigured"
 
-    
-def test_collect_expt_paths_no_metadata(tmp_path):
-    """Test that collect_expt_paths raises an error when metadata is not set up"""
-    # Create a temporary lab and config
-    lab_path = tmp_path / "lab"
-    lab_path.mkdir()
-    control_path = tmp_path / "control"
-    control_path.mkdir()
-
-    # Write a minimal config file
-    config = {
-            'model': 'mom6'
-    }
-    with open(control_path / "config.yaml", 'w') as f:
-        json.dump(config, f)
-
-    # Set up a mock experiment
-    with cd(control_path):
-        lab = Laboratory(lab_path=str(lab_path))
-        expt = Experiment(lab, reproduce=False)
-        expt.metadata = None  # Mock a bad metadata
-
-    with pytest.warns(UserWarning, match="Failed to collect experiment paths: 'NoneType' object has no attribute 'uuid'"):
-        expt_paths = collect_expt_paths(expt)
-        assert expt_paths == {}
 
 
 def test_display_expt_paths(capsys):


### PR DESCRIPTION
Previously, Payu automatically generated a new UUID and print a warning when no existing archive was found.

This PR changes that behavior to raise an error when an archive is not found. 
If the user explicitly provides the `--new-uuid` flag, Payu will instead print a warning and proceed to generate a new UUID.

Closes #776.