### PR TITLE
Update softfilelock corresponding to filelock 3.30.0

### DIFF
--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -13,7 +13,7 @@ import requests
 import threading
 from typing import Any, Optional
 import warnings
-from filelock import FileLock, Timeout
+from filelock import SoftFileLock, Timeout
 
 import cftime
 
@@ -476,7 +476,7 @@ def update_job_file(
     Update the job file with the provided data
     and return the updated data
     """
-    lock = FileLock(str(file_path) + ".lock", lifetime=LOCK_LIFETIME, timeout=LOCK_TIMEOUT)
+    lock = SoftFileLock(str(file_path) + ".lock", lifetime=LOCK_LIFETIME, timeout=LOCK_TIMEOUT)
     try:
         with lock:
             run_info = read_job_file(file_path)

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -486,7 +486,7 @@ def test_update_job_file_timeout(tmp_path):
         json.dump(old_data, f)
 
     # Mock the file lock to always raise a Timeout
-    with patch('payu.telemetry.FileLock') as MockLock:
+    with patch('payu.telemetry.SoftFileLock') as MockLock:
         mock_lock_instance = MockLock.return_value
         mock_lock_instance.__enter__.side_effect = Timeout("Lock timed out")
 


### PR DESCRIPTION
A recent release of the `filelock` package changed the behavior of file lock expiration. From `filelock`[ 3.30.0](https://github.com/tox-dev/filelock/releases/tag/3.30.0), `FileLock` ignores the `lifetime` parameter; lock expiration now only applies to `SoftFileLock`.

This PR updates payu job file to use `SoftFileLock` instead of `FileLock`, making sure that the lock expires after `LOCK_LIFETIME = 8`.
