### PR TITLE
Add job dependency: run > collate > postscript > sync.

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -430,9 +430,6 @@ User Processing
    configured path to sync output to, i.e. ``path``, is the correct location 
    before enabling automatic syncing or before running ``payu sync``.
 
-   If postscript is also configured, the latest output and restart files will
-   not be automatically synced after a run.
-
    ``enable`` (*Default:* ``False``):
       Controls whether or not a sync job is submitted either after the archive or 
       collation job, if collation is enabled.

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -71,8 +71,9 @@ archive
 Post-processing PBS Jobs
 ======================
 
-After payu completes the experiment steps, there are some optional post-processing steps 
-which will submit follow-up PBS jobs to do further processing on the archived output.
+After the model run completes, payu can submit optional follow-up PBS jobs to perform further 
+processing on the archived output. Please see :ref:`Postprocessing` for more details about the 
+run order and manual submission of these jobs.
 
 collate
    When enabled, payu joins a number of smaller files which contain different
@@ -80,14 +81,13 @@ collate
 
 postscript
    Users can specify arbitrary post-processing scripts, which runs as a separate PBS job. 
-   This step is after the collate job is completed successfully, if collate is enabled.
+   This step runs after the model run and collate job (if enabled) have completed successfully.
 
 sync
    When enabled, payu syncs the archive directory with a specificed remote directory.
-   Payu sync job is submitted after the collate job is completed successfully, if collate is enabled.
-   Currently, ``postscript`` and ``sync`` jobs are submitted at the same time.
-   As a result, ``payu sync`` does not wait for the postscript job to complete, 
-   and does not sync the most recent ``output`` directory (see :ref:`Postprocessing` and :ref:`User_processing`).
+   The sync job runs after the model run, collate job (if enabled), and postscript job (if enabled) 
+   have completed successfully.
+   
 
 Style Guide
 ===========

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -416,6 +416,24 @@ Other experiment runs will not be harmed by this command.
 Postprocessing
 ==============
 
+By default, payu submits all enabled postprocessing jobs automatically after the model run has completed.
+Postprocessing includes 
+- collate, 
+- postscript, 
+- sync. 
+These jobs can also be run manually if required.
+When payu submits postprocessing jobs, it adds job dependencies to ensure that they run in the correct order:: 
+
+   collate -> postscript -> sync
+
+If a postprocessing job failed, any subsequent job(s) will be terminated and removed from the queue.
+You can use ``payu status`` to check the status of all postprocessing jobs.
+To clean up postprocessing jobs that have been killed, please run ``payu status --update`` once.
+
+
+Collate
+--------
+
 Model output in parallel jobs is sometimes divided across several files, which
 can be inconvenient for analysis. Payu offers a ``collate`` subcommand to
 collate these separated files into a single file. This is only necessary, and 
@@ -446,6 +464,21 @@ using the ``-c`` option::
 
 This allows payu to use the collation settings from the specified ``config.yaml``
 while reading the uncollated files from the directory provided with ``-d``.
+
+When ``payu collate`` is called, payu will submit the subsequent postscript and sync jobs 
+after collation has completed, if they are enabled in the configuration file. 
+
+Postscript
+----------
+
+You may configure the postscript job in the configuration file (see :ref:`config`),
+which will run after the model run and collation (if enabled) has completed.
+To manually run the postscript for a specific run ``K``, please use::
+
+   payu postscript -i K
+
+Sync
+----
 
 To manually sync experiment output files to a remote archive, firstly ensure
 that ``path`` in the ``sync`` namespace in ``config.yaml``, 

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -215,7 +215,7 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     return payu_env_vars
 
 
-def submit_job(script, config, vars=None, expt=None, current_run=None, type=None, dry_run=False):
+def submit_job(script, config, vars=None, expt=None, current_run=None, type=None, dry_run=False, depends_on=None):
     """Submit a userscript the scheduler and return the job ID"""
 
     sched_name = config.get('scheduler', DEFAULT_SCHEDULER_CONFIG)
@@ -225,18 +225,18 @@ def submit_job(script, config, vars=None, expt=None, current_run=None, type=None
     try:
         if sched_name == 'pbs':
             # Use HPCpy to submit the job in PBS
-            job_or_cmd = sched.submit(script, config, vars, dry_run=dry_run)
-
             if dry_run:
                 # If dry_run is True, print out the submission command and exit
+                cmd = sched.submit(script, config, vars, dry_run=dry_run, depends_on=depends_on)
                 print(f"---- Dry run (submission skipped) -----\n"
-                    f"Generated command: {job_or_cmd}")
+                    f"Generated command: {cmd}")
                 return None
             else:
                 # Print the job ID and command after submission 
+                job = sched.submit(script, config, vars, dry_run=dry_run, depends_on=depends_on)
                 print(f"------ Job submitted ------\n"
-                    f"Submitted command: {job_or_cmd.history[0]}")
-                job_id = job_or_cmd.id
+                    f"Submitted command: {job.history[0]}")
+                job_id = job.id
                 print(f"Job ID: {job_id}")
         
         elif sched_name == 'slurm':
@@ -282,6 +282,7 @@ def submit_job(script, config, vars=None, expt=None, current_run=None, type=None
             scheduler=expt.scheduler,
             metadata=expt.metadata,
             current_run=current_run,
+            depends_on=depends_on
         )
 
     return job_id

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -215,7 +215,8 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     return payu_env_vars
 
 
-def submit_job(script, config, vars=None, expt=None, current_run=None, type=None, dry_run=False, depends_on=None):
+def submit_job(script, config, vars=None, expt=None, current_run=None, 
+               type=None, dry_run=False, depends_on=None, postscript=False):
     """Submit a userscript the scheduler and return the job ID"""
 
     sched_name = config.get('scheduler', DEFAULT_SCHEDULER_CONFIG)
@@ -227,13 +228,13 @@ def submit_job(script, config, vars=None, expt=None, current_run=None, type=None
             # Use HPCpy to submit the job in PBS
             if dry_run:
                 # If dry_run is True, print out the submission command and exit
-                cmd = sched.submit(script, config, vars, dry_run=dry_run, depends_on=depends_on)
+                cmd = sched.submit(script, config, vars, dry_run=dry_run, depends_on=depends_on, postscript=postscript)
                 print(f"---- Dry run (submission skipped) -----\n"
                     f"Generated command: {cmd}")
                 return None
             else:
                 # Print the job ID and command after submission 
-                job = sched.submit(script, config, vars, dry_run=dry_run, depends_on=depends_on)
+                job = sched.submit(script, config, vars, dry_run=dry_run, depends_on=depends_on, postscript=postscript)
                 print(f"------ Job submitted ------\n"
                     f"Submitted command: {job.history[0]}")
                 job_id = job.id

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -134,7 +134,7 @@ def get_model_type(model_type, config):
 def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
                  reproduce=None, force=False, force_prune_restarts=False,
                  sync_restarts=False, sync_ignore_last=False, runlog_off=False,
-                 repeat=False):
+                 repeat=False, exist_workflow=False):
     """Construct the environment variables used by payu for resubmissions."""
     payu_env_vars = {}
 
@@ -199,6 +199,9 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
 
     if repeat:
         payu_env_vars['PAYU_REPEAT'] = repeat
+        
+    if exist_workflow:
+        payu_env_vars['PAYU_EXIST_WORKFLOW'] = exist_workflow
 
     # Pass through important module related environment variables
     module_env_vars = ['MODULESHOME', 'MODULES_CMD', 'MODULEPATH', 'MODULEV']

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -8,6 +8,7 @@
 """
 # Standard imports
 import argparse
+import json
 import sysconfig
 import importlib
 import os
@@ -201,7 +202,7 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
         payu_env_vars['PAYU_REPEAT'] = repeat
         
     if exist_workflow:
-        payu_env_vars['PAYU_EXIST_WORKFLOW'] = exist_workflow
+       payu_env_vars['PAYU_EXIST_WORKFLOW'] = exist_workflow
 
     # Pass through important module related environment variables
     module_env_vars = ['MODULESHOME', 'MODULES_CMD', 'MODULEPATH', 'MODULEV']
@@ -239,7 +240,7 @@ def submit_job(script, config, vars=None, expt=None, current_run=None,
                 # Print the job ID and command after submission 
                 job = sched.submit(script, config, vars, dry_run=dry_run, depends_on=depends_on, postscript=postscript)
                 print(f"------ Job submitted ------\n"
-                    f"Submitted command: {job.history[0]}")
+                    f"Submitted command: {job.history[-1]}")
                 job_id = job.id
                 print(f"Job ID: {job_id}")
         

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -59,14 +59,6 @@ core_modules = ['python', 'payu']
 # Default payu parameters
 default_restart_freq = 5
 
-# Default job dependency
-DEFAULT_DEPENDENCIES = {
-    "collate": ["run"],
-    "postscript": ["run", "collate"],
-    "sync": ["run", "collate", "postscript"],
-}
-
-
 def timeit(time_name):
     """Decorator to time a function and store the elapsed time in seconds
     to the timings dictionary in the class"""
@@ -980,14 +972,16 @@ class Experiment(object):
             sp.check_call(shlex.split(cmd))
 
     def build_workflow(self):
-        """Build the workflow for the current run, including run, collate, postscript and sync steps."""
-        workflow = []
+        """Build the workflow for the current experiment, e.g.,
+        {"run": None, "collate": None, "postscript": None, "sync": None}. 
+        The value will be updated as job id when available"""
+        workflow = dict()
         if self.config.get('collate', {}).get('enable', True):
-            workflow.append('collate')
+            workflow['collate'] = None
         if self.postscript:
-            workflow.append('postscript')
+            workflow['postscript'] = None
         if self.config.get('sync', {}).get('enable', False):
-            workflow.append('sync')
+            workflow['sync'] = None
         return workflow
     
     @timeit("payu_collate_duration_seconds")
@@ -1054,14 +1048,14 @@ class Experiment(object):
     def set_userscript_env_vars(self):
         """Save information of output directories and current run to
         environment variables, so they can be accessed via user-scripts"""
-        os.environ.update(
-            {
+        update_env_vars = {
                 'PAYU_CURRENT_OUTPUT_DIR': self.output_path,
                 'PAYU_CURRENT_RESTART_DIR': self.restart_path,
                 'PAYU_ARCHIVE_DIR': self.archive_path,
                 'PAYU_CURRENT_RUN': str(self.counter)
             }
-        )
+        os.environ.update(update_env_vars)
+        return update_env_vars
 
     def run_userscript(self, script_cmd: str, type: str):
         """Run a user defined script or subcommand at various stages of the

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -1006,7 +1006,7 @@ class Experiment(object):
 
     @timeit("payu_sync_duration_seconds")
     def sync(self):
-        # Update collate stage to running
+        # Update sync stage to running
         telemetry.update_job_file(
             file_path=self.get_job_file(type='sync'),
             data={"stage": "running"}

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -970,19 +970,6 @@ class Experiment(object):
                 expt=self.counter
             )
             sp.check_call(shlex.split(cmd))
-
-    def build_workflow(self):
-        """Build the workflow for the current experiment, e.g.,
-        {"run": None, "collate": None, "postscript": None, "sync": None}. 
-        The value will be updated as job id when available"""
-        workflow = dict()
-        if self.config.get('collate', {}).get('enable', True):
-            workflow['collate'] = None
-        if self.postscript:
-            workflow['postscript'] = None
-        if self.config.get('sync', {}).get('enable', False):
-            workflow['sync'] = None
-        return workflow
     
     @timeit("payu_collate_duration_seconds")
     def collate(self):

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -38,7 +38,6 @@ from payu.fsops import make_symlink, read_config, movetree
 from payu.fsops import list_sorted_archive_dirs
 from payu.fsops import run_script_command
 from payu.fsops import get_size, str_to_bool
-from payu.fsops import get_job_id_given_job_type
 from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
 from payu.models import index as model_index
 from payu.runlog import Runlog
@@ -49,6 +48,7 @@ from payu.metadata import Metadata
 import payu.telemetry as telemetry
 from payu.git_utils import get_git_repository
 import payu.errors as errors
+
 
 # Setup logger
 logger = logging.getLogger(__name__)
@@ -88,6 +88,7 @@ class Experiment(object):
                  runlog_off=False, repeat=False):
         self.init_timings()
         self.lab = lab
+        self.config_path = config_path
         # Check laboratory directories are writable
         self.lab.initialize()
 
@@ -970,16 +971,6 @@ class Experiment(object):
             restart_volume_gb=get_size(self.restart_path),
         )
 
-        collate_config = self.config.get('collate', {})
-        collating = collate_config.get('enable', True)
-        if collating:
-            cmd = '{python} {payu} collate -i {expt}'.format(
-                python=sys.executable,
-                payu=self.payu_path,
-                expt=self.counter
-            )
-            sp.check_call(shlex.split(cmd))
-
         if self.config.get('hpctoolkit', False):
             cmd = '{python} {payu} profile -i {expt}'.format(
                 python=sys.executable,
@@ -988,9 +979,17 @@ class Experiment(object):
             )
             sp.check_call(shlex.split(cmd))
 
-        # Call postprocessing step after collation
-        self.postprocess()
-
+    def build_workflow(self):
+        """Build the workflow for the current run, including run, collate, postscript and sync steps."""
+        workflow = []
+        if self.config.get('collate', {}).get('enable', True):
+            workflow.append('collate')
+        if self.postscript:
+            workflow.append('postscript')
+        if self.config.get('sync', {}).get('enable', False):
+            workflow.append('sync')
+        return workflow
+    
     @timeit("payu_collate_duration_seconds")
     def collate(self):
         """ Run model collation and record the time taken in seconds to run collation"""
@@ -1023,67 +1022,6 @@ class Experiment(object):
     def profile(self):
         for model in self.models:
             model.profile()
-
-    def get_dependency_job_ids(self, current_job_type: str) -> list:
-        if current_job_type not in self.dependencies:
-            raise errors.PayuRuntimeError(
-                f"Current job type '{current_job_type}' not found in dependencies list: "
-                f"{self.dependencies}"
-            )
-
-        depends_on = []
-        for job_type in self.dependencies[current_job_type]:
-            job_id = get_job_id_given_job_type(self, job_type)
-
-            if job_id:
-                depends_on.append(job_id)
-        return depends_on
-            
-            
-    def postprocess(self):
-        """Submit any postprocessing scripts or remote syncing if enabled"""
-
-        # First submit postprocessing script
-        if self.postscript:
-            self.set_userscript_env_vars()
-            envmod.setup()
-            envmod.module('load', 'pbs')
-
-            # Postscript depends on run and collate jobs, if any of them exist
-            depends_on = self.get_dependency_job_ids('postscript')
-            
-            # Submit through HPCpy
-            # Job name is set to "payu_postscript"
-            postscript_job = client.submit(job_script = f"{self.postscript}",
-                      directives = ['-N payu_postscript'],
-                      depends_on = depends_on
-                      )
-            print(f"--- Postscript submitted ---\n"
-                f"Submitted command: {postscript_job.history[0]}\n"
-                f"Job ID: {postscript_job.id}.\n")
-
-            # Write postscript job file to archive/payu_jobs/{run_number}/postscript/{job_id}-gadi-pbs.json
-            telemetry.write_queued_job_file(
-                        archive_path=Path(self.archive_path),
-                        job_id=postscript_job.id,
-                        type='postscript',
-                        scheduler=self.scheduler,
-                        metadata=self.metadata,
-                        current_run=self.counter,
-                        depends_on=depends_on,
-                    )
-
-        # Submit a sync script if remote syncing is enabled
-        sync_config = self.config.get('sync', {})
-        syncing = sync_config.get('enable', False)
-        if syncing:
-            cmd = '{python} {payu} sync -i {expt}'.format(
-                python=sys.executable,
-                payu=self.payu_path,
-                expt=self.counter
-            )
-
-            sp.check_call(shlex.split(cmd))
 
     @timeit("payu_sync_duration_seconds")
     def sync(self):

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -27,6 +27,9 @@ import logging
 # Extensions
 from ruamel.yaml import YAML
 from packaging import version
+import hpcpy
+
+client = hpcpy.client.pbs.PBSClient()
 
 # Local
 import payu
@@ -34,8 +37,8 @@ from payu import envmod
 from payu.fsops import make_symlink, read_config, movetree
 from payu.fsops import list_sorted_archive_dirs
 from payu.fsops import run_script_command
-from payu.fsops import needs_subprocess_shell
 from payu.fsops import get_size, str_to_bool
+from payu.fsops import get_job_id_given_job_type
 from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
 from payu.models import index as model_index
 from payu.runlog import Runlog
@@ -55,6 +58,13 @@ core_modules = ['python', 'payu']
 
 # Default payu parameters
 default_restart_freq = 5
+
+# Default job dependency
+DEFAULT_DEPENDENCIES = {
+    "collate": ["run"],
+    "postscript": ["run", "collate"],
+    "sync": ["run", "collate", "postscript"],
+}
 
 
 def timeit(time_name):
@@ -978,9 +988,8 @@ class Experiment(object):
             )
             sp.check_call(shlex.split(cmd))
 
-        # Ensure postprocessing runs if model not collating
-        if not collating:
-            self.postprocess()
+        # Call postprocessing step after collation
+        self.postprocess()
 
     @timeit("payu_collate_duration_seconds")
     def collate(self):
@@ -1015,6 +1024,22 @@ class Experiment(object):
         for model in self.models:
             model.profile()
 
+    def get_dependency_job_ids(self, current_job_type: str) -> list:
+        if current_job_type not in self.dependencies:
+            raise errors.PayuRuntimeError(
+                f"Current job type '{current_job_type}' not found in dependencies list: "
+                f"{self.dependencies}"
+            )
+
+        depends_on = []
+        for job_type in self.dependencies[current_job_type]:
+            job_id = get_job_id_given_job_type(self, job_type)
+
+            if job_id:
+                depends_on.append(job_id)
+        return depends_on
+            
+            
     def postprocess(self):
         """Submit any postprocessing scripts or remote syncing if enabled"""
 
@@ -1024,13 +1049,29 @@ class Experiment(object):
             envmod.setup()
             envmod.module('load', 'pbs')
 
-            # Name of this PBS job is set to "payu_postscript"
-            cmd = 'qsub -N payu_postscript {script}'.format(script=self.postscript)
+            # Postscript depends on run and collate jobs, if any of them exist
+            depends_on = self.get_dependency_job_ids('postscript')
+            
+            # Submit through HPCpy
+            # Job name is set to "payu_postscript"
+            postscript_job = client.submit(job_script = f"{self.postscript}",
+                      directives = ['-N payu_postscript'],
+                      depends_on = depends_on
+                      )
+            print(f"--- Postscript submitted ---\n"
+                f"Submitted command: {postscript_job.history[0]}\n"
+                f"Job ID: {postscript_job.id}.\n")
 
-            if needs_subprocess_shell(cmd):
-                sp.check_call(cmd, shell=True)
-            else:
-                sp.check_call(shlex.split(cmd))
+            # Write postscript job file to archive/payu_jobs/{run_number}/postscript/{job_id}-gadi-pbs.json
+            telemetry.write_queued_job_file(
+                        archive_path=Path(self.archive_path),
+                        job_id=postscript_job.id,
+                        type='postscript',
+                        scheduler=self.scheduler,
+                        metadata=self.metadata,
+                        current_run=self.counter,
+                        depends_on=depends_on,
+                    )
 
         # Submit a sync script if remote syncing is enabled
         sync_config = self.config.get('sync', {})
@@ -1042,18 +1083,16 @@ class Experiment(object):
                 expt=self.counter
             )
 
-            if self.postscript:
-                print('payu: warning: postscript is configured, so by default '
-                      'the lastest outputs will not be synced. To sync the '
-                      'latest output, after the postscript job has completed '
-                      'run:\n'
-                      '    payu sync')
-                cmd += f' --sync-ignore-last'
-
             sp.check_call(shlex.split(cmd))
 
     @timeit("payu_sync_duration_seconds")
     def sync(self):
+        # Update collate stage to running
+        telemetry.update_job_file(
+            file_path=self.get_job_file(type='sync'),
+            data={"stage": "running"}
+        )
+
         # RUN any user scripts before syncing archive
         envmod.setup()
         pre_sync_script = self.userscripts.get('sync')

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -423,19 +423,3 @@ def str_to_bool(value):
         raise ValueError(f"Input is not acceptable. Please use 'True' or 'False' or '1' or '0'.")
     
 
-def get_job_id_given_job_type(expt, job_type):
-    """Get the job ID out of the most recent job file, given a specific type (run, collate, sync) for the current experiment."""
-    job_dir = Path(expt.archive_path) / "payu_jobs" / str(expt.counter) / job_type
-
-    if not job_dir.exists():
-        return None
-
-    # Get the most recent job file in the job directory
-    job_files = sorted(job_dir.glob("*.json"), key=lambda f: f.stat().st_mtime, reverse=True)
-    if not job_files:
-        return None
-
-    # Read the job ID from the most recent job file
-    with job_files[0].open('r') as f:
-        job_data = json.load(f)
-        return job_data.get("scheduler_job_id", None)

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -205,7 +205,9 @@ def check_exe_path(payu_path, pbs_script):
     if not os.path.isabs(pbs_script):
         pbs_script = os.path.join(payu_path, pbs_script)
 
-    assert os.path.isfile(pbs_script)
+    if not os.path.isfile(pbs_script):
+        raise errors.PayuRuntimeError(
+            'Payu executable not found at {0}.'.format(pbs_script))
 
     return pbs_script
 
@@ -419,3 +421,21 @@ def str_to_bool(value):
         return False
     else:
         raise ValueError(f"Input is not acceptable. Please use 'True' or 'False' or '1' or '0'.")
+    
+
+def get_job_id_given_job_type(expt, job_type):
+    """Get the job ID out of the most recent job file, given a specific type (run, collate, sync) for the current experiment."""
+    job_dir = Path(expt.archive_path) / "payu_jobs" / str(expt.counter) / job_type
+
+    if not job_dir.exists():
+        return None
+
+    # Get the most recent job file in the job directory
+    job_files = sorted(job_dir.glob("*.json"), key=lambda f: f.stat().st_mtime, reverse=True)
+    if not job_files:
+        return None
+
+    # Read the job ID from the most recent job file
+    with job_files[0].open('r') as f:
+        job_data = json.load(f)
+        return job_data.get("scheduler_job_id", None)

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -347,20 +347,20 @@ class PBS(Scheduler):
     def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None, 
                dry_run=False, depends_on=None, postscript=False):
         """Prepare a correct PBS command string"""
+        # Initialisation
+        if pbs_vars is None:
+            pbs_vars = {}
 
         if postscript:
             # Directly submit the postscript, no configuring the environment variables
             job_or_cmd = client.submit(job_script = f"{pbs_script}",
                             directives = ["-N payu_postscript"],
+                            variables = pbs_vars,
                             dry_run = dry_run,
                             depends_on = depends_on,
                             )
     
             return job_or_cmd
-
-        # Initialisation
-        if pbs_vars is None:
-            pbs_vars = {}
 
         if python_exe is None:
             python_exe = sys.executable

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -344,8 +344,19 @@ class PBS(Scheduler):
                 f"than the limit of {mem_per_node:.2f}GB per node for queue '{queue}'."
             )
 
-    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None, dry_run=False, depends_on=None):
+    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None, 
+               dry_run=False, depends_on=None, postscript=False):
         """Prepare a correct PBS command string"""
+
+        if postscript:
+            # Directly submit the postscript, no configuring the environment variables
+            job_or_cmd = client.submit(job_script = f"{pbs_script}",
+                            directives = ["-N payu_postscript"],
+                            dry_run = dry_run,
+                            depends_on = depends_on,
+                            )
+    
+            return job_or_cmd
 
         # Initialisation
         if pbs_vars is None:
@@ -492,7 +503,7 @@ class PBS(Scheduler):
 
         return jobid
 
-    def get_job_info(self) -> Optional[Dict[str, Any]]:
+    def get_job_info(self, jobid=None) -> Optional[Dict[str, Any]]:
         """
         Get information about the job from the PBS server
 
@@ -501,7 +512,8 @@ class PBS(Scheduler):
         Optional[Dict[str, Any]]
             Dictionary of information extracted from qstat output
         """
-        jobid = self.get_job_id()
+        if not jobid:
+            jobid = self.get_job_id()
 
         info = None
 

--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -344,7 +344,7 @@ class PBS(Scheduler):
                 f"than the limit of {mem_per_node:.2f}GB per node for queue '{queue}'."
             )
 
-    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None, dry_run=False):
+    def submit(self, pbs_script, pbs_config, pbs_vars=None, python_exe=None, dry_run=False, depends_on=None):
         """Prepare a correct PBS command string"""
 
         # Initialisation
@@ -465,6 +465,7 @@ class PBS(Scheduler):
                       queue = pbs_config.get('queue', 'normal'),
                       storage = list(storages) if storages else None,
                       variables = pbs_vars,
+                      depends_on = depends_on,
                       )
 
         return job_or_cmd

--- a/payu/status.py
+++ b/payu/status.py
@@ -4,6 +4,7 @@ payu runs by inspecting the job files generated for telemetry,
 scheduler stdout/stderr logs, and querying the scheduler
 """
 from pathlib import Path
+import re
 from typing import Any, Optional
 import warnings
 from datetime import datetime
@@ -454,10 +455,38 @@ def display_expt_paths(expt_paths):
     print("=" * line_width)
 
 
+def parse_exit_status_from_logs(stdout):
+    """
+    Attempt to parse the exit status from stdout/stderr logs.
+    
+    Returns:
+        Exit status code (int) if found, None otherwise
+    """
+    if not stdout or not stdout.exists():
+        logger.debug(f"Stdout file {stdout} does not exist, cannot parse exit status.")
+        return None
+    
+    try:
+        content = stdout.read_text()
+        # Look for a line that is "Exit status: N"
+        match = re.search(r"Exit Status:\s*(\d+)", content)
+        if match:
+            return int(match.group(1))
+    except (IOError, ValueError, OSError) as e:
+        logger.debug(f"Could not read exit status from stdout file {stdout}: {e}")
+    
+    return None
+
+
 def update_postscript_job_file(data, scheduler, job_file, stdout, stderr):
-    """Check if the postscript log file exists,  update the stage to exited and update scheduler info.
-     Otherwise, update from queued to queued/running,
-    Return the updated job file data"""
+    """Check if the postscript log file exists, update the stage to exited and update scheduler info.
+    Otherwise, update to running of status is "R".
+    
+    When the job has aged out of the scheduler, attempt to parse the exit status
+    from the log files as a fallback mechanism.
+    
+    Return the updated job file data
+    """
     job_id = data.get("scheduler_job_id")
         
     # If both stdout and stderr exist, update the stage to exited
@@ -465,9 +494,21 @@ def update_postscript_job_file(data, scheduler, job_file, stdout, stderr):
         data["stage"] = "exited"
 
         # Update the scheduler info by calling qstat -xf -F json job_id
+        exit_status = None
         if job_id and scheduler:
-            data["scheduler_job_info"] = scheduler.get_job_info(job_id)
-            data["payu_postscript_status"] = data["scheduler_job_info"].get("Jobs", {}).get(job_id, {}).get("Exit_status")
+            scheduler_info = scheduler.get_job_info(job_id)
+
+            if scheduler_info:
+                # Job still in scheduler - get exit status from scheduler
+                data["scheduler_job_info"] = scheduler_info
+                exit_status = scheduler_info.get("Jobs", {}).get(job_id, {}).get("Exit_status")
+            else:
+                # Job has aged out - try to parse from logs
+                logger.debug(f"Job {job_id} not found in scheduler, attempting to parse exit status from logs")
+                exit_status = parse_exit_status_from_logs(stdout)
+        
+        if exit_status is not None:
+            data["payu_postscript_status"] = exit_status
 
         update_job_file(job_file, data)
 

--- a/payu/status.py
+++ b/payu/status.py
@@ -198,8 +198,8 @@ def build_job_info(
                 type=data.get("scheduler_type")
             )
 
-            if job_type == "postscript":
-                data = update_postscript_job_file(data, job_file, stdout, stderr)
+            if job_type == "postscript" and "running" in data["stage"]:
+                data = update_postscript_job_file(data, expt.scheduler, job_file, stdout, stderr)
 
             run_info = {
                 "job_id": data.get("scheduler_job_id"),
@@ -310,11 +310,11 @@ def update_all_job_files(
             exit_status = None
             job_state = None
 
-        if exit_status and stage == "queued":
+        if exit_status and "queued" in stage:
             # Job has exited, but is still marked as queued in the job file
             remove_job_file(file_path=job_file)
 
-        elif job_state == "F" and stage == "queued":
+        elif job_state == "F" and "queued" in stage:
             # Job is killed or deleted but still exists in the job file
             remove_job_file(file_path=job_file)
 
@@ -454,21 +454,26 @@ def display_expt_paths(expt_paths):
     print("=" * line_width)
 
 
-def update_postscript_job_file(data, job_file, stdout, stderr):
-    """Check if the postscript log file exists and update the stage to exited or queued/running,
+def update_postscript_job_file(data, scheduler, job_file, stdout, stderr):
+    """Check if the postscript log file exists,  update the stage to exited and update scheduler info.
+     Otherwise, update from queued to queued/running,
     Return the updated job file data"""
+    job_id = data.get("scheduler_job_id")
+        
     # If both stdout and stderr exist, update the stage to exited
-    if stdout and stdout.exists() and stderr and stderr.exists():
+    if stdout and stderr and stdout.exists() and stderr.exists():
         data["stage"] = "exited"
 
-        # Write the updated job file
-        json.dump(data, job_file.open("w"), indent=4)
+        # Update the scheduler info by calling qstat -xf -F json job_id
+        if job_id and scheduler:
+            data["scheduler_job_info"] = scheduler.get_job_info(job_id)
+            data["payu_postscript_status"] = data["scheduler_job_info"].get("Jobs", {}).get(job_id, {}).get("Exit_status")
 
-    elif data["stage"] == "queued":
-        # If stdout or stderr is not ready, update the stage to queued/running
-        data["stage"] = "queued/running"
+        update_job_file(job_file, data)
 
-        # Write the updated job file
-        json.dump(data, job_file.open("w"), indent=4)
+    # If stdout and stderr are not ready, check if job_state is running (happens when user called payu status --update)
+    elif data.get("scheduler_job_info", {}).get("Jobs", {}).get(job_id, {}).get("job_state", None) == "R":
+        data["stage"] = "running"
+        update_job_file(job_file, data)
         
     return data

--- a/payu/status.py
+++ b/payu/status.py
@@ -493,7 +493,7 @@ def update_postscript_job_file(data, scheduler, job_file, stdout, stderr):
     if stdout and stderr and stdout.exists() and stderr.exists():
         data["stage"] = "exited"
 
-        # Update the scheduler info by calling qstat -xf -F json job_id
+        # Update the scheduler info by querying the scheduler
         exit_status = None
         if job_id and scheduler:
             scheduler_info = scheduler.get_job_info(job_id)

--- a/payu/status.py
+++ b/payu/status.py
@@ -178,7 +178,7 @@ def build_job_info(
     """
     status_data: dict[str, Any] = {}
     runs: dict[int, dict[str, list]] = {}
-    for job_type in ["run", "collate"]:
+    for job_type in ["run", "collate", "postscript", "sync"]:
         job_files = get_job_file_list(archive_path, run_number, all_runs, type=job_type)
         # If no job files found for this type, skip to the next type
         if not job_files:
@@ -198,6 +198,9 @@ def build_job_info(
                 type=data.get("scheduler_type")
             )
 
+            if job_type == "postscript":
+                data = update_postscript_job_file(data, job_file, stdout, stderr)
+
             run_info = {
                 "job_id": data.get("scheduler_job_id"),
                 "stage": data.get("stage"),
@@ -206,6 +209,7 @@ def build_job_info(
                 "stderr_file": str(stderr) if stderr else None,
                 "job_file": str(job_file),
                 "start_time": data.get("timings", {}).get("payu_start_time"),
+                "depends_on": data.get("depends_on"),
             }
 
             if job_type == "run":
@@ -384,6 +388,7 @@ def display_job_info(data: dict[str, Any]) -> None:
                 print(f"  {'-' * 13} {job_type.capitalize()} Info {'-' * 13}")
                 print_line("Job ID", "job_id", job_info)
                 print_line("Run ID", "run_id", job_info)
+                print_line("Job Dependencies", "depends_on", job_info)
                 print_line("Stage", "stage", job_info)
 
                 # Read out qtime and stime from the job file and display queue time
@@ -447,3 +452,23 @@ def display_expt_paths(expt_paths):
     print_line("Archive Directory", "archive_path", expt_paths, description = "Where all experiment outputs are stored")
     print_line("Sync Destination", "sync_path", expt_paths, description = "Remote directory to sync outputs to")
     print("=" * line_width)
+
+
+def update_postscript_job_file(data, job_file, stdout, stderr):
+    """Check if the postscript log file exists and update the stage to exited or queued/running,
+    Return the updated job file data"""
+    # If both stdout and stderr exist, update the stage to exited
+    if stdout and stdout.exists() and stderr and stderr.exists():
+        data["stage"] = "exited"
+
+        # Write the updated job file
+        json.dump(data, job_file.open("w"), indent=4)
+
+    elif data["stage"] == "queued":
+        # If stdout or stderr is not ready, update the stage to queued/running
+        data["stage"] = "queued/running"
+
+        # Write the updated job file
+        json.dump(data, job_file.open("w"), indent=4)
+        
+    return data

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -4,17 +4,26 @@
 import argparse
 import os
 from pathlib import Path
+import json
 
 # Local
 from payu import cli
 from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
-from payu.telemetry import record_run, get_job_file_path_with_id
+from payu.telemetry import record_run
 from payu.fsops import read_config
+import payu.errors as errors
 
 from payu.subcommands.postscript_cmd import submit_postscript
 from payu.subcommands.sync_cmd import submit_sync
+from payu.workflow import Workflow
+
+# A function lookup dictionary for subcommand job submission functions in runscript
+fn = {
+    "postscript": submit_postscript,
+    "sync": submit_sync
+}
 
 title = 'collate'
 parameters = {'description': 'Collate tiled output into single output files'}
@@ -22,14 +31,17 @@ parameters = {'description': 'Collate tiled output into single output files'}
 arguments = [args.model, args.config, args.initial, args.laboratory,
              args.dir_path, args.dry_run]
 
-def submit_collate(expt, depends_on=None):
+def submit_collate(counter, depends_on=None):
     """ Submit the collate job by calling runcmd.
     Return the job id of the collate job"""
-    job_id = runcmd(
-            init_run=expt.counter,
-            depends_on=depends_on,
-            exist_workflow=True
-        )
+    try:
+        job_id = runcmd(
+                init_run=counter,
+                depends_on=depends_on,
+                exist_workflow=True,
+                )
+    except Exception as e:
+        raise errors.PayuRuntimeError(f"Failed to submit collate job: {e}")
     return job_id
 
 
@@ -126,52 +138,30 @@ def runscript(**run_args):
     for var in pbs_vars:
         os.environ[var] = str(pbs_vars[var])
 
-    # Get exist_workflow from environment variable (passed from runcmd via PBS)
-    exist_workflow = os.environ.get('PAYU_EXIST_WORKFLOW', 'false').lower() == 'true'
-    workflow = dict()
-
     lab = Laboratory(run_args.model_type,
                      run_args.config_path,
                      run_args.lab_path)
     expt = Experiment(lab)
+
+    # Initialise the Workflow class to manage the workflow
+    workflow = Workflow(expt.config,
+                        run_number=expt.counter)
+    
     try:
         # Collate the model output
         expt.collate()
 
-        # Build workflow chain if no workflow is provided in collate runcmd
-        if not exist_workflow:
-            workflow = expt.build_workflow()
-            workflow.pop('collate', None)
-
-            # Submit each job in the workflow, pass the job ID onto the next job as dependency
-            next_depends_on = expt.scheduler.get_job_id(short=False)
-            for step in workflow.keys():
-                if step == 'postscript':
-                    postscript_job_id = submit_postscript(expt, depends_on=next_depends_on)
-                    next_depends_on = postscript_job_id
-                elif step == 'sync':
-                    sync_job_id = submit_sync(expt, depends_on=next_depends_on)
-                    next_depends_on = sync_job_id
-                # Update the workflow dictionary with the job ID for each step
-                workflow[step] = next_depends_on
-
         # If collation succeeds, then collate_status is set to 0
         collate_status = 0
-
+        
     except:
         # If collation fails, then collate_status is set to 1
         collate_status = 1
-        # If collate fails, remove job files of all dependent jobs
-        # Only when collate builds its own workflow
-        if not exist_workflow and workflow:
-            for step, job_id in workflow.items():
-                job_file_path = get_job_file_path_with_id(
-                                    archive_path=Path(expt.archive_path),
-                                    run_number=expt.counter,
-                                    job_id=job_id,
-                                    type=step
-                                )
-                job_file_path.unlink(missing_ok=True)
+
+        # If collate is called by payu-run, there may be postscript/sync waiting in queue
+        # Clean up any later jobs in the workflow
+        # workflow.clean_up(failed_step='collate', job_file=expt.get_job_file(type='run'))
+
         raise
     
     finally:
@@ -190,3 +180,10 @@ def runscript(**run_args):
             stage="exited"
         )
 
+        # Submit follow-up jobs in the workflow, if payu-collate succeed and not called by payu-run
+        exist_workflow = os.environ.get('PAYU_EXIST_WORKFLOW', 'false').lower() == 'true'
+
+        if collate_status == 0 and not exist_workflow:
+            workflow.build_workflow(expt.postscript)
+            workflow.workflow_steps.pop('collate', None)
+            workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False))

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -11,7 +11,7 @@ from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu.telemetry import record_run
-from payu import fsops
+from payu.fsops import read_config, get_job_id_given_job_type
 
 title = 'collate'
 parameters = {'description': 'Collate tiled output into single output files'}
@@ -22,7 +22,7 @@ arguments = [args.model, args.config, args.initial, args.laboratory,
 
 def runcmd(model_type, config_path, init_run, lab_path, dir_path, dry_run=False):
 
-    pbs_config = fsops.read_config(config_path)
+    pbs_config = read_config(config_path)
     pbs_vars = cli.set_env_vars(init_run=init_run,
                                 lab_path=lab_path,
                                 dir_path=dir_path)
@@ -94,7 +94,8 @@ def runcmd(model_type, config_path, init_run, lab_path, dir_path, dry_run=False)
 
     # Submit the collation job and write queue job file
     cli.submit_job('payu-collate', pbs_config, pbs_vars, expt=expt, 
-                current_run = int(init_run) if init_run else None, type='collate', dry_run=dry_run)
+                current_run = int(init_run) if init_run else None, type='collate', 
+                dry_run=dry_run, depends_on=expt.get_dependency_job_ids('collate'))
 
     
 

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -171,4 +171,5 @@ def runscript(**run_args):
         exist_workflow = str_to_bool(os.environ.get('PAYU_EXIST_WORKFLOW', 'false'))
 
         if collate_status == 0 and not exist_workflow:
-            workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False))
+            workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False),
+                                    config=expt.config)

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -12,7 +12,7 @@ from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu.telemetry import record_run
-from payu.fsops import read_config
+from payu.fsops import read_config, str_to_bool
 import payu.errors as errors
 
 from payu.workflow import Workflow
@@ -136,8 +136,7 @@ def runscript(**run_args):
     expt = Experiment(lab)
 
     # Initialise the Workflow class to manage the workflow
-    workflow = Workflow(expt.config,
-                        run_number=expt.counter)
+    workflow = Workflow.read_config(expt.config, run_number=expt.counter, skip_step='collate')
     
     try:
         # Collate the model output
@@ -169,9 +168,7 @@ def runscript(**run_args):
         )
 
         # Submit follow-up jobs in the workflow, if payu-collate succeed and not called by payu-run
-        exist_workflow = os.environ.get('PAYU_EXIST_WORKFLOW', 'false').lower() == 'true'
+        exist_workflow = str_to_bool(os.environ.get('PAYU_EXIST_WORKFLOW', 'false'))
 
         if collate_status == 0 and not exist_workflow:
-            workflow.build_workflow()
-            workflow.workflow_steps.pop('collate', None)
             workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False))

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -10,7 +10,7 @@ from payu import cli
 from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
-from payu.telemetry import record_run
+from payu.telemetry import record_run, get_job_file_path_with_id
 from payu.fsops import read_config
 
 from payu.subcommands.postscript_cmd import submit_postscript
@@ -26,26 +26,22 @@ def submit_collate(expt, depends_on=None):
     """ Submit the collate job by calling runcmd.
     Return the job id of the collate job"""
     job_id = runcmd(
-            model_type=expt.lab.model_type,
-            config_path=expt.config_path,
             init_run=expt.counter,
-            lab_path=expt.lab.basepath,
-            dir_path=expt.output_path,
             depends_on=depends_on,
             exist_workflow=True
         )
     return job_id
 
 
-def runcmd(model_type, config_path, init_run, lab_path, dir_path, dry_run=False, depends_on=None, exist_workflow=False):
+def runcmd(model_type=None, config_path=None, init_run=None, 
+           lab_path=None, dir_path=None, dry_run=False, depends_on=None, 
+           exist_workflow=False):
 
     pbs_config = read_config(config_path)
     pbs_vars = cli.set_env_vars(init_run=init_run,
                                 lab_path=lab_path,
-                                dir_path=dir_path)
-
-    # Pass exist_workflow as an environment variable so runscript() can access it
-    pbs_vars['PAYU_EXIST_WORKFLOW'] = str(exist_workflow).lower()
+                                dir_path=dir_path,
+                                exist_workflow=exist_workflow)
 
     collate_config = pbs_config.get('collate', {})
 
@@ -132,6 +128,7 @@ def runscript(**run_args):
 
     # Get exist_workflow from environment variable (passed from runcmd via PBS)
     exist_workflow = os.environ.get('PAYU_EXIST_WORKFLOW', 'false').lower() == 'true'
+    workflow = dict()
 
     lab = Laboratory(run_args.model_type,
                      run_args.config_path,
@@ -148,26 +145,35 @@ def runscript(**run_args):
 
             # Submit each job in the workflow, pass the job ID onto the next job as dependency
             next_depends_on = expt.scheduler.get_job_id(short=False)
-            for step in workflow:
+            for step in workflow.keys():
                 if step == 'postscript':
                     postscript_job_id = submit_postscript(expt, depends_on=next_depends_on)
                     next_depends_on = postscript_job_id
                 elif step == 'sync':
                     sync_job_id = submit_sync(expt, depends_on=next_depends_on)
                     next_depends_on = sync_job_id
+                # Update the workflow dictionary with the job ID for each step
+                workflow[step] = next_depends_on
 
         # If collation succeeds, then collate_status is set to 0
         collate_status = 0
+
     except:
         # If collation fails, then collate_status is set to 1
         collate_status = 1
         # If collate fails, remove job files of all dependent jobs
         # Only when collate builds its own workflow
         if not exist_workflow and workflow:
-            for step in workflow:
-                job_file_path = expt.get_job_file(type=step)
+            for step, job_id in workflow.items():
+                job_file_path = get_job_file_path_with_id(
+                                    archive_path=Path(expt.archive_path),
+                                    run_number=expt.counter,
+                                    job_id=job_id,
+                                    type=step
+                                )
                 job_file_path.unlink(missing_ok=True)
         raise
+    
     finally:
         # Record collation job information into job file
         job_file_path = expt.get_job_file(type='collate')

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -150,10 +150,6 @@ def runscript(**run_args):
         # If collation fails, then collate_status is set to 1
         collate_status = 1
 
-        # If collate is called by payu-run, there may be postscript/sync waiting in queue
-        # Clean up any later jobs in the workflow
-        # workflow.clean_up(failed_step='collate', job_file=expt.get_job_file(type='run'))
-
         raise
     
     finally:
@@ -176,6 +172,6 @@ def runscript(**run_args):
         exist_workflow = os.environ.get('PAYU_EXIST_WORKFLOW', 'false').lower() == 'true'
 
         if collate_status == 0 and not exist_workflow:
-            workflow.build_workflow(expt.postscript)
+            workflow.build_workflow()
             workflow.workflow_steps.pop('collate', None)
             workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False))

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -11,7 +11,10 @@ from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu.telemetry import record_run
-from payu.fsops import read_config, get_job_id_given_job_type
+from payu.fsops import read_config
+
+from payu.subcommands.postscript_cmd import submit_postscript
+from payu.subcommands.sync_cmd import submit_sync
 
 title = 'collate'
 parameters = {'description': 'Collate tiled output into single output files'}
@@ -19,13 +22,30 @@ parameters = {'description': 'Collate tiled output into single output files'}
 arguments = [args.model, args.config, args.initial, args.laboratory,
              args.dir_path, args.dry_run]
 
+def submit_collate(expt, depends_on=None):
+    """ Submit the collate job by calling runcmd.
+    Return the job id of the collate job"""
+    job_id = runcmd(
+            model_type=expt.lab.model_type,
+            config_path=expt.config_path,
+            init_run=expt.counter,
+            lab_path=expt.lab.basepath,
+            dir_path=expt.output_path,
+            depends_on=depends_on,
+            exist_workflow=True
+        )
+    return job_id
 
-def runcmd(model_type, config_path, init_run, lab_path, dir_path, dry_run=False):
+
+def runcmd(model_type, config_path, init_run, lab_path, dir_path, dry_run=False, depends_on=None, exist_workflow=False):
 
     pbs_config = read_config(config_path)
     pbs_vars = cli.set_env_vars(init_run=init_run,
                                 lab_path=lab_path,
                                 dir_path=dir_path)
+
+    # Pass exist_workflow as an environment variable so runscript() can access it
+    pbs_vars['PAYU_EXIST_WORKFLOW'] = str(exist_workflow).lower()
 
     collate_config = pbs_config.get('collate', {})
 
@@ -93,10 +113,10 @@ def runcmd(model_type, config_path, init_run, lab_path, dir_path, dry_run=False)
     expt = Experiment(lab)
 
     # Submit the collation job and write queue job file
-    cli.submit_job('payu-collate', pbs_config, pbs_vars, expt=expt, 
+    job_id = cli.submit_job('payu-collate', pbs_config, pbs_vars, expt=expt, 
                 current_run = int(init_run) if init_run else None, type='collate', 
-                dry_run=dry_run, depends_on=expt.get_dependency_job_ids('collate'))
-
+                dry_run=dry_run, depends_on=depends_on)
+    return job_id
     
 
 
@@ -110,19 +130,43 @@ def runscript(**run_args):
     for var in pbs_vars:
         os.environ[var] = str(pbs_vars[var])
 
+    # Get exist_workflow from environment variable (passed from runcmd via PBS)
+    exist_workflow = os.environ.get('PAYU_EXIST_WORKFLOW', 'false').lower() == 'true'
+
     lab = Laboratory(run_args.model_type,
                      run_args.config_path,
                      run_args.lab_path)
     expt = Experiment(lab)
     try:
         # Collate the model output
-        # If collation succeeds, then collate_status is set to 0
         expt.collate()
-        expt.postprocess()
+
+        # Build workflow chain if no workflow is provided in collate runcmd
+        if not exist_workflow:
+            workflow = expt.build_workflow()
+            workflow.pop('collate', None)
+
+            # Submit each job in the workflow, pass the job ID onto the next job as dependency
+            next_depends_on = expt.scheduler.get_job_id(short=False)
+            for step in workflow:
+                if step == 'postscript':
+                    postscript_job_id = submit_postscript(expt, depends_on=next_depends_on)
+                    next_depends_on = postscript_job_id
+                elif step == 'sync':
+                    sync_job_id = submit_sync(expt, depends_on=next_depends_on)
+                    next_depends_on = sync_job_id
+
+        # If collation succeeds, then collate_status is set to 0
         collate_status = 0
     except:
         # If collation fails, then collate_status is set to 1
         collate_status = 1
+        # If collate fails, remove job files of all dependent jobs
+        # Only when collate builds its own workflow
+        if not exist_workflow and workflow:
+            for step in workflow:
+                job_file_path = expt.get_job_file(type=step)
+                job_file_path.unlink(missing_ok=True)
         raise
     finally:
         # Record collation job information into job file
@@ -139,3 +183,4 @@ def runscript(**run_args):
             type="collate",
             stage="exited"
         )
+

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -15,15 +15,7 @@ from payu.telemetry import record_run
 from payu.fsops import read_config
 import payu.errors as errors
 
-from payu.subcommands.postscript_cmd import submit_postscript
-from payu.subcommands.sync_cmd import submit_sync
 from payu.workflow import Workflow
-
-# A function lookup dictionary for subcommand job submission functions in runscript
-fn = {
-    "postscript": submit_postscript,
-    "sync": submit_sync
-}
 
 title = 'collate'
 parameters = {'description': 'Collate tiled output into single output files'}
@@ -31,7 +23,7 @@ parameters = {'description': 'Collate tiled output into single output files'}
 arguments = [args.model, args.config, args.initial, args.laboratory,
              args.dir_path, args.dry_run]
 
-def submit_collate(counter, depends_on=None):
+def submit_collate(counter, depends_on=None, config=None):
     """ Submit the collate job by calling runcmd.
     Return the job id of the collate job"""
     try:

--- a/payu/subcommands/postscript_cmd.py
+++ b/payu/subcommands/postscript_cmd.py
@@ -44,6 +44,7 @@ def runcmd(model_type=None, config_path=None, init_run=None, lab_path=None, dry_
     # Initialise experiment to determine archive path and run number (which is needed to write job file)
     lab = Laboratory(model_type, config_path, lab_path)
     expt = Experiment(lab)
+    expt.set_counters(keep_run_number=True)
     
     # Submit through HPCpy
     # Job name is set to "payu_postscript"

--- a/payu/subcommands/postscript_cmd.py
+++ b/payu/subcommands/postscript_cmd.py
@@ -5,11 +5,11 @@ import os
 
 # Local
 from payu import cli
-from payu import envmod
 from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu.fsops import read_config
+import payu.errors as errors
 
 
 title = 'postscript'
@@ -18,20 +18,20 @@ parameters = {'description': 'Run postscript commands provided by the user in co
 arguments = [args.model, args.config, args.laboratory, args.initial, args.dry_run]
 
             
-def submit_postscript(expt, depends_on=None):
+def submit_postscript(counter, depends_on=None):
     """ Submit postprocessing script if configured in config.yaml. Return the job id of the postscript job"""
-    job_id = runcmd(
-        model_type=expt.lab.model_type,
-        config_path=expt.config_path,
-        init_run=expt.counter,
-        lab_path=expt.lab.basepath,
-        dry_run=False,
-        depends_on=depends_on
-    )
+    try:
+        job_id = runcmd(
+            init_run=counter,
+            dry_run=False,
+            depends_on=depends_on
+            )
+    except Exception as e:
+        raise errors.PayuRuntimeError(f"Failed to submit postscript job: {e}")
     return job_id
 
 
-def runcmd(model_type, config_path, init_run, lab_path, dry_run=False, depends_on=None):
+def runcmd(model_type=None, config_path=None, init_run=None, lab_path=None, dry_run=False, depends_on=None):
     """Submit the postscript job via PBS/scheduler"""
     
     pbs_config = read_config(config_path)
@@ -44,9 +44,6 @@ def runcmd(model_type, config_path, init_run, lab_path, dry_run=False, depends_o
     # Initialise experiment to determine archive path and run number (which is needed to write job file)
     lab = Laboratory(model_type, config_path, lab_path)
     expt = Experiment(lab)
-
-    envmod.setup()
-    envmod.module('load', 'pbs')
     
     # Submit through HPCpy
     # Job name is set to "payu_postscript"

--- a/payu/subcommands/postscript_cmd.py
+++ b/payu/subcommands/postscript_cmd.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+
+# Standard Library
+from pathlib import Path
+
+# Local
+from payu import cli
+from payu import envmod
+from payu.experiment import Experiment
+from payu.laboratory import Laboratory
+import payu.subcommands.args as args
+from payu.fsops import read_config
+from payu.telemetry import (
+    read_job_file, 
+    update_job_file,
+)
+
+title = 'postscript'
+parameters = {'description': 'Run postscript commands provided by the user in config.yaml'}
+
+arguments = [args.model, args.config, args.laboratory, args.initial, args.dry_run]
+
+            
+def submit_postscript(expt, depends_on=None):
+    """ Submit postprocessing script if configured in config.yaml. Return the job id of the postscript job"""
+    job_id = runcmd(
+        model_type=expt.lab.model_type,
+        config_path=expt.config_path,
+        init_run=expt.counter,
+        lab_path=expt.lab.basepath,
+        dry_run=False,
+        depends_on=depends_on
+    )
+    return job_id
+
+
+def runcmd(model_type, config_path, init_run, lab_path, dry_run=False, depends_on=None):
+    """Submit the postscript job via PBS/scheduler"""
+    
+    pbs_config = read_config(config_path)
+
+    postscript = pbs_config.get('postscript', {})
+    if not postscript:
+        print("No postscript commands found in config.yaml. Skipping postscript submission.")
+        return None
+
+    # Initialise experiment to determine archive path and run number (which is needed to write job file)
+    lab = Laboratory(model_type, config_path, lab_path)
+    expt = Experiment(lab)
+
+    expt.set_userscript_env_vars()
+    envmod.setup()
+    envmod.module('load', 'pbs')
+    
+    # Submit through HPCpy
+    # Job name is set to "payu_postscript"
+    postscript_job = cli.submit_job(
+                        script = postscript, 
+                        config={"scheduler": expt.scheduler_name},
+                        expt=expt,
+                        current_run=int(init_run) if init_run else None,
+                        type="postscript",
+                        dry_run=dry_run,
+                        depends_on=depends_on,
+                        postscript=True
+                        )
+
+    return postscript_job
+
+runscript = runcmd

--- a/payu/subcommands/postscript_cmd.py
+++ b/payu/subcommands/postscript_cmd.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 # Standard Library
-from pathlib import Path
+import os
 
 # Local
 from payu import cli
@@ -10,10 +10,7 @@ from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu.fsops import read_config
-from payu.telemetry import (
-    read_job_file, 
-    update_job_file,
-)
+
 
 title = 'postscript'
 parameters = {'description': 'Run postscript commands provided by the user in config.yaml'}
@@ -48,21 +45,21 @@ def runcmd(model_type, config_path, init_run, lab_path, dry_run=False, depends_o
     lab = Laboratory(model_type, config_path, lab_path)
     expt = Experiment(lab)
 
-    expt.set_userscript_env_vars()
     envmod.setup()
     envmod.module('load', 'pbs')
     
     # Submit through HPCpy
     # Job name is set to "payu_postscript"
     postscript_job = cli.submit_job(
-                        script = postscript, 
+                        script = os.path.expandvars(postscript),  # Expand any environment variables in the postscript command
                         config={"scheduler": expt.scheduler_name},
+                        vars=expt.set_userscript_env_vars(),
                         expt=expt,
                         current_run=int(init_run) if init_run else None,
                         type="postscript",
                         dry_run=dry_run,
                         depends_on=depends_on,
-                        postscript=True
+                        postscript=True,
                         )
 
     return postscript_job

--- a/payu/subcommands/postscript_cmd.py
+++ b/payu/subcommands/postscript_cmd.py
@@ -18,7 +18,7 @@ parameters = {'description': 'Run postscript commands provided by the user in co
 arguments = [args.model, args.config, args.laboratory, args.initial, args.dry_run]
 
             
-def submit_postscript(counter, depends_on=None):
+def submit_postscript(counter, depends_on=None, config=None):
     """ Submit postprocessing script if configured in config.yaml. Return the job id of the postscript job"""
     try:
         job_id = runcmd(

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -205,11 +205,9 @@ def runscript(**run_args):
             run_status = 0
 
             # Initialise the Workflow class to manage the workflow
-            workflow = Workflow(expt.config,
-                                run_number=expt.counter)
+            workflow = Workflow.read_config(expt.config, run_number=expt.counter)
                 
             # Submit each job in the workflow, pass the job ID onto the next job as dependency
-            workflow.build_workflow()
             workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False))
             
         except:

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -12,14 +12,10 @@ from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu import fsops
 from payu.manifest import Manifest
-from payu.telemetry import get_job_file_path_with_id, record_run
+from payu.telemetry import record_run
 from payu.schedulers.pbs import PBS
 import payu.errors as errors
-
-# Local imports for subcommand job submission
-from payu.subcommands.collate_cmd import submit_collate
-from payu.subcommands.postscript_cmd import submit_postscript
-from payu.subcommands.sync_cmd import submit_sync
+from payu.workflow import Workflow
 
 title = 'run'
 parameters = {'description': 'Run the model experiment'}
@@ -201,41 +197,24 @@ def runscript(**run_args):
               ''.format(expt.n_runs, n_runs_per_submit, subrun))
         # Set job filepath for the payu run
         expt.set_job_file()
-        # Build workflow chain
-        workflow = expt.build_workflow()
         try:
             expt.setup()
             expt.run()
             expt.archive(force_prune_restarts=run_args.force_prune_restarts)
-            
-            # Submit each job in the workflow, pass the job ID onto the next job as dependency
-            next_depends_on = expt.scheduler.get_job_id(short=False)
-            for step in workflow.keys():
-                if step == 'collate':
-                    collate_job_id = submit_collate(expt, depends_on=next_depends_on)
-                    next_depends_on = collate_job_id
-                elif step == 'postscript':
-                    postscript_job_id = submit_postscript(expt, depends_on=next_depends_on)
-                    next_depends_on = postscript_job_id
-                elif step == 'sync':
-                    sync_job_id = submit_sync(expt, depends_on=next_depends_on)
-                    next_depends_on = sync_job_id
-                # Update the workflow dictionary with the job ID for each step
-                workflow[step] = next_depends_on
 
             run_status = 0
+
+            # Initialise the Workflow class to manage the workflow
+            workflow = Workflow(expt.config,
+                                run_number=expt.counter)
+                
+            # Submit each job in the workflow, pass the job ID onto the next job as dependency
+            workflow.build_workflow(expt.postscript)
+            workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False))
+            
         except:
             run_status = 1
-            # If run fails, remove job files of all dependent jobs
-            if workflow:
-                for step in workflow.keys():
-                    job_file_path = get_job_file_path_with_id(
-                                        archive_path=Path(expt.archive_path),
-                                        run_number=expt.counter,
-                                        job_id=workflow[step],
-                                        type=step
-                                    )
-                    job_file_path.unlink(missing_ok=True)
+
             raise
         finally:
             # Record job information for experiment run
@@ -247,6 +226,7 @@ def runscript(**run_args):
                 file_path=expt.job_file,
                 archive_path=Path(expt.archive_path),
             )   
+
 
         # Finished runs
         if expt.n_runs == 0:

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -16,6 +16,12 @@ from payu.telemetry import record_run
 from payu.schedulers.pbs import PBS
 import payu.errors as errors
 
+# Local imports for subcommand job submission
+from payu.subcommands.collate_cmd import submit_collate
+from payu.subcommands.postscript_cmd import submit_postscript
+from payu.subcommands.sync_cmd import submit_sync
+from payu.subcommands.status_cmd import runcmd as status_runcmd
+
 title = 'run'
 parameters = {'description': 'Run the model experiment'}
 
@@ -196,13 +202,34 @@ def runscript(**run_args):
               ''.format(expt.n_runs, n_runs_per_submit, subrun))
         # Set job filepath for the payu run
         expt.set_job_file()
+        # Build workflow chain
+        workflow = expt.build_workflow()
         try:
             expt.setup()
             expt.run()
             expt.archive(force_prune_restarts=run_args.force_prune_restarts)
+            
+            # Submit each job in the workflow, pass the job ID onto the next job as dependency
+            next_depends_on = expt.scheduler.get_job_id(short=False)
+            for step in workflow:
+                if step == 'collate':
+                    collate_job_id = submit_collate(expt, depends_on=next_depends_on)
+                    next_depends_on = collate_job_id
+                elif step == 'postscript':
+                    postscript_job_id = submit_postscript(expt, depends_on=next_depends_on)
+                    next_depends_on = postscript_job_id
+                elif step == 'sync':
+                    sync_job_id = submit_sync(expt, depends_on=next_depends_on)
+                    next_depends_on = sync_job_id
+
             run_status = 0
         except:
             run_status = 1
+            # If run fails, remove job files of all dependent jobs
+            if workflow:
+                for step in workflow:
+                    job_file_path = expt.get_job_file(type=step)
+                    job_file_path.unlink(missing_ok=True)
             raise
         finally:
             # Record job information for experiment run
@@ -213,7 +240,7 @@ def runscript(**run_args):
                 config=expt.config,
                 file_path=expt.job_file,
                 archive_path=Path(expt.archive_path),
-            )
+            )   
 
         # Finished runs
         if expt.n_runs == 0:

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -12,7 +12,7 @@ from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu import fsops
 from payu.manifest import Manifest
-from payu.telemetry import record_run
+from payu.telemetry import get_job_file_path_with_id, record_run
 from payu.schedulers.pbs import PBS
 import payu.errors as errors
 
@@ -20,7 +20,6 @@ import payu.errors as errors
 from payu.subcommands.collate_cmd import submit_collate
 from payu.subcommands.postscript_cmd import submit_postscript
 from payu.subcommands.sync_cmd import submit_sync
-from payu.subcommands.status_cmd import runcmd as status_runcmd
 
 title = 'run'
 parameters = {'description': 'Run the model experiment'}
@@ -211,7 +210,7 @@ def runscript(**run_args):
             
             # Submit each job in the workflow, pass the job ID onto the next job as dependency
             next_depends_on = expt.scheduler.get_job_id(short=False)
-            for step in workflow:
+            for step in workflow.keys():
                 if step == 'collate':
                     collate_job_id = submit_collate(expt, depends_on=next_depends_on)
                     next_depends_on = collate_job_id
@@ -221,14 +220,21 @@ def runscript(**run_args):
                 elif step == 'sync':
                     sync_job_id = submit_sync(expt, depends_on=next_depends_on)
                     next_depends_on = sync_job_id
+                # Update the workflow dictionary with the job ID for each step
+                workflow[step] = next_depends_on
 
             run_status = 0
         except:
             run_status = 1
             # If run fails, remove job files of all dependent jobs
             if workflow:
-                for step in workflow:
-                    job_file_path = expt.get_job_file(type=step)
+                for step in workflow.keys():
+                    job_file_path = get_job_file_path_with_id(
+                                        archive_path=Path(expt.archive_path),
+                                        run_number=expt.counter,
+                                        job_id=workflow[step],
+                                        type=step
+                                    )
                     job_file_path.unlink(missing_ok=True)
             raise
         finally:

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -209,7 +209,7 @@ def runscript(**run_args):
                                 run_number=expt.counter)
                 
             # Submit each job in the workflow, pass the job ID onto the next job as dependency
-            workflow.build_workflow(expt.postscript)
+            workflow.build_workflow()
             workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False))
             
         except:

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -208,7 +208,8 @@ def runscript(**run_args):
             workflow = Workflow.read_config(expt.config, run_number=expt.counter)
                 
             # Submit each job in the workflow, pass the job ID onto the next job as dependency
-            workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False))
+            workflow.submit_workflow(depends_on=expt.scheduler.get_job_id(short=False),
+                                    config=expt.config)
             
         except:
             run_status = 1

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -174,8 +174,9 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
 
     current_run = int(init_run) if init_run is not None else expt.counter
 
-    cli.submit_job('payu-run', pbs_config, pbs_vars, expt, current_run, type='run', dry_run=dry_run)
-
+    cli.submit_job('payu-run', pbs_config, pbs_vars, expt, 
+                   current_run, type='run', 
+                   dry_run=dry_run)
 
 def runscript(**run_args):
     run_args = argparse.Namespace(**run_args)

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -105,6 +105,8 @@ def runscript(**run_args):
                      run_args.config_path,
                      run_args.lab_path)
     expt = Experiment(lab)
+    # Set the counters to keep the run number for sync job file
+    expt.set_counters(keep_run_number=True)
 
     try:
         expt.sync()

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -3,13 +3,15 @@
 # Standard Library
 import argparse
 import os
+from pathlib import Path
 
 # Local
 from payu import cli
 from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
-from payu import fsops
+from payu.fsops import read_config, get_job_id_given_job_type
+from payu.telemetry import record_run
 
 title = 'sync'
 parameters = {'description': 'Sync model output to a remote directory'}
@@ -21,7 +23,7 @@ arguments = [args.model, args.config, args.initial, args.laboratory, args.dir_pa
 def runcmd(model_type, config_path, init_run, lab_path, dir_path, sync_restarts,
            sync_ignore_last, dry_run=False):
 
-    pbs_config = fsops.read_config(config_path)
+    pbs_config = read_config(config_path)
 
     pbs_vars = cli.set_env_vars(init_run=init_run,
                                 lab_path=lab_path,
@@ -59,8 +61,14 @@ def runcmd(model_type, config_path, init_run, lab_path, dir_path, sync_restarts,
 
     pbs_config['qsub_flags'] = sync_config.get('qsub_flags', '')
 
+    # Initialise experiment to determine archive path and run number (which is needed to write job file)
+    lab = Laboratory(model_type, config_path, lab_path)
+    expt = Experiment(lab)
+
     # Submit PBS job with expt = None so no job file is written
-    cli.submit_job('payu-sync', pbs_config, pbs_vars, dry_run=dry_run)
+    cli.submit_job('payu-sync', pbs_config, pbs_vars, expt=expt, 
+                   current_run=int(init_run) if init_run else None, type='sync',
+                   dry_run=dry_run, depends_on=expt.get_dependency_job_ids('sync'))
 
 
 def runscript(**run_args):
@@ -80,4 +88,24 @@ def runscript(**run_args):
                      run_args.lab_path)
     expt = Experiment(lab)
 
-    expt.sync()
+    try:
+        expt.sync()
+        sync_status = 0
+    except:
+        sync_status = 1
+        raise
+    finally:
+        # Record sync job information into job file
+        job_file_path = expt.get_job_file(type='sync')
+
+        # Record the sync status (duration time and success/failure) in the job file
+        record_run(
+            timings=expt.timings,
+            scheduler=expt.scheduler,
+            status=sync_status,
+            config=expt.config,
+            file_path=job_file_path,
+            archive_path=Path(expt.archive_path),
+            type="sync",
+            stage="exited"
+        )

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -24,22 +24,17 @@ def submit_sync(expt, depends_on=None):
     Return the job id of the sync job"""
     sync_config = expt.config.get('sync', {})
     job_id = runcmd(
-        model_type=expt.lab.model_type,
-        config_path=expt.config_path,
         init_run=expt.counter,
-        lab_path=expt.lab.basepath,
-        dir_path=expt.output_path,
         sync_restarts = sync_config.get('restarts', False),
         sync_ignore_last = sync_config.get('ignore_last', False),
-        dry_run=False,
-        depends_on=depends_on
+        depends_on=depends_on,
     )
 
     return job_id
 
 
-def runcmd(model_type, config_path, init_run, lab_path, dir_path, sync_restarts,
-           sync_ignore_last, dry_run=False, depends_on=None):
+def runcmd(model_type=None, config_path=None, init_run=None, lab_path=None, dir_path=None, 
+           sync_restarts=None, sync_ignore_last=None, dry_run=False, depends_on=None):
 
     pbs_config = read_config(config_path)
 

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -12,6 +12,7 @@ from payu.laboratory import Laboratory
 import payu.subcommands.args as args
 from payu.fsops import read_config
 from payu.telemetry import record_run
+import payu.errors as errors
 
 title = 'sync'
 parameters = {'description': 'Sync model output to a remote directory'}
@@ -19,17 +20,20 @@ parameters = {'description': 'Sync model output to a remote directory'}
 arguments = [args.model, args.config, args.initial, args.laboratory, args.dir_path,
              args.sync_restarts, args.sync_ignore_last, args.dry_run]
 
-def submit_sync(expt, depends_on=None):
+def submit_sync(counter, depends_on=None, config=None):
     """ Submit the sync job by calling runcmd.
     Return the job id of the sync job"""
-    sync_config = expt.config.get('sync', {})
-    job_id = runcmd(
-        init_run=expt.counter,
-        sync_restarts = sync_config.get('restarts', False),
-        sync_ignore_last = sync_config.get('ignore_last', False),
-        depends_on=depends_on,
-    )
+    sync_config = config.get('sync', {})
+    try:
+        job_id = runcmd(
+            init_run=counter,
+            sync_restarts = sync_config.get('restarts', False),
+            sync_ignore_last = sync_config.get('ignore_last', False),
+            depends_on=depends_on,
+            )
 
+    except Exception as e:
+        raise errors.PayuRuntimeError(f"Failed to submit sync job: {e}")
     return job_id
 
 

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -10,7 +10,7 @@ from payu import cli
 from payu.experiment import Experiment
 from payu.laboratory import Laboratory
 import payu.subcommands.args as args
-from payu.fsops import read_config, get_job_id_given_job_type
+from payu.fsops import read_config
 from payu.telemetry import record_run
 
 title = 'sync'
@@ -19,9 +19,27 @@ parameters = {'description': 'Sync model output to a remote directory'}
 arguments = [args.model, args.config, args.initial, args.laboratory, args.dir_path,
              args.sync_restarts, args.sync_ignore_last, args.dry_run]
 
+def submit_sync(expt, depends_on=None):
+    """ Submit the sync job by calling runcmd.
+    Return the job id of the sync job"""
+    sync_config = expt.config.get('sync', {})
+    job_id = runcmd(
+        model_type=expt.lab.model_type,
+        config_path=expt.config_path,
+        init_run=expt.counter,
+        lab_path=expt.lab.basepath,
+        dir_path=expt.output_path,
+        sync_restarts = sync_config.get('restarts', False),
+        sync_ignore_last = sync_config.get('ignore_last', False),
+        dry_run=False,
+        depends_on=depends_on
+    )
+
+    return job_id
+
 
 def runcmd(model_type, config_path, init_run, lab_path, dir_path, sync_restarts,
-           sync_ignore_last, dry_run=False):
+           sync_ignore_last, dry_run=False, depends_on=None):
 
     pbs_config = read_config(config_path)
 
@@ -66,9 +84,10 @@ def runcmd(model_type, config_path, init_run, lab_path, dir_path, sync_restarts,
     expt = Experiment(lab)
 
     # Submit PBS job with expt = None so no job file is written
-    cli.submit_job('payu-sync', pbs_config, pbs_vars, expt=expt, 
+    job_id = cli.submit_job('payu-sync', pbs_config, pbs_vars, expt=expt, 
                    current_run=int(init_run) if init_run else None, type='sync',
-                   dry_run=dry_run, depends_on=expt.get_dependency_job_ids('sync'))
+                   dry_run=dry_run, depends_on=depends_on)
+    return job_id
 
 
 def runscript(**run_args):

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -392,10 +392,11 @@ def write_queued_job_file(
         job_id=job_id,
         type=type
     )
+    stage = "queued/running" if type == "postscript" else "queued"
     data = {
         "scheduler_job_id": job_id,
         "scheduler_type": scheduler.name,
-        "stage": "queued",
+        "stage": stage,
         "payu_current_run": current_run,
         "depends_on": depends_on,
     }

--- a/payu/telemetry.py
+++ b/payu/telemetry.py
@@ -366,7 +366,8 @@ def write_queued_job_file(
             type: str,
             scheduler: Scheduler,
             metadata: Metadata,
-            current_run: int
+            current_run: int,
+            depends_on: Optional[list[str]] = None,
         ) -> None:
     """Initialise the queued job file in the control path with the job ID
 
@@ -396,6 +397,7 @@ def write_queued_job_file(
         "scheduler_type": scheduler.name,
         "stage": "queued",
         "payu_current_run": current_run,
+        "depends_on": depends_on,
     }
     data.update(get_metadata(metadata))
     update_job_file(file_path=job_file_path, data=data)

--- a/payu/workflow.py
+++ b/payu/workflow.py
@@ -3,22 +3,25 @@
 class Workflow:
     """Class to manage the workflow of run, collate, postscript, sync jobs."""
     
-    def __init__(self, config, run_number=None):
-        self.run_number = run_number
+    def __init__(self, workflow_steps, config=None, run_number=None):
+        self.workflow_steps = workflow_steps
         self.config = config
+        self.run_number = run_number
 
+    @classmethod
+    def read_config(cls, config, run_number=None, skip_step=None):
+        """Read the config dictionary and return a dictionary of workflow steps to be executed.
+        If skip_step is provided, that step will be skipped in the workflow."""
+        workflow_steps = dict()
 
-    def build_workflow(self):
-        """Build the workflow for the current experiment, e.g.,
-        {"collate": None, "postscript": None, "sync": None}. 
-        The value will be updated as job id when available"""
-        self.workflow_steps = dict()
-        if self.config.get('collate', {}).get('enable', True):
-            self.workflow_steps['collate'] = None
-        if self.config.get('postscript', None):
-            self.workflow_steps['postscript'] = None
-        if self.config.get('sync', {}).get('enable', False):
-            self.workflow_steps['sync'] = None
+        if config.get('collate', {}).get('enable', True) and skip_step != 'collate':
+            workflow_steps['collate'] = None
+        if config.get('postscript', None) and skip_step != 'postscript':
+            workflow_steps['postscript'] = None
+        if config.get('sync', {}).get('enable', False) and skip_step != 'sync':
+            workflow_steps['sync'] = None
+
+        return cls(workflow_steps, config, run_number)
 
 
     def submit_workflow(self, depends_on):
@@ -29,6 +32,7 @@ class Workflow:
         for step in self.workflow_steps.keys():
             self.workflow_steps[step] = fn[step](self.run_number, depends_on, self.config)
 
+            # Next step depends on this step's job ID
             depends_on = self.workflow_steps[step]
 
         return self.workflow_steps

--- a/payu/workflow.py
+++ b/payu/workflow.py
@@ -8,14 +8,14 @@ class Workflow:
         self.config = config
 
 
-    def build_workflow(self, postscript):
+    def build_workflow(self):
         """Build the workflow for the current experiment, e.g.,
         {"collate": None, "postscript": None, "sync": None}. 
         The value will be updated as job id when available"""
         self.workflow_steps = dict()
         if self.config.get('collate', {}).get('enable', True):
             self.workflow_steps['collate'] = None
-        if postscript:
+        if self.config.get('postscript', None):
             self.workflow_steps['postscript'] = None
         if self.config.get('sync', {}).get('enable', False):
             self.workflow_steps['sync'] = None

--- a/payu/workflow.py
+++ b/payu/workflow.py
@@ -1,0 +1,54 @@
+# --- Work in progress: build a workflow class ---
+# Local imports for subcommand job submission
+from payu.telemetry import get_job_file_path_with_id
+import json
+
+class Workflow:
+    """Class to manage the workflow of run, collate, postscript, sync jobs."""
+    
+    def __init__(self, config, run_number=None):
+        self.run_number = run_number
+        self.config = config
+
+
+    def build_workflow(self, postscript):
+        """Build the workflow for the current experiment, e.g.,
+        {"collate": None, "postscript": None, "sync": None}. 
+        The value will be updated as job id when available"""
+        self.workflow_steps = dict()
+        if self.config.get('collate', {}).get('enable', True):
+            self.workflow_steps['collate'] = None
+        if postscript:
+            self.workflow_steps['postscript'] = None
+        if self.config.get('sync', {}).get('enable', False):
+            self.workflow_steps['sync'] = None
+
+
+    def submit_workflow(self, depends_on):
+        """Submit all later jobs in the workflow in order, passing job IDs as dependencies,
+        Update the value in workflow dictionary."""
+        for step in self.workflow_steps.keys():
+            if step == "collate":
+                from payu.subcommands.collate_cmd import submit_collate
+                depends_on = submit_collate(self.run_number, depends_on)
+
+            elif step == "postscript":
+                from payu.subcommands.postscript_cmd import submit_postscript
+                depends_on = submit_postscript(self.run_number, depends_on)
+
+            elif step == "sync":
+                from payu.subcommands.sync_cmd import submit_sync
+                depends_on = submit_sync(self.run_number, depends_on, self.config)
+
+            else:
+                raise ValueError(f"Unknown workflow step: {step}")
+
+            self.workflow_steps[step] = depends_on
+
+        return self.workflow_steps
+
+
+    def clean_up(self, failed_step):
+        """Clean up any later jobs that depends on the current failed job."""
+        # I don't know how to implement this
+        pass

--- a/payu/workflow.py
+++ b/payu/workflow.py
@@ -3,9 +3,8 @@
 class Workflow:
     """Class to manage the workflow of run, collate, postscript, sync jobs."""
     
-    def __init__(self, workflow_steps, config=None, run_number=None):
+    def __init__(self, workflow_steps, run_number=None):
         self.workflow_steps = workflow_steps
-        self.config = config
         self.run_number = run_number
 
     @classmethod
@@ -14,23 +13,23 @@ class Workflow:
         If skip_step is provided, that step will be skipped in the workflow."""
         workflow_steps = dict()
 
-        if config.get('collate', {}).get('enable', True) and skip_step != 'collate':
+        if skip_step != 'collate' and config.get('collate', {}).get('enable', True):
             workflow_steps['collate'] = None
-        if config.get('postscript', None) and skip_step != 'postscript':
+        if skip_step != 'postscript' and config.get('postscript', None):
             workflow_steps['postscript'] = None
-        if config.get('sync', {}).get('enable', False) and skip_step != 'sync':
+        if skip_step != 'sync' and config.get('sync', {}).get('enable', False):
             workflow_steps['sync'] = None
 
-        return cls(workflow_steps, config, run_number)
+        return cls(workflow_steps, run_number)
 
 
-    def submit_workflow(self, depends_on):
+    def submit_workflow(self, depends_on, config):
         """Submit all later jobs in the workflow in order, passing job IDs as dependencies,
         Update the value in workflow dictionary."""
         fn = self.import_subcommands()
 
         for step in self.workflow_steps.keys():
-            self.workflow_steps[step] = fn[step](self.run_number, depends_on, self.config)
+            self.workflow_steps[step] = fn[step](self.run_number, depends_on, config)
 
             # Next step depends on this step's job ID
             depends_on = self.workflow_steps[step]

--- a/payu/workflow.py
+++ b/payu/workflow.py
@@ -1,7 +1,4 @@
-# --- Work in progress: build a workflow class ---
-# Local imports for subcommand job submission
-from payu.telemetry import get_job_file_path_with_id
-import json
+# --- Build a Workflow class to manage the workflow of collate, postscript, sync jobs ---
 
 class Workflow:
     """Class to manage the workflow of run, collate, postscript, sync jobs."""
@@ -27,26 +24,29 @@ class Workflow:
     def submit_workflow(self, depends_on):
         """Submit all later jobs in the workflow in order, passing job IDs as dependencies,
         Update the value in workflow dictionary."""
+        fn = self.import_subcommands()
+
         for step in self.workflow_steps.keys():
-            if step == "collate":
-                from payu.subcommands.collate_cmd import submit_collate
-                depends_on = submit_collate(self.run_number, depends_on)
+            self.workflow_steps[step] = fn[step](self.run_number, depends_on, self.config)
 
-            elif step == "postscript":
-                from payu.subcommands.postscript_cmd import submit_postscript
-                depends_on = submit_postscript(self.run_number, depends_on)
-
-            elif step == "sync":
-                from payu.subcommands.sync_cmd import submit_sync
-                depends_on = submit_sync(self.run_number, depends_on, self.config)
-
-            else:
-                raise ValueError(f"Unknown workflow step: {step}")
-
-            self.workflow_steps[step] = depends_on
+            depends_on = self.workflow_steps[step]
 
         return self.workflow_steps
 
+    @staticmethod
+    def import_subcommands():
+        # Local imports for subcommand job submission
+        from payu.subcommands.collate_cmd import submit_collate
+        from payu.subcommands.postscript_cmd import submit_postscript
+        from payu.subcommands.sync_cmd import submit_sync
+
+        # Build a function lookup dictionary
+        return {
+            "collate": submit_collate,
+            "postscript": submit_postscript,
+            "sync": submit_sync
+        }
+    
 
     def clean_up(self, failed_step):
         """Clean up any later jobs that depends on the current failed job."""

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -18,6 +18,7 @@ from payu.status import (
     collect_expt_paths,
     display_expt_paths,
     parse_exit_status_from_logs,
+    update_postscript_job_file,
 )
 
 from payu.laboratory import Laboratory
@@ -1150,3 +1151,83 @@ Some log output...
 
     # Test when stdout does not exist
     assert parse_exit_status_from_logs(tmp_path / "nonexistent.stdout") is None
+
+
+@pytest.mark.parametrize(
+    "stdout_exists,scheduler_has_info,job_state,expected_stage,expected_exit_status",
+    [
+        # Both stdout and stderr exist with scheduler info
+        (True, True, None, "exited", 0),
+        # Both stdout and stderr exist but scheduler has no info, parse from logs
+        (True, False, None, "exited", 0),
+        # Job is running (job_state="R" due to payu status --update before) but logs don't exist yet
+        (False, None, "R", "running", None),
+        # Neither condition met - data should be unchanged
+        (False, None, None, "queued/running", None),
+    ]
+)
+def test_update_postscript_job_file(tmp_path, stdout_exists, scheduler_has_info, job_state, expected_stage, expected_exit_status):
+    """Test that update_postscript_job_file correctly updates the job file with running/exit status."""
+    # Create temporary stdout/stderr files
+    stdout_path = tmp_path / "postscript.out"
+    stderr_path = tmp_path / "postscript.err"
+    if stdout_exists:
+        stderr_path.touch()
+        stdout_path.write_bytes(b"Exit Status:        0\n")
+    
+    # Create job file
+    job_file = tmp_path / "test-postscript-id-3.json"
+    
+    # Set up initial job data
+    data = {
+        "scheduler_job_id": "test-postscript-id-3",
+        "stage": "queued/running",
+        "payu_current_run": 3,
+    }
+    
+    # User called payu status --update beforehand
+    if job_state == "R":
+        data["scheduler_job_info"] = {
+            "Jobs": {
+                "test-postscript-id-3": {
+                    "job_state": "R"
+                }
+            }
+        }
+    
+    # Set up mock scheduler to fetch job info
+    mock_scheduler = MagicMock()
+
+    if scheduler_has_info:
+        # If job still in scheduler
+        mock_scheduler.get_job_info.return_value = {
+            "Jobs": {
+                "test-postscript-id-3": {
+                    "Exit_status": 0,
+                    "job_state": "F"
+                }
+            }
+        }
+    
+    else:
+        # If job no longer in scheduler, return None
+        mock_scheduler.get_job_info.return_value = None
+    
+    # Call the function
+    result = update_postscript_job_file(data, mock_scheduler, job_file, stdout_path, stderr_path)
+    
+    # Assertions
+    assert result["stage"] == expected_stage
+    
+    if expected_exit_status is not None:
+        assert result.get("payu_postscript_status") == expected_exit_status
+    
+    # Verify job file was updated when expected
+    if expected_stage in ["exited", "running"]:
+        assert job_file.exists()
+
+    # Verify that the job file is not updated (not created in this test)
+    # if the stage is still "queued/running"
+    if expected_stage == "queued/running":
+        assert not job_file.exists()
+        assert data["stage"] == "queued/running"

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -380,6 +380,7 @@ def test_get_job_file_list_selected_run(tmp_path, queued_job, running_job,
 
 def expected_archive_job_info(run_number):
     return {
+        'depends_on': None,
         'exit_status': 0,
         'job_id': f'test-job-id-{run_number}',
         'run_id': f'commit-hash{run_number}',
@@ -394,6 +395,7 @@ def expected_archive_job_info(run_number):
 
 def expected_running_job_info():
     return {
+        'depends_on': None,
         'exit_status': None,
         'job_id': 'test-job-id-3',
         'run_id': 'commit-hash3',
@@ -409,6 +411,7 @@ def expected_running_job_info():
 
 def expected_queued_job_info():
     return {
+        'depends_on': None,
         'exit_status': None,
         'job_id': 'test-job-id-3',
         'run_id': None,
@@ -423,6 +426,7 @@ def expected_queued_job_info():
 
 def expected_failed_job_info():
     return {
+        'depends_on': None,
         'exit_status': 1,
         'job_id': 'test-job-id-0failed',
         'run_id': 'commit-hash-failed',
@@ -436,6 +440,7 @@ def expected_failed_job_info():
 
 def expected_running_collate_job_info(run_number):
     return {
+        'depends_on': None,
         'job_id': f'test-collate-id-{run_number}',
         'stage': 'running',
         'exit_status': None,
@@ -446,6 +451,7 @@ def expected_running_collate_job_info(run_number):
 
 def expected_collate_job_info(run_number):
     return {
+        'depends_on': None,
         'job_id': f'test-collate-id-{run_number}',
         'stage': 'exited',
         'exit_status': 0,
@@ -456,6 +462,7 @@ def expected_collate_job_info(run_number):
 
 def expected_failed_collate_job_info():
     return {
+        'depends_on': None,
         'job_id': "test-collate-id-0failed",
         'stage': 'exited',
         'exit_status': 1,

--- a/test/test_status.py
+++ b/test/test_status.py
@@ -17,6 +17,7 @@ from payu.status import (
     display_job_info,
     collect_expt_paths,
     display_expt_paths,
+    parse_exit_status_from_logs,
 )
 
 from payu.laboratory import Laboratory
@@ -1118,3 +1119,34 @@ def test__sort_run_jobs():
         {"job_id": "1", "start_time": "2025-06-01T09:00:00"},
         {"job_id": "3", "start_time": "2025-06-03T09:00:00"},
     ]
+
+def test_parse_exit_status_from_logs(tmp_path):
+    """Test that parse_exit_status_from_logs correctly extracts exit status from logs."""
+    stdout_path = tmp_path / "test.stdout"
+
+    # Write some expected log content
+    log_content = """
+Some log output...
+Model finished with exit status: 0
+More log output...
+======================================================================================
+                  Resource Usage on 2026-08-19 15:07:58:
+   Job Id:             176671730.gadi-pbs
+   Project:            tm70
+   Exit Status:        0
+   Service Units:      0.02
+   JobFS Requested:    100.0MB                JobFS Used: 0B
+======================================================================================
+"""
+    stdout_path.write_text(log_content)
+    assert parse_exit_status_from_logs(stdout_path) == 0
+
+    # Write log content without exit status
+    log_content_no_status = """
+Some log output...
+"""
+    stdout_path.write_text(log_content_no_status)
+    assert parse_exit_status_from_logs(stdout_path) is None
+
+    # Test when stdout does not exist
+    assert parse_exit_status_from_logs(tmp_path / "nonexistent.stdout") is None

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -368,6 +368,7 @@ def test_write_queued_job_file(tmp_path, mock_scheduler, mock_metadata):
     assert queued_file.exists()
     with open(queued_file, 'r') as f:
         assert json.load(f) == {
+            "depends_on": None,
             "stage": "queued",
             "scheduler_job_id": "test-id",
             "scheduler_type": "test-scheduler",

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -1,0 +1,83 @@
+import copy
+from unittest.mock import Mock
+
+import pytest
+
+from payu.workflow import Workflow
+
+from .common import config as config_orig
+
+@pytest.mark.parametrize(
+    "collate_value, sync_value, postscript, expect_workflow", 
+    [   
+        # collate/postscript/sync enabled
+        ({"enable": True}, {"enable": True}, "-v ${PBS_NCI_STORAGE} postscript.sh", 
+         {"collate": None, "postscript": None, "sync": None}),
+
+        # Manually disable collate and sync, postscript enabled
+        ({"enable": False}, {"enable": False}, "-v ${PBS_NCI_STORAGE} postscript.sh",
+         {"postscript": None}),
+
+         # By default, collate is enabled, postscript is disabled, sync is disabled
+        (None, None, None,
+         {"collate": None}),
+
+        # A case that no follow-up jobs are enabled
+        ({"enable": False}, {"enable": False}, "",
+         {}),
+    ]
+)
+def test_build_workflow(collate_value, sync_value, postscript, expect_workflow):
+    """Test the build_workflow method include correct stage based on the config.yaml."""
+    config = copy.deepcopy(config_orig)
+
+    # Update the config based on the test
+    for key, value in {"collate": collate_value, "postscript": postscript, "sync": sync_value}.items():
+        if value is not None:
+            config[key] = value
+        else:
+            config.pop(key, None)
+
+    # Initialize the Workflow class and build the workflow
+    workflow = Workflow(config, run_number=1)
+    workflow.build_workflow()
+
+    # Assert that the workflow_steps dictionary are as expected
+    assert workflow.workflow_steps == expect_workflow
+
+
+def test_submit_workflow(monkeypatch):
+    """ Test that submit_workflow calls the corresponding subcommand functions
+    and updates the workflow_steps dictionary with job IDs. """
+    # Create mock functions
+    mock_submit_collate = Mock(return_value="collate_job_id")
+    mock_submit_postscript = Mock(return_value="postscript_job_id")
+    mock_submit_sync = Mock(return_value="sync_job_id")
+
+    # Initialise the workflow class and change the workflow_steps
+    workflow = Workflow(config_orig, run_number=1)
+    workflow.build_workflow()
+    workflow.workflow_steps = {"collate": None, "postscript": None, "sync": None}
+
+    # When workflow import subcommands, it returns the mock function instead of the real ones
+    monkeypatch.setattr(
+        workflow,
+        "import_subcommands",
+        lambda: {
+            "collate": mock_submit_collate,
+            "postscript": mock_submit_postscript,
+            "sync": mock_submit_sync,
+        },
+    )
+
+    # Call the submit_workflow and check the new workflow_steps dictionary
+    assert workflow.submit_workflow("run_job_id") == {
+        "collate": "collate_job_id",
+        "postscript": "postscript_job_id",
+        "sync": "sync_job_id",
+    }
+
+    # Assert the mock functions were called with correct dependencies
+    mock_submit_collate.assert_called_once_with(1, "run_job_id", config_orig)
+    mock_submit_postscript.assert_called_once_with(1, "collate_job_id", config_orig)
+    mock_submit_sync.assert_called_once_with(1, "postscript_job_id", config_orig)

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -8,27 +8,31 @@ from payu.workflow import Workflow
 from .common import config as config_orig
 
 @pytest.mark.parametrize(
-    "collate_value, sync_value, postscript, expect_workflow", 
+    "collate_value, sync_value, postscript, skip_step, expect_workflow", 
     [   
         # collate/postscript/sync enabled
         ({"enable": True}, {"enable": True}, "-v ${PBS_NCI_STORAGE} postscript.sh", 
-         {"collate": None, "postscript": None, "sync": None}),
+         None, {"collate": None, "postscript": None, "sync": None}),
 
         # Manually disable collate and sync, postscript enabled
         ({"enable": False}, {"enable": False}, "-v ${PBS_NCI_STORAGE} postscript.sh",
-         {"postscript": None}),
+         None, {"postscript": None}),
 
          # By default, collate is enabled, postscript is disabled, sync is disabled
         (None, None, None,
-         {"collate": None}),
+         None, {"collate": None}),
 
         # A case that no follow-up jobs are enabled
         ({"enable": False}, {"enable": False}, "",
-         {}),
+         None, {}),
+
+        # collate/postscript/sync enabled, but collate is skipped (e.g., workflow called by payu collate)
+        ({"enable": True}, {"enable": True}, "-v ${PBS_NCI_STORAGE} postscript.sh", 
+         "collate", {"postscript": None, "sync": None}),
     ]
 )
-def test_build_workflow(collate_value, sync_value, postscript, expect_workflow):
-    """Test the build_workflow method include correct stage based on the config.yaml."""
+def test_workflow_read_config(collate_value, sync_value, postscript, skip_step, expect_workflow):
+    """Test the read_config class method include correct stage based on the config.yaml."""
     config = copy.deepcopy(config_orig)
 
     # Update the config based on the test
@@ -39,8 +43,7 @@ def test_build_workflow(collate_value, sync_value, postscript, expect_workflow):
             config.pop(key, None)
 
     # Initialize the Workflow class and build the workflow
-    workflow = Workflow(config, run_number=1)
-    workflow.build_workflow()
+    workflow = Workflow.read_config(config, run_number=1, skip_step=skip_step)
 
     # Assert that the workflow_steps dictionary are as expected
     assert workflow.workflow_steps == expect_workflow
@@ -55,8 +58,7 @@ def test_submit_workflow(monkeypatch):
     mock_submit_sync = Mock(return_value="sync_job_id")
 
     # Initialise the workflow class and change the workflow_steps
-    workflow = Workflow(config_orig, run_number=1)
-    workflow.build_workflow()
+    workflow = Workflow.read_config(config_orig, run_number=1)
     workflow.workflow_steps = {"collate": None, "postscript": None, "sync": None}
 
     # When workflow import subcommands, it returns the mock function instead of the real ones

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -73,7 +73,7 @@ def test_submit_workflow(monkeypatch):
     )
 
     # Call the submit_workflow and check the new workflow_steps dictionary
-    assert workflow.submit_workflow("run_job_id") == {
+    assert workflow.submit_workflow("run_job_id", config=config_orig) == {
         "collate": "collate_job_id",
         "postscript": "postscript_job_id",
         "sync": "sync_job_id",


### PR DESCRIPTION
This PR adds job dependency to payu in the order of run > collate > postscript > sync. Sync now includes the last output and begins after postscript is finished.
Each step generates a job file.
This PR also updates `payu status` to
```
========================================
Run: 45
  ------------- Run Info -------------
  Job ID:            176017091.gadi-pbs
  Run ID:            bcdff5eeda6d72d0c0c45b8c6e0c39c83f244da8
  Stage:             archive
::
  Error Log:         xxx
  Job File:          xxx
 ------------- Collate Info -------------
  Job ID:            176017180.gadi-pbs
  Starts After:      ['176017091.gadi-pbs']
  Stage:             exited
  Total Queue Time:  0h 1m 39s
  Exit Status:       0 (Success)
  Output Log:        xxx
  Error Log:        xxx
  Job File:          xxx
  ------------- Postscript Info -------------
  Job ID:            176017185.gadi-pbs
  Starts After:      ['176017091.gadi-pbs', '176017180.gadi-pbs']
  Stage:             exited
  Output Log:        xxx
  Error Log:         xxxx
  Job File:          xxx
  ------------- Sync Info -------------
  Job ID:            176017188.gadi-pbs
  Starts After:      ['176017091.gadi-pbs', '176017180.gadi-pbs', '176017185.gadi-pbs']
  Stage:             exited
  Total Queue Time:  0h 2m 39s
  Exit Status:       0 (Success)
  Output Log:        xxx
  Error Log:        xxx
  Job File:          xxx
========================================
```
Closes #774 
Closes #787