### PR TITLE
Add runlog-off, repeat and reproduce-off CLI flag in payu run

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -264,12 +264,12 @@ If you have instructed ``payu`` to run for a number of resubmits but for some
 reason need to stop a run after the current run has completed create a file
 called ``stop_run`` in the control directory. 
 
-It is possible to require that a run reproduce an existing run using the 
-``-r/--reproduce`` flag:
+You may require a run to reproduce an existing run using the ``-r/--reproduce`` flag, 
+which overrides the reproduce setting in the configuration file.:
 
    payu run -r
 
-When this invoked all the manifests are read in and hashes checked for consistency
+When enabled, all manifests are read in and hashes are checked for consistency
 and only if all executables, inputs and restart files are unchanged will the run
 proceed. As the restart files are read directly from the manifests which are written
 before the previous run completed, by definition a restart run will not look for 
@@ -279,6 +279,10 @@ The reproduce option can be useful to be able to re-run a simulation for the
 purposes of checking reproducibility when compute infrastructure changes, or when
 spinning off a perturbation run to ensure consistency with a control run before
 applying modifications.
+
+To override the reproduce setting in configuration and skip the reproducibility check 
+for a particular run, please use ``payu run -r False``. This allows the run to 
+proceed even if manifests have changed.
 
 To run from an existing model run, also called a warm start, set the
 ``restart`` option to point to the folder containing the restart files

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -132,9 +132,9 @@ def get_model_type(model_type, config):
 
 
 def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
-                 reproduce=False, force=False, force_prune_restarts=False,
+                 reproduce=None, force=False, force_prune_restarts=False,
                  sync_restarts=False, sync_ignore_last=False, runlog_off=False,
-                 repeat_run=False, reproduce_off=False):
+                 repeat=False):
     """Construct the environment variables used by payu for resubmissions."""
     payu_env_vars = {}
 
@@ -179,11 +179,8 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     if dir_path:
         payu_env_vars['PAYU_DIR_PATH'] = os.path.normpath(dir_path)
 
-    if reproduce:
+    if reproduce is not None:
         payu_env_vars['PAYU_REPRODUCE'] = reproduce
-
-    if reproduce_off:
-        payu_env_vars['PAYU_REPRODUCE_OFF'] = reproduce_off
 
     if force:
         payu_env_vars['PAYU_FORCE'] = force
@@ -200,8 +197,8 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     if runlog_off:
         payu_env_vars['PAYU_RUNLOG_OFF'] = runlog_off
 
-    if repeat_run:
-        payu_env_vars['PAYU_REPEAT_RUN'] = repeat_run
+    if repeat:
+        payu_env_vars['PAYU_REPEAT'] = repeat
 
     # Pass through important module related environment variables
     module_env_vars = ['MODULESHOME', 'MODULES_CMD', 'MODULEPATH', 'MODULEV']

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -133,7 +133,8 @@ def get_model_type(model_type, config):
 
 def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
                  reproduce=False, force=False, force_prune_restarts=False,
-                 sync_restarts=False, sync_ignore_last=False):
+                 sync_restarts=False, sync_ignore_last=False, runlog_off=False,
+                 repeat_run=False, reproduce_off=False):
     """Construct the environment variables used by payu for resubmissions."""
     payu_env_vars = {}
 
@@ -181,6 +182,9 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     if reproduce:
         payu_env_vars['PAYU_REPRODUCE'] = reproduce
 
+    if reproduce_off:
+        payu_env_vars['PAYU_REPRODUCE_OFF'] = reproduce_off
+
     if force:
         payu_env_vars['PAYU_FORCE'] = force
 
@@ -192,6 +196,12 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
 
     if force_prune_restarts:
         payu_env_vars['PAYU_FORCE_PRUNE_RESTARTS'] = force_prune_restarts
+
+    if runlog_off:
+        payu_env_vars['PAYU_RUNLOG_OFF'] = runlog_off
+
+    if repeat_run:
+        payu_env_vars['PAYU_REPEAT_RUN'] = repeat_run
 
     # Pass through important module related environment variables
     module_env_vars = ['MODULESHOME', 'MODULES_CMD', 'MODULEPATH', 'MODULEV']

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -100,9 +100,7 @@ class Experiment(object):
         self.postscript = self.config.get('postscript')
         # repeat prioritise CLI flag > environment variable > config.yaml
         if not repeat:
-            repeat = os.environ.get('PAYU_REPEAT', False)
-        if not repeat:
-            repeat = self.config.get('repeat', False)
+            repeat = os.environ.get('PAYU_REPEAT', False) or self.config.get('repeat', False)
         self.repeat = repeat
 
         # Configuration
@@ -163,7 +161,7 @@ class Experiment(object):
 
         # runlog_off prioritise CLI flag > environment variable > config.yaml (in runlog.py)
         if not runlog_off:
-            runlog_off = os.environ.get('PAYU_RUNLOG_OFF', False)
+            runlog_off = os.environ.get('PAYU_RUNLOG_OFF', 'False').lower() == 'true'
 
         self.runlog = Runlog(self, runlog_off)
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -35,7 +35,7 @@ from payu.fsops import make_symlink, read_config, movetree
 from payu.fsops import list_sorted_archive_dirs
 from payu.fsops import run_script_command
 from payu.fsops import needs_subprocess_shell
-from payu.fsops import get_size
+from payu.fsops import get_size, str_to_bool
 from payu.schedulers import index as scheduler_index, DEFAULT_SCHEDULER_CONFIG
 from payu.models import index as model_index
 from payu.runlog import Runlog
@@ -73,9 +73,9 @@ def timeit(time_name):
 
 
 class Experiment(object):
-    def __init__(self, lab, reproduce=False, force=False, metadata_off=False, config_path=None, 
+    def __init__(self, lab, reproduce=None, force=False, metadata_off=False, config_path=None, 
                  is_new_experiment=False, keep_uuid=False, set_template_values=False, parent_info=None,
-                 runlog_off=False, repeat_run=False, reproduce_off=False):
+                 runlog_off=False, repeat=False):
         self.init_timings()
         self.lab = lab
         # Check laboratory directories are writable
@@ -98,12 +98,12 @@ class Experiment(object):
         # Payu experiment type
         self.debug = self.config.get('debug', False)
         self.postscript = self.config.get('postscript')
-        # repeat_run prioritise CLI flag > environment variable > config.yaml
-        if not repeat_run:
-            repeat_run = os.environ.get('PAYU_REPEAT_RUN', False)
-        if not repeat_run:
-            repeat_run = self.config.get('repeat', False)
-        self.repeat_run = repeat_run
+        # repeat prioritise CLI flag > environment variable > config.yaml
+        if not repeat:
+            repeat = os.environ.get('PAYU_REPEAT', False)
+        if not repeat:
+            repeat = self.config.get('repeat', False)
+        self.repeat = repeat
 
         # Configuration
         self.expand_shell_vars = True
@@ -144,16 +144,14 @@ class Experiment(object):
                                 restart_path=self.prior_restart_path,
                                 parent_info=parent_info)
 
-        if not reproduce:
+        if reproduce is None:
             # check environment for reproduce flag under PBS
-            reproduce = os.environ.get('PAYU_REPRODUCE', False)
-
-        if not reproduce_off:
-            reproduce_off = os.environ.get('PAYU_REPRODUCE_OFF', False)
+            reproduce = os.environ.get('PAYU_REPRODUCE', None)
+            reproduce = str_to_bool(reproduce) if reproduce else None
 
         # Initialize manifest
         self.manifest = Manifest(self.config.get('manifest', {}),
-                                 reproduce=reproduce, reproduce_off=reproduce_off)
+                                 reproduce=reproduce)
 
         # Miscellaneous configurations
         userscript_val = self.config.get('userscripts', {})
@@ -165,10 +163,9 @@ class Experiment(object):
 
         # runlog_off prioritise CLI flag > environment variable > config.yaml (in runlog.py)
         if not runlog_off:
-            self.runlog_off = os.environ.get('PAYU_RUNLOG_OFF', False)
-        else:
-            self.runlog_off = runlog_off
-        self.runlog = Runlog(self)
+            runlog_off = os.environ.get('PAYU_RUNLOG_OFF', False)
+
+        self.runlog = Runlog(self, runlog_off)
 
         #  This is a bit hacky
         default_payu_bin = os.path.dirname(sys.argv[0])
@@ -446,13 +443,13 @@ class Experiment(object):
         no_restarts = self.max_output_index(output_type="restart") is None
         # Check if a user restart directory is avaiable
         user_restart_dir = self.config.get('restart')
-        if (no_restarts or self.repeat_run) and user_restart_dir:
+        if (no_restarts or self.repeat) and user_restart_dir:
             if not os.path.isdir(user_restart_dir):
                 raise errors.PayuConfigError(
                     f"No restart directory found at {user_restart_dir}. "
                     "Check 'restart:' field in config.yaml."
                 )
-            if self.counter > 0 and not self.repeat_run:
+            if self.counter > 0 and not self.repeat:
                 warnings.warn(
                     "Starting run from restart directory (in config.yaml): "
                     f"{user_restart_dir}"
@@ -462,11 +459,11 @@ class Experiment(object):
             prior_restart_dir = 'restart{0:03}'.format(self.counter - 1)
             prior_restart_path = os.path.join(self.archive_path,
                                               prior_restart_dir)
-            if os.path.exists(prior_restart_path) and not self.repeat_run:
+            if os.path.exists(prior_restart_path) and not self.repeat:
                 self.prior_restart_path = prior_restart_path
             else:
                 self.prior_restart_path = None
-                if self.counter > 0 and not self.repeat_run:
+                if self.counter > 0 and not self.repeat:
                     warnings.warn(
                         "No prior restart directory found in archive "
                         "or specified in config.yaml"
@@ -1184,9 +1181,9 @@ class Experiment(object):
         for restart in restarts:
             restart_indices[restart] = int(restart.lstrip('restart'))
 
-        # TODO: Previous logic was to prune all restarts if self.repeat_run
+        # TODO: Previous logic was to prune all restarts if self.repeat
         # Still need to figure out what should happen in this case
-        if self.repeat_run:
+        if self.repeat:
             return [os.path.join(self.archive_path, restart)
                     for restart in restarts]
 

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -74,7 +74,8 @@ def timeit(time_name):
 
 class Experiment(object):
     def __init__(self, lab, reproduce=False, force=False, metadata_off=False, config_path=None, 
-                 is_new_experiment=False, keep_uuid=False, set_template_values=False, parent_info=None):
+                 is_new_experiment=False, keep_uuid=False, set_template_values=False, parent_info=None,
+                 runlog_off=False, repeat_run=False, reproduce_off=False):
         self.init_timings()
         self.lab = lab
         # Check laboratory directories are writable
@@ -97,7 +98,12 @@ class Experiment(object):
         # Payu experiment type
         self.debug = self.config.get('debug', False)
         self.postscript = self.config.get('postscript')
-        self.repeat_run = self.config.get('repeat', False)
+        # repeat_run prioritise CLI flag > environment variable > config.yaml
+        if not repeat_run:
+            repeat_run = os.environ.get('PAYU_REPEAT_RUN', False)
+        if not repeat_run:
+            repeat_run = self.config.get('repeat', False)
+        self.repeat_run = repeat_run
 
         # Configuration
         self.expand_shell_vars = True
@@ -142,9 +148,12 @@ class Experiment(object):
             # check environment for reproduce flag under PBS
             reproduce = os.environ.get('PAYU_REPRODUCE', False)
 
+        if not reproduce_off:
+            reproduce_off = os.environ.get('PAYU_REPRODUCE_OFF', False)
+
         # Initialize manifest
         self.manifest = Manifest(self.config.get('manifest', {}),
-                                 reproduce=reproduce)
+                                 reproduce=reproduce, reproduce_off=reproduce_off)
 
         # Miscellaneous configurations
         userscript_val = self.config.get('userscripts', {})
@@ -154,6 +163,11 @@ class Experiment(object):
         if init_script:
             self.run_userscript(init_script, 'init')
 
+        # runlog_off prioritise CLI flag > environment variable > config.yaml (in runlog.py)
+        if not runlog_off:
+            self.runlog_off = os.environ.get('PAYU_RUNLOG_OFF', False)
+        else:
+            self.runlog_off = runlog_off
         self.runlog = Runlog(self)
 
         #  This is a bit hacky

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -1180,7 +1180,7 @@ class Experiment(object):
             restart_indices[restart] = int(restart.lstrip('restart'))
 
         # TODO: Previous logic was to prune all restarts if self.repeat
-        # Still need to figure out what should happen in this case
+        # Should add a check if any restart exists before the run (issue 845)
         if self.repeat:
             return [os.path.join(self.archive_path, restart)
                     for restart in restarts]

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -100,7 +100,7 @@ class Experiment(object):
         self.postscript = self.config.get('postscript')
         # repeat prioritise CLI flag > environment variable > config.yaml
         if not repeat:
-            repeat = os.environ.get('PAYU_REPEAT', False) or self.config.get('repeat', False)
+            repeat = str_to_bool(os.environ.get('PAYU_REPEAT', False)) or self.config.get('repeat', False)
         self.repeat = repeat
 
         # Configuration

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -406,3 +406,13 @@ def get_size(work_path):
 
     # Convert the total size from bytes to gigabytes
     return (int(total_size) * ureg.byte).to(ureg.gibibyte).magnitude
+
+def str_to_bool(value):
+    if isinstance(value, bool):
+        return value
+    if value.lower() in ('true', '1'):
+        return True
+    elif value.lower() in ('false', '0'):
+        return False
+    else:
+        raise ValueError(f"Input is not acceptable. Please use 'True' or 'False' or '1' or '0'.")

--- a/payu/fsops.py
+++ b/payu/fsops.py
@@ -408,6 +408,9 @@ def get_size(work_path):
     return (int(total_size) * ureg.byte).to(ureg.gibibyte).magnitude
 
 def str_to_bool(value):
+    """Convert a boolean-like value to `bool`. Accepts a boolean directly, or a 
+    case-insensitive string in: `{"true", "1", "false", "0"}`.
+    """
     if isinstance(value, bool):
         return value
     if value.lower() in ('true', '1'):

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -272,17 +272,17 @@ class Manifest(object):
         self.manifests = {}
         self.previous_manifests = {}
         self.reproduce = {}
+        print(f"Manifest reproduce flag: {reproduce}")
 
+        reproduce_config = self.manifest_config.get('reproduce', {})
         for mf in ['input', 'restart', 'exe']:
             self.init_mf(mf)
-            if reproduce is not None:
+            if reproduce is None:
+                # If reproduce is None, read config.yaml setting and fall back to False
+                self.reproduce[mf] = reproduce_config.get(mf, False)
+            else:
                 # If reproduce is True or False, set all manifests to that value
                 self.reproduce[mf] = reproduce
-
-            else:
-                # If reproduce is None, read config.yaml setting and fall back to False
-                reproduce_config = self.manifest_config.get('reproduce', {})
-                self.reproduce[mf] = reproduce_config.get(mf, False)
 
         # Make sure the manifests directory exists
         os.makedirs(os.path.dirname(self.manifests['exe'].path), exist_ok=True)

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -238,7 +238,7 @@ class Manifest(object):
     methods to operate on them
     """
 
-    def __init__(self, config, reproduce, reproduce_off=False):
+    def __init__(self, config, reproduce):
 
         # Manifest control configuration
         self.manifest_config = config
@@ -273,14 +273,17 @@ class Manifest(object):
         self.previous_manifests = {}
         self.reproduce = {}
 
-        # reproduce_off flag > config.yaml > reproduce flag
-        reproduce_config = self.manifest_config.get('reproduce', {})
         for mf in ['input', 'restart', 'exe']:
             self.init_mf(mf)
-            if reproduce_off:
-                self.reproduce[mf] = False
+            if reproduce is not None:
+                # If reproduce is True or False, set all manifests to that value
+                self.reproduce[mf] = reproduce
+
             else:
-                self.reproduce[mf] = reproduce_config.get(mf, reproduce)
+                # If reproduce is None, read config.yaml setting and fall back to False
+                reproduce_config = self.manifest_config.get('reproduce', {})
+                self.reproduce[mf] = reproduce_config.get(mf, False)
+
         # Make sure the manifests directory exists
         os.makedirs(os.path.dirname(self.manifests['exe'].path), exist_ok=True)
 

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -272,7 +272,6 @@ class Manifest(object):
         self.manifests = {}
         self.previous_manifests = {}
         self.reproduce = {}
-        print(f"Manifest reproduce flag: {reproduce}")
 
         reproduce_config = self.manifest_config.get('reproduce', {})
         for mf in ['input', 'restart', 'exe']:

--- a/payu/manifest.py
+++ b/payu/manifest.py
@@ -238,7 +238,7 @@ class Manifest(object):
     methods to operate on them
     """
 
-    def __init__(self, config, reproduce):
+    def __init__(self, config, reproduce, reproduce_off=False):
 
         # Manifest control configuration
         self.manifest_config = config
@@ -271,12 +271,16 @@ class Manifest(object):
         # Initialise manifests and reproduce flags
         self.manifests = {}
         self.previous_manifests = {}
-        reproduce_config = self.manifest_config.get('reproduce', {})
         self.reproduce = {}
+
+        # reproduce_off flag > config.yaml > reproduce flag
+        reproduce_config = self.manifest_config.get('reproduce', {})
         for mf in ['input', 'restart', 'exe']:
             self.init_mf(mf)
-            self.reproduce[mf] = reproduce_config.get(mf, reproduce)
-
+            if reproduce_off:
+                self.reproduce[mf] = False
+            else:
+                self.reproduce[mf] = reproduce_config.get(mf, reproduce)
         # Make sure the manifests directory exists
         os.makedirs(os.path.dirname(self.manifests['exe'].path), exist_ok=True)
 

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -22,14 +22,20 @@ class Runlog(object):
 
         self.expt = expt
 
-        # Fetch and update the runlog config
-        runlog_config = self.expt.config.get('runlog', {})
-        if isinstance(runlog_config, bool):
-            self.enabled = runlog_config
+        if self.expt.runlog_off:
+            self.enabled = False
             runlog_config = {}
+
         else:
-            assert isinstance(runlog_config, dict)
-            self.enabled = runlog_config.pop('enable', True)
+            # Fetch and update the runlog config
+            runlog_config = self.expt.config.get('runlog', {})
+            if isinstance(runlog_config, bool):
+                self.enabled = runlog_config
+                runlog_config = {}
+            else:
+                assert isinstance(runlog_config, dict)
+                self.enabled = runlog_config.pop('enable', True)            
+
         self.config = runlog_config
 
         self.manifest = []

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -16,27 +16,22 @@ from payu.git_utils import GitRepository, get_git_repository
 import payu.errors as errors
 
 class Runlog(object):
-    def __init__(self, expt):
+    def __init__(self, expt, runlog_off=False):
         # Disable user's global git rc file
         os.environ['GIT_CONFIG_NOGLOBAL'] = 'yes'
 
         self.expt = expt
 
-        if self.expt.runlog_off:
-            self.enabled = False
-            runlog_config = {}
-
+        # If runlog_off is specified in CLI or environment variable, disable runlog
+        if runlog_off:
+            runlog_config = {'enable': False}
         else:
             # Fetch and update the runlog config
             runlog_config = self.expt.config.get('runlog', {})
             if isinstance(runlog_config, bool):
-                self.enabled = runlog_config
-                runlog_config = {}
-            else:
-                assert isinstance(runlog_config, dict)
-                self.enabled = runlog_config.pop('enable', True)            
+                runlog_config = {'enable': runlog_config}
 
-        self.config = runlog_config
+        self.enabled = runlog_config.pop('enable', True)            
 
         self.manifest = []
 

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -31,8 +31,7 @@ class Runlog(object):
             if isinstance(runlog_config, bool):
                 runlog_config = {'enable': runlog_config}
 
-        self.enabled = runlog_config.pop('enable', True)   
-        print(f"Runlog enabled: {self.enabled}")         
+        self.enabled = runlog_config.pop('enable', True)  
 
         self.manifest = []
 

--- a/payu/runlog.py
+++ b/payu/runlog.py
@@ -31,7 +31,8 @@ class Runlog(object):
             if isinstance(runlog_config, bool):
                 runlog_config = {'enable': runlog_config}
 
-        self.enabled = runlog_config.pop('enable', True)            
+        self.enabled = runlog_config.pop('enable', True)   
+        print(f"Runlog enabled: {self.enabled}")         
 
         self.manifest = []
 

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from payu.fsops import str_to_bool
 
 # Model type selection
 model = {
@@ -43,7 +44,7 @@ nruns = {
         'action':   'store',
         'dest':     'n_runs',
         'default':  None,
-        'help':     'Number of successive experiments ro run',
+        'help':     'Number of successive experiments to run',
     }
 }
 
@@ -94,23 +95,15 @@ dir_path = {
 
 # Specify a reproducible run
 reproduce = {
-    'flags': ('--reproduce', '--repro', '-r'),
+    'flags': ['--reproduce', '--repro', '-r'],
     'parameters': {
-        'action':   'store_true',
+        'action':   'store',
         'dest':     'reproduce',
-        'default':  False,
-        'help': 'A fallback value when manifest reproduce section is not configured in config.yaml',
-    }
-}
-
-
-reproduce_off = {
-    'flags': ('--reproduce-off',),
-    'parameters': {
-        'action':   'store_true',
-        'dest':     'reproduce_off',
-        'default':  False,
-        'help': 'Disable reproducible run, ignoring any manifest reproduce section in config.yaml',
+        'nargs':     '?',    # Accepts `-r`, `-r True`, or `-r False`
+        'const':    True,    # When only `-r` is provided, set reproduce to True (boolean)
+        'default':  None,    # When `-r` is not provided, set reproduce to None
+        'type': str_to_bool,
+        'help': 'Set up for a reproducible run, overriding any manifest reproduce section in config.yaml.',
     }
 }
 
@@ -420,10 +413,10 @@ runlog_off = {
     }
 }
 
-repeat_run = {
+repeat = {
     'flags': ['--repeat'],
     'parameters': {
-        'dest': 'repeat_run',
+        'dest': 'repeat',
         'action': 'store_true',
         'default': False,
         'help': 'Remove any archived restart files and repeat the initial run upon resubmission'

--- a/payu/subcommands/args.py
+++ b/payu/subcommands/args.py
@@ -99,10 +99,20 @@ reproduce = {
         'action':   'store_true',
         'dest':     'reproduce',
         'default':  False,
-        'help':     'Only run if manifests are correct',
+        'help': 'A fallback value when manifest reproduce section is not configured in config.yaml',
     }
 }
 
+
+reproduce_off = {
+    'flags': ('--reproduce-off',),
+    'parameters': {
+        'action':   'store_true',
+        'dest':     'reproduce_off',
+        'default':  False,
+        'help': 'Disable reproducible run, ignoring any manifest reproduce section in config.yaml',
+    }
+}
 
 # Force run to proceed despite existing directories
 force = {
@@ -396,5 +406,26 @@ dry_run = {
         'action': 'store_true',
         'default': False,
         'help': 'Print out the submission command without executing it'
+    }
+}
+
+
+runlog_off = {
+    'flags': ['--runlog-off'],
+    'parameters': {
+        'dest': 'runlog_off',
+        'action': 'store_true',
+        'default': False,
+        'help': 'Disable runlog tracking for this experiment'
+    }
+}
+
+repeat_run = {
+    'flags': ['--repeat'],
+    'parameters': {
+        'dest': 'repeat_run',
+        'action': 'store_true',
+        'default': False,
+        'help': 'Remove any archived restart files and repeat the initial run upon resubmission'
     }
 }

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -22,9 +22,20 @@ parameters = {'description': 'Run the model experiment'}
 
 arguments = [args.model, args.config, args.initial, args.nruns,
              args.laboratory, args.reproduce, args.force,
-             args.force_prune_restarts, args.is_new_experiment, args.dry_run]
+             args.force_prune_restarts, args.is_new_experiment, args.dry_run,
+             args.runlog_off, args.repeat_run, args.reproduce_off]
 
 logger = logging.getLogger(__name__)
+
+
+def validate_reproduce_flags(reproduce, reproduce_off):
+    """
+    Validate that --reproduce and --reproduce-off are not both set.
+    """
+    if reproduce and reproduce_off:
+        raise errors.PayuConfigError(
+            "--reproduce and --reproduce-off cannot both be specified."
+        )
 
 
 def validate_platform_node(platform, queue, get_queue_node_shape):
@@ -48,21 +59,28 @@ def validate_platform_node(platform, queue, get_queue_node_shape):
 
 def runcmd(model_type, config_path, init_run, n_runs, lab_path,
            reproduce=False, force=False, force_prune_restarts=False,
-           is_new_experiment=False, dry_run=False):
+           is_new_experiment=False, dry_run=False, runlog_off=False, 
+           repeat_run=False, reproduce_off=False):
+    validate_reproduce_flags(reproduce, reproduce_off)
+
     # Get job submission configuration
     pbs_config = fsops.read_config(config_path)
     pbs_vars = cli.set_env_vars(init_run=init_run,
                                 n_runs=n_runs,
                                 lab_path=lab_path,
                                 reproduce=reproduce,
+                                reproduce_off=reproduce_off,
                                 force=force,
-                                force_prune_restarts=force_prune_restarts)
+                                force_prune_restarts=force_prune_restarts,
+                                runlog_off=runlog_off,
+                                repeat_run=repeat_run)
 
     # Initialise Experiment early so we can detect scheduler
     # Run experiment initialisation to update metadata,
     # and determine the run counter and uuid before job submission
     lab = Laboratory(model_type, config_path, lab_path)
-    expt = Experiment(lab, reproduce=reproduce, force=force, is_new_experiment=is_new_experiment)
+    expt = Experiment(lab, reproduce=reproduce, reproduce_off=reproduce_off, force=force, is_new_experiment=is_new_experiment, 
+                    runlog_off=runlog_off, repeat_run=repeat_run)
 
     # Set the queue
     # NOTE: Maybe force all jobs on the normal queue
@@ -174,11 +192,13 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
 
 def runscript(**run_args):
     run_args = argparse.Namespace(**run_args)
+    validate_reproduce_flags(run_args.reproduce, run_args.reproduce_off)
 
     lab = Laboratory(run_args.model_type, run_args.config_path,
                      run_args.lab_path)
 
-    expt = Experiment(lab, reproduce=run_args.reproduce, force=run_args.force, is_new_experiment=run_args.is_new_experiment)
+    expt = Experiment(lab, reproduce=run_args.reproduce, reproduce_off=run_args.reproduce_off, force=run_args.force, is_new_experiment=run_args.is_new_experiment,
+                      runlog_off=run_args.runlog_off, repeat_run=run_args.repeat_run)
 
     n_runs_per_submit = expt.config.get('runspersub', 1)
     subrun = 1

--- a/payu/subcommands/run_cmd.py
+++ b/payu/subcommands/run_cmd.py
@@ -3,7 +3,6 @@ import os
 import argparse
 from pathlib import Path
 
-import sys
 import logging
 
 # Local imports
@@ -23,19 +22,9 @@ parameters = {'description': 'Run the model experiment'}
 arguments = [args.model, args.config, args.initial, args.nruns,
              args.laboratory, args.reproduce, args.force,
              args.force_prune_restarts, args.is_new_experiment, args.dry_run,
-             args.runlog_off, args.repeat_run, args.reproduce_off]
+             args.runlog_off, args.repeat]
 
 logger = logging.getLogger(__name__)
-
-
-def validate_reproduce_flags(reproduce, reproduce_off):
-    """
-    Validate that --reproduce and --reproduce-off are not both set.
-    """
-    if reproduce and reproduce_off:
-        raise errors.PayuConfigError(
-            "--reproduce and --reproduce-off cannot both be specified."
-        )
 
 
 def validate_platform_node(platform, queue, get_queue_node_shape):
@@ -58,10 +47,9 @@ def validate_platform_node(platform, queue, get_queue_node_shape):
 
 
 def runcmd(model_type, config_path, init_run, n_runs, lab_path,
-           reproduce=False, force=False, force_prune_restarts=False,
+           reproduce=None, force=False, force_prune_restarts=False,
            is_new_experiment=False, dry_run=False, runlog_off=False, 
-           repeat_run=False, reproduce_off=False):
-    validate_reproduce_flags(reproduce, reproduce_off)
+           repeat=False):
 
     # Get job submission configuration
     pbs_config = fsops.read_config(config_path)
@@ -69,18 +57,17 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
                                 n_runs=n_runs,
                                 lab_path=lab_path,
                                 reproduce=reproduce,
-                                reproduce_off=reproduce_off,
                                 force=force,
                                 force_prune_restarts=force_prune_restarts,
                                 runlog_off=runlog_off,
-                                repeat_run=repeat_run)
+                                repeat=repeat)
 
     # Initialise Experiment early so we can detect scheduler
     # Run experiment initialisation to update metadata,
     # and determine the run counter and uuid before job submission
     lab = Laboratory(model_type, config_path, lab_path)
-    expt = Experiment(lab, reproduce=reproduce, reproduce_off=reproduce_off, force=force, is_new_experiment=is_new_experiment, 
-                    runlog_off=runlog_off, repeat_run=repeat_run)
+    expt = Experiment(lab, reproduce=reproduce, force=force, is_new_experiment=is_new_experiment, 
+                    runlog_off=runlog_off, repeat=repeat)
 
     # Set the queue
     # NOTE: Maybe force all jobs on the normal queue
@@ -192,13 +179,12 @@ def runcmd(model_type, config_path, init_run, n_runs, lab_path,
 
 def runscript(**run_args):
     run_args = argparse.Namespace(**run_args)
-    validate_reproduce_flags(run_args.reproduce, run_args.reproduce_off)
 
     lab = Laboratory(run_args.model_type, run_args.config_path,
                      run_args.lab_path)
 
-    expt = Experiment(lab, reproduce=run_args.reproduce, reproduce_off=run_args.reproduce_off, force=run_args.force, is_new_experiment=run_args.is_new_experiment,
-                      runlog_off=run_args.runlog_off, repeat_run=run_args.repeat_run)
+    expt = Experiment(lab, reproduce=run_args.reproduce, force=run_args.force, is_new_experiment=run_args.is_new_experiment,
+                      runlog_off=run_args.runlog_off, repeat=run_args.repeat)
 
     n_runs_per_submit = expt.config.get('runspersub', 1)
     subrun = 1

--- a/payu/subcommands/setup_cmd.py
+++ b/payu/subcommands/setup_cmd.py
@@ -19,7 +19,7 @@ arguments = [
 
 
 def runcmd(model_type, config_path, lab_path,
-           reproduce=False, force=False, metadata_off=False, is_new_experiment=False):
+           reproduce=None, force=False, metadata_off=False, is_new_experiment=False):
 
     lab = Laboratory(model_type, config_path, lab_path)
     expt = Experiment(lab, reproduce=reproduce, force=force,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -205,7 +205,7 @@ def test_parse_run(parser):
     assert len(args) == 0
 
 def test_parse_run_reproduce_arg(parser):
-    """ Test that --reproduce argument can accpet True or False values. """
+    """ Test that --reproduce argument can accept True or False values. """
     cmd = 'run'
     false_cmd = (
             f"payu {cmd} "

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -10,6 +10,7 @@ import logging
 import payu
 import payu.cli
 import payu.errors as errors
+from payu.subcommands.run_cmd import validate_reproduce_flags
 
 verbose = True
 ORIGINAL_WARNING = warnings.formatwarning
@@ -132,6 +133,9 @@ def test_parse_run(parser):
     assert args.pop('force_prune_restarts') is False
     assert args.pop('is_new_experiment') is False
     assert args.pop('dry_run') is False
+    assert args.pop('runlog_off') is False
+    assert args.pop('repeat_run') is False
+    assert args.pop('reproduce_off') is False
 
     assert len(args) == 0
 
@@ -148,6 +152,9 @@ def test_parse_run(parser):
             "--force-prune-restarts "
             "--new-uuid "
             "--dry-run "
+            "--runlog-off "
+            "--repeat "
+            "--reproduce-off "
             )
 
     run_cmd, args = parse_args(parser, long_cmd)
@@ -164,6 +171,9 @@ def test_parse_run(parser):
     assert args.pop('force_prune_restarts') is True
     assert args.pop('is_new_experiment') is True
     assert args.pop('dry_run') is True
+    assert args.pop('runlog_off') is True
+    assert args.pop('repeat_run') is True
+    assert args.pop('reproduce_off') is True
 
     assert len(args) == 0
 
@@ -193,6 +203,9 @@ def test_parse_run(parser):
     assert args.pop('force_prune_restarts') is True
     assert args.pop('is_new_experiment') is False
     assert args.pop('dry_run') is False
+    assert args.pop('runlog_off') is False
+    assert args.pop('repeat_run') is False
+    assert args.pop('reproduce_off') is False
 
     assert len(args) == 0
 
@@ -519,3 +532,11 @@ def test_submit_job_error_msg_from_hpcpy():
             payu.cli.submit_job(config={"scheduler": "pbs"}, script="submit_script.sh")
             assert "Error occurred while submitting a job to scheduler pbs" in str(exc_info.value)
             assert "Error: HPCpy submission failed" in str(exc_info.value)
+
+def test_validate_reproduce_flags():
+    """Test that validate_reproduce_flags raises an error when both reproduce and reproduce_off are True."""
+    validate_reproduce_flags(False, True)
+    validate_reproduce_flags(True, False)
+    with pytest.raises(errors.PayuConfigError, match="--reproduce and --reproduce-off cannot both be specified."):
+        validate_reproduce_flags(True, True)
+    

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -10,7 +10,6 @@ import logging
 import payu
 import payu.cli
 import payu.errors as errors
-from payu.subcommands.run_cmd import validate_reproduce_flags
 
 verbose = True
 ORIGINAL_WARNING = warnings.formatwarning
@@ -58,7 +57,7 @@ def test_parse_setup(parser):
     assert args.pop('model_type') is None
     assert args.pop('config_path') is None
     assert args.pop('lab_path') is None
-    assert args.pop('reproduce') is False
+    assert args.pop('reproduce') is None
     assert args.pop('force') is False
     assert args.pop('metadata_off') is False
     assert args.pop('is_new_experiment') is False
@@ -126,7 +125,7 @@ def test_parse_run(parser):
     assert args.pop('model_type') is None
     assert args.pop('config_path') is None
     assert args.pop('lab_path') is None
-    assert args.pop('reproduce') is False
+    assert args.pop('reproduce') is None
     assert args.pop('force') is False
     assert args.pop('init_run') is None
     assert args.pop('n_runs') is None
@@ -134,8 +133,7 @@ def test_parse_run(parser):
     assert args.pop('is_new_experiment') is False
     assert args.pop('dry_run') is False
     assert args.pop('runlog_off') is False
-    assert args.pop('repeat_run') is False
-    assert args.pop('reproduce_off') is False
+    assert args.pop('repeat') is False
 
     assert len(args) == 0
 
@@ -154,7 +152,6 @@ def test_parse_run(parser):
             "--dry-run "
             "--runlog-off "
             "--repeat "
-            "--reproduce-off "
             )
 
     run_cmd, args = parse_args(parser, long_cmd)
@@ -172,8 +169,7 @@ def test_parse_run(parser):
     assert args.pop('is_new_experiment') is True
     assert args.pop('dry_run') is True
     assert args.pop('runlog_off') is True
-    assert args.pop('repeat_run') is True
-    assert args.pop('reproduce_off') is True
+    assert args.pop('repeat') is True
 
     assert len(args) == 0
 
@@ -204,10 +200,34 @@ def test_parse_run(parser):
     assert args.pop('is_new_experiment') is False
     assert args.pop('dry_run') is False
     assert args.pop('runlog_off') is False
-    assert args.pop('repeat_run') is False
-    assert args.pop('reproduce_off') is False
+    assert args.pop('repeat') is False
 
     assert len(args) == 0
+
+def test_parse_run_reproduce_arg(parser):
+    """ Test that --reproduce argument can accpet True or False values. """
+    cmd = 'run'
+    false_cmd = (
+            f"payu {cmd} "
+            "--reproduce "
+            "False "
+            )
+    run_cmd, args = parse_args(parser, false_cmd)
+    
+    assert run_cmd.__module__ == 'payu.subcommands.{cmd}_cmd'.format(cmd=cmd)
+
+    assert args.pop('reproduce') == False
+
+    true_cmd = (
+                f"payu {cmd} "
+                "--reproduce "
+                "True "
+                )
+    run_cmd, args = parse_args(parser, true_cmd)
+    
+    assert run_cmd.__module__ == 'payu.subcommands.{cmd}_cmd'.format(cmd=cmd)
+
+    assert args.pop('reproduce') == True
 
 
 def test_parse_sweep(parser):
@@ -533,10 +553,4 @@ def test_submit_job_error_msg_from_hpcpy():
             assert "Error occurred while submitting a job to scheduler pbs" in str(exc_info.value)
             assert "Error: HPCpy submission failed" in str(exc_info.value)
 
-def test_validate_reproduce_flags():
-    """Test that validate_reproduce_flags raises an error when both reproduce and reproduce_off are True."""
-    validate_reproduce_flags(False, True)
-    validate_reproduce_flags(True, False)
-    with pytest.raises(errors.PayuConfigError, match="--reproduce and --reproduce-off cannot both be specified."):
-        validate_reproduce_flags(True, True)
     

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -335,7 +335,7 @@ def test_check_payu_version_configured_invalid_version(minimum_version):
          ]
 )
 @pytest.mark.filterwarnings("error")
-def test_runlog_off(runlog, enabled):
+def test_runlog_enable(runlog, enabled):
     config = copy.deepcopy(config_orig)
     if runlog == None:
         config.pop('runlog') #remove from config for default case
@@ -470,7 +470,7 @@ def test_null_userscripts():
 
 
 @patch('payu.git_utils.get_git_repository')
-def test_setup_runlog_offd_not_git(mock_git_repo):
+def test_setup_runlog_enabled_not_git(mock_git_repo):
     """ Test an error is raised if runlog is enabled but no git repository is found."""
     mock_git_repo.return_value = None
 

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -335,7 +335,7 @@ def test_check_payu_version_configured_invalid_version(minimum_version):
          ]
 )
 @pytest.mark.filterwarnings("error")
-def test_runlog_enable(runlog, enabled):
+def test_runlog_off(runlog, enabled):
     config = copy.deepcopy(config_orig)
     if runlog == None:
         config.pop('runlog') #remove from config for default case
@@ -470,7 +470,7 @@ def test_null_userscripts():
 
 
 @patch('payu.git_utils.get_git_repository')
-def test_setup_runlog_enabled_not_git(mock_git_repo):
+def test_setup_runlog_offd_not_git(mock_git_repo):
     """ Test an error is raised if runlog is enabled but no git repository is found."""
     mock_git_repo.return_value = None
 

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -45,14 +45,14 @@ def setup_and_teardown():
         print(e)
 
 
-def init_experiment(config):
+def init_experiment(config, reproduce=None, runlog_off=False, repeat=False):
     """Helper function to initialize an experiment with a given config."""
     write_config(config)
     make_inputs()
 
     with cd(ctrldir):
         lab = payu.laboratory.Laboratory(lab_path=str(labdir))
-        expt = payu.experiment.Experiment(lab, reproduce=False)
+        expt = payu.experiment.Experiment(lab, reproduce=reproduce, runlog_off=runlog_off, repeat=repeat)
         return expt
 
 
@@ -347,6 +347,95 @@ def test_runlog_enable(runlog, enabled):
 
     assert model.expt.runlog.enabled == enabled
 
+
+@pytest.mark.parametrize(
+    "runlog_off_flag, runlog_off_env, config_runlog, expected_enabled",
+    [
+        (True, None, True, False),
+        (False, "True", True, False),
+        (False, None, False, False),
+        (False, None, True, True),
+    ],
+)
+def test_runlog_off_flag(monkeypatch, runlog_off_flag, runlog_off_env, config_runlog, expected_enabled):
+    """Test that --runlog-off disables runlog and overrides config.yaml."""
+    config = copy.deepcopy(config_orig)
+    config["runlog"] = config_runlog
+
+    if runlog_off_env is None:
+        monkeypatch.delenv("PAYU_RUNLOG_OFF", raising=False)
+    else:
+        monkeypatch.setenv("PAYU_RUNLOG_OFF", runlog_off_env)
+
+    expt = init_experiment(config, runlog_off=runlog_off_flag)
+    assert expt.runlog.enabled == expected_enabled
+
+
+@pytest.mark.parametrize(
+    "reproduce_flag, env_value, expected_reproduce",
+    [
+        (True, None, True),
+        (False, None, False),
+        (None, "True", True),
+        (None, "False", False),
+    ],
+)
+def test_reproduce_flag(monkeypatch, reproduce_flag, env_value, expected_reproduce):
+    config = copy.deepcopy(config_orig)
+
+    if env_value is None:
+        monkeypatch.delenv("PAYU_REPRODUCE", raising=False)
+    else:
+        monkeypatch.setenv("PAYU_REPRODUCE", env_value)
+
+    expt = init_experiment(config, reproduce=reproduce_flag)
+
+    for value in expt.manifest.reproduce.values():
+        assert value == expected_reproduce
+
+
+@pytest.mark.parametrize(
+    "config_reproduce",
+    [
+        ({"input": True, "exe": True, "restart": True}),
+        ({"input": False, "exe": True, "restart": False}),
+        ({"input": True, "exe": False, "restart": True}),
+    ],
+)
+def test_no_reproduce_flag(monkeypatch, config_reproduce):
+    """Test that manifest reproduce values are taken from config.yaml when -r is not provided."""
+    config = copy.deepcopy(config_orig)
+    config["manifest"]["reproduce"] = config_reproduce
+
+    monkeypatch.delenv("PAYU_REPRODUCE", raising=False)
+    expt = init_experiment(config)
+
+    assert expt.manifest.reproduce == config_reproduce
+
+
+@pytest.mark.parametrize(
+    "repeat_flag, repeat_env, repeat_config, expected_repeat",
+    [
+        (True, None, False, True),  # CLI flag > environment variable > config.yaml
+        (False, 'True', False, True),  
+        (False, None, True, True),
+        (False, None, False, False),
+        (True, 'False', False, True),
+    ]
+)
+def test_repeat_flag_priority(monkeypatch, repeat_flag, repeat_env, repeat_config, expected_repeat):
+    """Test that the repeat flag follows the priority: CLI flag > environment variable > config.yaml"""
+    config = copy.deepcopy(config_orig)
+    config['repeat'] = repeat_config
+
+    # Set up or clear the PAYU_REPEAT environment variable
+    if repeat_env is None:
+        monkeypatch.delenv('PAYU_REPEAT', raising=False)
+    else:
+        monkeypatch.setenv('PAYU_REPEAT', repeat_env)
+
+    expt = init_experiment(config, repeat=repeat_flag)
+    assert expt.repeat == expected_repeat
 
 def test_set_prior_restart_path_no_restarts_in_archive():
     """Test that prior restart path is set to None if no restarts in archive."""


### PR DESCRIPTION
This PR adds `--runlog-off`, `--repeat` and `--reproduce-off` command-line flags to `payu run`.

### `--runlog-off`:
This experiment skips git commits. The runlog section in `config.yaml` is ignored.

### `--repeat`
This run becomes a repeat run, and `config.yaml` repeat setting is ignored.

### `--reproduce=False`
Disables manifest reproducibility checks for executable, input, and restart files. 
When `--reproduce=True` is added, all manifests will be checked for reproducibility (exe, input and restarts). 
The reproduce section in `config.yaml` is ignored.

Closes #302