### PR TITLE
Update schema version to 1-0-4

### DIFF
--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -42,7 +42,7 @@ PARENT_HASH_FIELD = "parent_experiment_branch_commit"
 
 # Metadata Schema
 SCHEMA_FIELD = "schema_version"
-SCHEMA_VERSION = "1-0-3"
+SCHEMA_VERSION = "1-0-4"
 SCHEMA_COMMIT_HASH = "cff183437134592723b09af6620e5cb190abeb22" 
 SCHEMA_URL = f"https://raw.githubusercontent.com/ACCESS-NRI/schema/{SCHEMA_COMMIT_HASH}/au.org.access-nri/model/output/experiment-metadata/{SCHEMA_VERSION}.json"
 placeholder_text = "__REPLACE_ME__"
@@ -477,7 +477,7 @@ def add_template_metadata_values(metadata: CommentedMap) -> None:
             description = value.get('description', None)
             if description is not None:
                 if key == SCHEMA_FIELD:
-                    # Set the schema to 1-0-3
+                    # Set the schema to 1-0-4
                     metadata[key] = SCHEMA_VERSION
                     anchor_key = key
                     anchor_description = description

--- a/test/resources/metadata_example.yaml
+++ b/test/resources/metadata_example.yaml
@@ -22,7 +22,7 @@ keywords:
 - global
 - access-esm1.6
 # All full-line comments should be removed
-schema_version: 1-0-3
+schema_version: 1-0-4
 reference: https://doi.org/10.5281/zenodo.17490072 # In line comments should be reserved
 
 # Customised header comment should be removed

--- a/test/resources/metadata_example_arranged.yaml
+++ b/test/resources/metadata_example_arranged.yaml
@@ -10,7 +10,7 @@ created: '2026-07-02'
 url: url
 model: MOM6
 parent_experiment: 4d052f54-ddc0-4cb6-9fbb-c89054462d72
-schema_version: 1-0-3
+schema_version: 1-0-4
 
 # ---- User feel free to update. ----
 description: |-
@@ -30,3 +30,4 @@ license: CC-BY-4.0
 version: '1.0'
 long_description: __REPLACE_ME__  # Long description of the experiment (string)
 # realm: The realm(s) included in the experiment (array of strings)
+# parent_experiment_branch_time: The model time corresponding to the restart path used to create this branch, e.g., 1951-02-01T00:00:00 (string)

--- a/test/resources/metadata_unchange.yaml
+++ b/test/resources/metadata_unchange.yaml
@@ -9,7 +9,7 @@ email: email
 created: '2026-07-02'
 url: url
 model: MOM6
-schema_version: 1-0-3
+schema_version: 1-0-4
 
 # ---- User feel free to update. ----
 description: |-

--- a/test/resources/mock_schema.yaml
+++ b/test/resources/mock_schema.yaml
@@ -3,7 +3,7 @@
   "type": "object",
   "properties": {
       "schema_version": {
-          "const": "1-0-3",
+          "const": "1-0-4",
           "description": "The version of the schema (string)"
       },
       "name": {
@@ -51,6 +51,11 @@
           },
           "description": "The realm(s) included in the experiment (array of strings)"
       },
+      "parent_experiment_branch_time": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "The model time corresponding to the restart path used to create this branch, e.g., 1951-02-01T00:00:00 (string)"
+        },
   },
   "required": [
       "name",

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -499,6 +499,7 @@ model: TEST-MODEL
 description: {placeholder_text}  # Short description of the experiment (string, < 150 char)
 long_description: {placeholder_text} # Long description of the experiment (string)
 # realm: The realm(s) included in the experiment (array of strings)
+# parent_experiment_branch_time: The model time corresponding to the restart path used to create this branch, e.g., 1951-02-01T00:00:00 (string)
 """
     assert (ctrldir / 'metadata.yaml').read_text() == expected_metadata
 


### PR DESCRIPTION
This PR increments the metadata schema version to 1-0-4. This PR also updates the unit tests to include the parent branch time.
Closes #846 