### PR TITLE
Update relative restart path to absolute path.

### DIFF
--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -155,7 +155,7 @@ class Model(object):
         if self.prior_restart_path and not os.path.isabs(self.prior_restart_path):
             # Update to absolute path, assuming it is relative to control path
             rel_path = os.path.join(self.expt.control_path, self.prior_restart_path)
-            self.prior_restart_path = os.path.realpath(rel_path)
+            self.prior_restart_path = os.path.realpath(rel_path, strict=True)
             print(f"Prior restart path is set as a relative path, resolved to {self.prior_restart_path}")
 
         if len(self.expt.models) > 1:

--- a/payu/models/model.py
+++ b/payu/models/model.py
@@ -151,6 +151,13 @@ class Model(object):
         self.prior_output_path = self.expt.prior_output_path
         self.prior_restart_path = self.expt.prior_restart_path
 
+        # If prior restart path exists and is a relative path
+        if self.prior_restart_path and not os.path.isabs(self.prior_restart_path):
+            # Update to absolute path, assuming it is relative to control path
+            rel_path = os.path.join(self.expt.control_path, self.prior_restart_path)
+            self.prior_restart_path = os.path.realpath(rel_path)
+            print(f"Prior restart path is set as a relative path, resolved to {self.prior_restart_path}")
+
         if len(self.expt.models) > 1:
 
             # If '-d' option specified for collate don't want to change the

--- a/test/common.py
+++ b/test/common.py
@@ -171,9 +171,10 @@ def make_inputs():
                          1000**2 + i)
 
 
-def make_restarts(fnames=None):
+def make_restarts(fnames=None, restartdir = None):
     # Create some fake restart files
-    restartdir = labdir / 'archive' / 'restarts'
+    if restartdir is None:
+        restartdir = labdir / 'archive' / 'restarts'
     restartdir.mkdir(parents=True, exist_ok=True)
     if fnames is None:
         fnames = ['restart_00{i}.bin'.format(i=i) for i in range(1, 4)]

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -11,7 +11,7 @@ import json
 import payu
 import payu.errors as errors
 
-from .common import cd, make_random_file, get_manifests
+from .common import cd, make_random_file, get_manifests, make_restarts
 from .common import tmpdir, ctrldir, labdir, workdir
 from .common import payu_init, payu_setup, sweep_work
 from .common import config as config_orig
@@ -72,7 +72,7 @@ def make_config_files():
 
 
 def run_payu_setup(config=config_orig, create_inputs=False,
-                   create_config_files=True):
+                   create_config_files=True, create_restarts=False, restartdir=None):
     """Helper function to write config.yaml files, make inputs,
     config files and run experiment setup"""
     # Setup files
@@ -80,6 +80,8 @@ def run_payu_setup(config=config_orig, create_inputs=False,
     make_exe()
     if create_inputs:
         make_inputs()
+    if create_restarts:
+        make_restarts(restartdir=restartdir)
     if create_config_files:
         make_config_files()
 
@@ -166,6 +168,43 @@ def test_setup_inputs(input_path, is_symlink, is_absolute):
         # Check fullpath is a resolved path
         assert Path(manifest_fullpath).is_absolute()
         assert not Path(manifest_fullpath).is_symlink()
+
+
+@pytest.mark.parametrize(
+    "restart_path, is_absolute",
+    [
+        (labdir / 'restart' / 'my_restart', False),
+        (ctrldir / 'ctrl_restart', False),
+        (tmpdir / 'tmp_restart', True)
+    ]
+)
+def test_setup_restart_paths(restart_path, is_absolute):
+    """Test restart paths are created in work directory,
+    and added to restart manifest"""
+    # Modify config to specify restart path
+    # If not is_absolute, use relative path to the control directory
+    config = copy.deepcopy(config_orig)
+    config['restart'] = str(restart_path) if is_absolute else os.path.relpath(restart_path, start=ctrldir)
+
+    # Run payu setup
+    run_payu_setup(config=config, create_inputs=True, create_config_files=True,
+                   create_restarts=True, restartdir=restart_path)
+
+    restart_manifest = get_manifests(ctrldir/'manifests')['restart.yaml']
+
+    for i in range(1, 4):
+        file_name = f'restart_00{i}.bin'
+
+        # Check relative path is added to manifest
+        filepath = str(Path('work') / file_name)
+        assert filepath in restart_manifest
+
+        # Check manifest fullpath
+        manifest_fullpath = restart_manifest[filepath]['fullpath']
+        assert manifest_fullpath == str(restart_path / file_name)
+
+        # Check fullpath is a resolved path
+        assert Path(manifest_fullpath).is_absolute()
 
 
 def test_setup():


### PR DESCRIPTION
Previously, `payu setup` and `payu run` would fail when a relative `restart:` path was configured in `config.yaml`.

This PR resolves relative restart paths to absolute paths, assuming that the restart paths is relative to the control directory. 

Closes #762 