### PR TITLE
Update `experiment_prefix` and `manifest: reproduce` in documentation.

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -265,19 +265,18 @@ section for details.
 
 ``reproduce``
       These options allow fine-grained control of manifest checking to enable
-      reproducible experiments. The default value is the value of the global
-      ``reproduce`` flag, which is set using a command line argument and
-      defaults to *False*. These options **override** the global ``reproduce``
-      flag. If set to *True* payu will refuse to run if the MD5 hashes in the
-      relevant manifest do not match.
+      reproducible experiments. By default, all options are *False*. They are 
+      **overriden** by the global ``reproduce (True/False)`` flag (see :ref:`running-experiment`). 
+      If an option is set to *True*, payu will refuse to run if the MD5 hashes in the relevant 
+      manifest do not match.
 
-      ``exe`` (*Default: global reproduce flag*)
+      ``exe`` (*Default: False*)
             Enforce executable reproducibility.
 
-      ``input`` (*Default: global reproduce flag*)
+      ``input`` (*Default: False*)
             Enforce input file reproducibility.
 
-      ``restart`` (*Default: global reproduce flag*)
+      ``restart`` (*Default: False*)
             Enforce restart file reproducibility.
 
 ``ignore`` (*Default:* ``[.*]``):

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -253,8 +253,9 @@ configuration.
    (see :ref:`experiment_names`).
 
 ``experiment_prefix``
-   The prefix to used when generating an experiment name, if ``experiment`` is not set.
-   The experiment name will be generated as ``<experiment_prefix>-<branch_name>-<UUID>``.
+   The prefix to use when generating an experiment name, if ``experiment`` is not set.
+   This overrides the default of using the control directory name (see :ref:`experiment_names`).
+   The experiment name is generated as ``<experiment_prefix>-<branch_name>-<UUID>``.
 
 Manifests
 ---------

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -250,7 +250,11 @@ configuration.
 ``experiment``
    The experiment name used for archival. This will override the experiment
    name generated using metadata and existing archives 
-   (see :ref:`usage-metadata`).
+   (see :ref:`experiment_names`).
+
+``experiment_prefix``
+   The prefix to used when generating an experiment name, if ``experiment`` is not set.
+   The experiment name will be generated as ``<experiment_prefix>-<branch_name>-<UUID>``.
 
 Manifests
 ---------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -530,6 +530,7 @@ Some common metadata fields are shown in the table below, with their definitions
 
 .. _schema: https://github.com/ACCESS-NRI/schema/blob/main/experiment_asset.json
 
+.. _experiment_names:
 Experiment names
 ----------------
 
@@ -557,6 +558,9 @@ To preserve backwards compatibility, if there's a pre-existing archive under
 the *control directory* name, this will remain the experiment name (e.g. 
 ``my_expt`` in the above example). Similarly, if the ``experiment`` value is
 configured (see :ref:`config`), this will be used for the experiment name.
+Alternatively, if ``experiment`` is not set but ``experiment_prefix`` is set, 
+payu uses the prefix instead of the control directory name to generate the experiment name 
+(i.e., ``<experiment_prefix>-<branch_name>-<UUID>``).
 
 Switching between related experiments
 -------------------------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -203,7 +203,7 @@ created manually:
 .. _git: https://git-scm.com
    
 
-
+.. _running-experiment:
 Running your experiment
 =======================
 


### PR DESCRIPTION
This PR updates the documentation to include `experiment_prefix` and update the `manifest: reproduce` in config.rst. 
Ref #746 