### PR TITLE
Add `sync:base_path` to PBS storage flag if `sync:path` is not set.

### DIFF
--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -434,7 +434,8 @@ class PBS(Scheduler):
         module_use_paths = pbs_config.get('modules', {}).get('use', [])
         extra_search_paths.extend(module_use_paths)
 
-        remote_sync_directory = pbs_config.get('sync', {}).get('path', None)
+        sync_config = pbs_config.get('sync', {})
+        remote_sync_directory = sync_config.get('path', None) or sync_config.get('base_path', None)
         if remote_sync_directory is not None:
             extra_search_paths.append(remote_sync_directory)
         storages.update(find_mounts(extra_search_paths, mounts))


### PR DESCRIPTION
Previously payu did not add `sync:base_path` to PBS storage, leading to fail run.

This PR adds the mount of `sync:base_path` to PBS storage. This only happens if `sync:path` is not set, otherwise, `sync:path` is used.

Closes #798.

Manual tests
1. `sync:base_path` points to an unavailable project, and `sync:path` not set. Error out before the PBS submission.
2. `sync:base_path` points to a correct project, but `sync:path` points to an unavailable project. Error out before the PBS submission -> payu priorities `sync:path` and found no access to the assigned project.
3. `sync:base_path` points to a correct project -> new storage is addd to PBS submission.