### PR TITLE
Skip asking for branch_or_commit if branch is specified in URL.

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -112,8 +112,11 @@ For example::
       payu clone ${REPOSITORY} my_expt
       cd my_expt
 
-Where ``${REPOSITORY}`` is the git URL or path of the repository to clone from, 
-for example, https://github.com/payu-org/mom-example.git.
+Where ``${REPOSITORY}`` is the Git URL or path of the repository to clone from, 
+for example, https://github.com/payu-org/mom-example.git. For non-interactive payu clone, 
+the repository URL must use the base ``<org>/<repo>`` format. Branch names  
+in the repository URL (e.g., https://github.com/payu-org/mom-example/tree/master) are 
+supported only in interactive payu clone (see below).
 
 To clone and checkout an existing git branch, use the ``-B/--branch`` flag and
 specify the branch name::

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -113,10 +113,10 @@ For example::
       cd my_expt
 
 Where ``${REPOSITORY}`` is the Git URL or path of the repository to clone from, 
-for example, https://github.com/payu-org/mom-example.git. For non-interactive payu clone, 
-the repository URL must use the base ``<org>/<repo>`` format. Branch names  
+for example, https://github.com/payu-org/mom-example.git. Branch names  
 in the repository URL (e.g., https://github.com/payu-org/mom-example/tree/master) are 
-supported only in interactive payu clone (see below).
+supported, but only in interactive payu clone (see below). For non-interactive payu clone, 
+the repository URL must use the base ``<org>/<repo>`` format.
 
 To clone and checkout an existing git branch, use the ``-B/--branch`` flag and
 specify the branch name::

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -12,6 +12,7 @@ import warnings
 from pathlib import Path
 from typing import Optional
 import shutil
+import urllib
 
 from ruamel.yaml import YAML, CommentedMap, constructor
 import git
@@ -255,6 +256,29 @@ def switch_symlink(lab_dir_path: Path, control_path: Path,
         sym_path.symlink_to(dir_path)
         print(f"Added {sym_dir} symlink to {dir_path}")
 
+def validate_repo_url(repository: str) -> None:
+    """Validate the repository URL or path.
+
+    Parameters:
+        repository: str
+            Git URL or path to Git repository to validate
+    """
+    split_url = urllib.parse.urlsplit(repository)
+    if split_url.netloc != 'github.com':
+        return # Not a GitHub URL, skip validation
+
+    # Check if the URL is /<org>/<repo> format
+    path = split_url.path
+    parts = path.strip("/").split("/")
+    if len(parts) != 2:
+        raise errors.PayuBranchError(
+            f"Malformed GitHub repository URL: {repository}.\n"
+            "Expected one of the following formats:\n"
+            "   https://github.com/<org>/<repo>,\n"
+            "   https://github.com/<org>/<repo>/tree/<branch> (clone wizard only).\n"
+            "Please check the URL and try again."
+        )
+
 
 def clone(repository: str,
           directory: Path,
@@ -324,6 +348,7 @@ def clone(repository: str,
         )
 
     # git clone the repository
+    validate_repo_url(repository)
     repo = git_clone(repository, control_path, branch)
 
     if restart_path:
@@ -370,13 +395,14 @@ def clone(repository: str,
 
     except (errors.PayuBranchError, errors.PayuFileNotFoundError) as e:
         # Remove directory if incomplete checkout
-        shutil.rmtree(control_path)
+        shutil.rmtree(control_path, ignore_errors=True)
         msg = (
-            "Incomplete checkout. To run payu clone again, modify/remove "
-            "the checkout new branch flag: --new-branch/-b, or "
-            "checkout existing branch flag: --branch/-B "
-            f"\n  Checkout error: {e}\n"
-            "For more infomation on payu clone, run `payu clone --help`"
+            f"Incomplete checkout. Checkout error: {e}\n"
+            "Please try one of the following:\n"
+            "    Choose a source branch with a valid payu configuration file, \n"
+            "    Use --branch/-B to checkout an existing branch, \n"
+            "    Modify or remove the new branch flag: --new-branch/-b, \n"
+            "For more information on payu clone, please run `payu clone --help`"
         )
         raise errors.PayuBranchError(msg)
     finally:

--- a/payu/subcommands/clone_cmd.py
+++ b/payu/subcommands/clone_cmd.py
@@ -246,6 +246,7 @@ def fetch_branches(url):
 def fetch_tags(url):
     """Fetch all tags from the remote repository."""
     try:
+        validate_repo_url(url)
         result = subprocess.run(
             ["git", "ls-remote", "--tags", url],
             stdout=subprocess.PIPE,

--- a/payu/subcommands/clone_cmd.py
+++ b/payu/subcommands/clone_cmd.py
@@ -97,7 +97,7 @@ def runcmd(model_type, config_path, lab_path, keep_uuid,
         qprint("Press 'Ctrl+C' at any time to exit.")
         qprint("Enter '?' during any prompt to view the flowchart.")
         qprint("-"*dash_length)
-        user_params = prompts_for_clone(repository, local_directory, dash_length)
+        user_params = prompts_for_clone(dash_length)
         repository = user_params.get('repository')
         local_directory = user_params.get('local_directory')
         branch = user_params.get('branch')
@@ -129,26 +129,33 @@ def runcmd(model_type, config_path, lab_path, keep_uuid,
 
 runscript = runcmd
 
-def prompts_for_clone(repository, local_directory, dash_length=50):
+def prompts_for_clone(dash_length=50, start_point=None):
     """Prompt the user for input to guide the cloning process."""
     cli_command = "payu clone"
     # Source selection
     repository = ask_for_repo_url()
 
-    branch_or_tag = select_branch_or_tag()
-    if branch_or_tag == "An existing branch":
-        branches = fetch_branches(repository)
-        branch = ask_for_branch_name(branches)
-        start_point = None
+    # Check if branch is specified in repo url
+    repository, branch = check_branch_in_url(repository)
+    if branch:
+        # If branch is specified in the repo url
         cli_command += f" -B {branch}"
 
     else:
-        qprint("You chose to clone from a tag or commit.")
-        qprint("Payu will create a new experiment UUID and new branch for this clone.")
-        all_tags = fetch_tags(repository)
-        start_point = ask_for_tag_or_commit(all_tags)
-        branch = None
-        cli_command += f" -s {start_point}"
+        # Ask if user want to clone based on an existing branch or a tag/commit
+        branch_or_tag = select_branch_or_tag()
+
+        if branch_or_tag == "An existing branch":
+            branches = fetch_branches(repository)
+            branch = ask_for_branch_name(branches)
+            cli_command += f" -B {branch}"
+
+        else:
+            qprint("You chose to clone from a tag or commit.")
+            qprint("Payu will create a new experiment UUID and new branch for this clone.")
+            all_tags = fetch_tags(repository)
+            start_point = ask_for_tag_or_commit(all_tags)
+            cli_command += f" -s {start_point}"
 
     # Local directory and experiment setup
     local_directory = ask_for_local_directory()
@@ -200,6 +207,21 @@ def prompts_for_clone(repository, local_directory, dash_length=50):
         'keep_uuid': not is_new_expt,
         'short_path': short_path,
     }
+
+def check_branch_in_url(repository):
+    """Check if a branch is specified in the repository URL."""
+    split_pattern = '/tree/'
+    # Check if branch is specified in the url
+    if split_pattern not in repository:
+        return repository, None
+
+    repo_url, branch = repository.split(split_pattern)
+    # Validate the repository URL
+    if branch in fetch_branches(repo_url):
+        qprint(f'Found branch "{branch}" specified in the URL. Cloning from this branch.')
+        return repo_url, branch
+    else:
+        raise errors.PayuBranchError(f'Branch "{branch}" not found in repository {repo_url}.')
 
 def fetch_branches(url):
     """Fetch all branches from the remote repository."""

--- a/payu/subcommands/clone_cmd.py
+++ b/payu/subcommands/clone_cmd.py
@@ -14,7 +14,7 @@ import os
 from prompt_toolkit.completion import PathCompleter
 from importlib.resources import files
 
-from payu.branch import clone
+from payu.branch import clone, validate_repo_url
 import payu.subcommands.args as args
 import payu.errors as errors
 
@@ -135,8 +135,8 @@ def prompts_for_clone(dash_length=50, start_point=None):
     # Source selection
     repository = ask_for_repo_url()
 
-    # Check if branch is specified in repo url
-    repository, branch = check_branch_in_url(repository)
+    # Check if /tree/<branch> is specified in repo url
+    repository, branch = check_tree_in_url(repository)
     if branch:
         # If branch is specified in the repo url
         cli_command += f" -B {branch}"
@@ -208,7 +208,7 @@ def prompts_for_clone(dash_length=50, start_point=None):
         'short_path': short_path,
     }
 
-def check_branch_in_url(repository):
+def check_tree_in_url(repository):
     """Check if a branch is specified in the repository URL."""
     split_pattern = '/tree/'
     # Check if branch is specified in the url
@@ -226,6 +226,7 @@ def check_branch_in_url(repository):
 def fetch_branches(url):
     """Fetch all branches from the remote repository."""
     try:
+        validate_repo_url(url)
         result = subprocess.run(
             ["git", "ls-remote", "--heads", url],
             stdout=subprocess.PIPE,
@@ -236,7 +237,11 @@ def fetch_branches(url):
         branches = [line.split('\t')[1].replace("refs/heads/", "") for line in result.stdout.splitlines()]
         return branches
     except subprocess.CalledProcessError as e:
-        raise errors.PayuBranchError(f'Error fetching branches: {e}') from e
+        raise errors.PayuBranchError(f'Error fetching branches: '
+                                     f'{e.returncode}'
+                                     f'{e.stdout}'
+                                     f'{e.stderr}'
+                                     ) from e
 
 def fetch_tags(url):
     """Fetch all tags from the remote repository."""

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -1012,7 +1012,7 @@ def test_prompts_for_clone_from_branch_not_new_experiment(monkeypatch):
     monkeypatch.setattr(clone_cmd, "ask_for_restart_path", lambda: tmpdir / "restart_path")
     monkeypatch.setattr(clone_cmd, "confirm_shortpath", lambda: False)
     
-    result = clone_cmd.prompts_for_clone(None, None)
+    result = clone_cmd.prompts_for_clone()
     assert result['repository'] == "https://test_repo.git"
     assert result['branch'] == "master"
     assert result['local_directory'] == "new_expt_local_dir"
@@ -1038,7 +1038,7 @@ def test_prompts_for_clone_from_branch_new_experiment(monkeypatch):
     monkeypatch.setattr(clone_cmd, "confirm_shortpath", lambda: True)
     monkeypatch.setattr(clone_cmd, "ask_for_new_shortpath", lambda: "/scratch/shortpath")
 
-    result = clone_cmd.prompts_for_clone(None, None)
+    result = clone_cmd.prompts_for_clone()
     assert result['repository'] == "https://test_repo.git"
     assert result['branch'] == "master"
     assert result['local_directory'] == "new_expt_local_dir"
@@ -1063,7 +1063,7 @@ def test_prompts_for_clone_from_tag_with_restart(monkeypatch):
     monkeypatch.setattr(clone_cmd, "ask_for_restart_path", lambda: tmpdir / "restart_path")
     monkeypatch.setattr(clone_cmd, "confirm_shortpath", lambda: False)
 
-    result = clone_cmd.prompts_for_clone(None, None)
+    result = clone_cmd.prompts_for_clone()
     assert result['repository'] == "https://test_repo.git"
     assert result['branch'] == None
     assert result['start_point'] == "v1.0"
@@ -1072,3 +1072,21 @@ def test_prompts_for_clone_from_tag_with_restart(monkeypatch):
     assert result['new_branch_name'] == "new_branch"
     assert result['keep_uuid'] is False
     assert result['short_path'] == None
+
+
+def test_check_branch_in_url(monkeypatch):
+    """ Test check_branch_in_url correctly checks if a branch name is included in a URL"""
+    base_url = "https://github.com/repository.git"
+    monkeypatch.setattr(clone_cmd, "fetch_branches", lambda repository: ["master", "branch1"])
+
+    repo_url, branch = clone_cmd.check_branch_in_url(base_url)
+    assert repo_url == base_url
+    assert branch is None
+
+    repo_url, branch = clone_cmd.check_branch_in_url(base_url+"/tree/branch1")
+    assert repo_url == base_url
+    assert branch == "branch1"
+
+    with pytest.raises(errors.PayuBranchError, match=f'Branch "new_branch" not found in repository {base_url}'):
+        clone_cmd.check_branch_in_url(base_url+"/tree/new_branch")
+

--- a/test/test_branch.py
+++ b/test/test_branch.py
@@ -1074,19 +1074,19 @@ def test_prompts_for_clone_from_tag_with_restart(monkeypatch):
     assert result['short_path'] == None
 
 
-def test_check_branch_in_url(monkeypatch):
-    """ Test check_branch_in_url correctly checks if a branch name is included in a URL"""
+def test_check_tree_in_url(monkeypatch):
+    """ Test check_tree_in_url correctly checks if a branch name is included in a URL"""
     base_url = "https://github.com/repository.git"
     monkeypatch.setattr(clone_cmd, "fetch_branches", lambda repository: ["master", "branch1"])
 
-    repo_url, branch = clone_cmd.check_branch_in_url(base_url)
+    repo_url, branch = clone_cmd.check_tree_in_url(base_url)
     assert repo_url == base_url
     assert branch is None
 
-    repo_url, branch = clone_cmd.check_branch_in_url(base_url+"/tree/branch1")
+    repo_url, branch = clone_cmd.check_tree_in_url(base_url+"/tree/branch1")
     assert repo_url == base_url
     assert branch == "branch1"
 
     with pytest.raises(errors.PayuBranchError, match=f'Branch "new_branch" not found in repository {base_url}'):
-        clone_cmd.check_branch_in_url(base_url+"/tree/new_branch")
+        clone_cmd.check_tree_in_url(base_url+"/tree/new_branch")
 


### PR DESCRIPTION
In payu clone interactive mode, when a branch is specified in the provided URL, Payu will:
- Extract the branch name from the URL (by splitting `/tree/`)
- Validate that the branch exists in the repository.
- Clone directly from the specified branch.
- Skip the branch_or_commit prompt.
- Skip the enter_branch_name prompt.

Closes #837 
