### PR TITLE
Add shortpath before the checkout_branch

### DIFF
--- a/payu/branch.py
+++ b/payu/branch.py
@@ -360,6 +360,11 @@ def clone(repository: str,
         # cd into cloned directory
         os.chdir(control_path)
 
+        if short_path:
+            # Update shortpath in config file
+            config_path = check_config_path(config_path)
+            add_new_key_to_config('shortpath', short_path, config_path=config_path)
+
         # Use checkout wrapper
         if new_branch_name is not None:
             # Create and checkout new branch
@@ -388,10 +393,6 @@ def clone(repository: str,
                             is_new_experiment=True,
                             parent_experiment=parent_experiment)
     
-        if short_path:
-            # Update shortpath in config file
-            config_path = check_config_path(config_path)
-            add_new_key_to_config('shortpath', short_path, config_path=config_path)
 
     except (errors.PayuBranchError, errors.PayuFileNotFoundError) as e:
         # Remove directory if incomplete checkout

--- a/payu/branch.py
+++ b/payu/branch.py
@@ -142,6 +142,7 @@ def checkout_branch(branch_name: str,
                     control_path: Optional[Path] = None,
                     model_type: Optional[str] = None,
                     lab_path: Optional[Path] = None,
+                    short_path: Optional[Path] = None,
                     parent_experiment: Optional[str] = None) -> None:
     """Checkout branch, setup metadata and add symlinks
 
@@ -202,6 +203,10 @@ def checkout_branch(branch_name: str,
 
     # Check config file exists on checked out branch
     config_path = check_config_path(config_path)
+
+    # Add shortpath to config if specified
+    if short_path:
+        add_new_key_to_config('shortpath', short_path, config_path=config_path)
 
     # Initialise Lab
     lab = Laboratory(model_type, config_path, lab_path)
@@ -360,11 +365,6 @@ def clone(repository: str,
         # cd into cloned directory
         os.chdir(control_path)
 
-        if short_path:
-            # Update shortpath in config file
-            config_path = check_config_path(config_path)
-            add_new_key_to_config('shortpath', short_path, config_path=config_path)
-
         # Use checkout wrapper
         if new_branch_name is not None:
             # Create and checkout new branch
@@ -376,6 +376,7 @@ def clone(repository: str,
                             control_path=control_path,
                             model_type=model_type,
                             lab_path=lab_path,
+                            short_path=short_path,
                             parent_experiment=parent_experiment,
                             start_point=start_point)
         else:
@@ -390,6 +391,7 @@ def clone(repository: str,
                             control_path=control_path,
                             model_type=model_type,
                             lab_path=lab_path,
+                            short_path=short_path,
                             is_new_experiment=True,
                             parent_experiment=parent_experiment)
     

--- a/payu/git_utils.py
+++ b/payu/git_utils.py
@@ -223,7 +223,7 @@ class GitRepository:
                         start_point in remote_branches):
                     # Use hash for remote start point
                     start_point = remote_branches[start_point].commit
-                branch = self.repo.create_head(branch_name, commit=start_point)
+                branch = self.repo.create_head(branch_name, commit=self.repo.commit(start_point))
             else:
                 branch = self.repo.create_head(branch_name)
 


### PR DESCRIPTION
This PR adds the shortpath to config.yaml before checking out branch in payu clone. With this, payu clone will create the new archive directory in the designated shortpath project, instead of the default project.
Example payu clone output:
```
============================================================
Running command:
    payu clone -B release-1deg_jra55_iaf -b expt --shortpath /scratch/vk83/ https://github.com/ACCESS-NRI/access-om2-configs.git dddd
Cloned repository from https://github.com/ACCESS-NRI/access-om2-configs.git to directory: /home/189/qc4677/tmp/dddd
Added 'shortpath: /scratch/vk83' to configuration file: config.yaml
Created and checked out new branch: dddx
laboratory path:  /scratch/vk83/qc4677/access-om2
binary path:  /scratch/vk83/qc4677/access-om2/bin
input path:  /scratch/vk83/qc4677/access-om2/input
work path:  /scratch/vk83/qc4677/access-om2/work
archive path:  /scratch/vk83/qc4677/access-om2/archive
Generated new experiment uuid:  068c3c50-8279-4dd5-87a2-901c52198b0c
No prior restart path provided. Skip adding parent branch time to metadata.
Updated metadata. Experiment UUID: 068c3c50-8279-4dd5-87a2-901c52198b0c
Creating archive directory: /scratch/vk83/qc4677/access-om2/archive/dddd-dddx-068c3c50
Added archive symlink to /scratch/vk83/qc4677/access-om2/archive/dddd-dddx-068c3c50
To change directory to control directory run:
  cd dddd
```
Closes #842.