### PR TITLE
Include python 3.13 and 3.14 in CI test.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
     # Run the job for different versions of python
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -88,7 +88,7 @@ def generate_parser(is_interactive=False):
     subcmds = [importlib.import_module(mod) for mod in modnames]
 
     # Construct the subcommand parser
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog='payu')
     parser.add_argument('--version', action='version',
                         version='payu {0}'.format(payu.__version__))
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -450,16 +450,19 @@ def test_set_logger_runscript(log_level_arg, log_level_env, expected_log_level, 
 def test_parse_arg_count(capsys, monkeypatch):
     """Test that the parser correctly excludes --stacktrace when counting arguments."""
     # confirm print help is triggered when only --stacktrace is provided
-    monkeypatch.setattr(sys, "argv", ["payu --stacktrace"])
+    monkeypatch.setattr(sys, "argv", ["payu", "--stacktrace"])
     payu.cli.parse()
-    assert "usage: payu --stacktrace [-h] [--version]" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "usage: payu" in output
+    assert "[-h] [--version]" in output
 
     # confirm print help is not triggered when a subcommand is provided, even with --stacktrace
     monkeypatch.setattr(sys, "argv", ["payu", "list", "--stacktrace"])
     monkeypatch.setattr("payu.subcommands.list_cmd.runcmd", lambda *args, **kwargs: None)
     payu.cli.parse()
-    assert "usage: payu" not in capsys.readouterr().out
-    assert "[-h] [--version]" not in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "usage: payu" not in output
+    assert "[-h] [--version]" not in output
 
 
 


### PR DESCRIPTION
This PR updates python version in CI testing from ["3.10", "3.11", "3.12"] to ["3.10", "3.11", "3.12", "3.13", "3.14"].
Closes #812. 
Note that python3/3.13 and python3/3.14 is not available on Gadi, checked on 30/07/2026.