### PR TITLE
Check for pre-existing restarts if repeat is True.

### DIFF
--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -128,10 +128,6 @@ class Experiment(object):
 
         self.set_output_paths()
 
-        # If repeat is True, check for pre-existing restarts
-        if self.repeat:
-            self.check_restart_exists()
-
         if parent_info is None:
             parent_info = {}
 
@@ -443,6 +439,15 @@ class Experiment(object):
         # Prior restart path
         # Check if there are any restart directories in archive
         no_restarts = self.max_output_index(output_type="restart") is None
+
+        # If repeat is True, check for pre-existing restarts 
+        if self.repeat and not no_restarts:
+            raise errors.PayuConfigError(
+                    f"Pre-existing restarts are found in the archive \'{self.archive_path}\'.\n"
+                    "A repeat run is expected to start from the initial conditions.\n"
+                    "Please remove all restart directories before a repeat run."
+                )
+
         # Check if a user restart directory is avaiable
         user_restart_dir = self.config.get('restart')
         if (no_restarts or self.repeat) and user_restart_dir:
@@ -473,24 +478,6 @@ class Experiment(object):
 
         for model in self.models:
             model.set_model_output_paths()
-
-    def check_restart_exists(self):
-        """Check if any restart directories already exist in the archive path. 
-        If so, raise an error to prevent removing previous restarts due to repeat: True."""
-        # Check if archive path exists
-        if not os.path.exists(self.archive_path):
-            return
-        
-        # Sorted list of restart directories in archive
-        restarts = list_sorted_archive_dirs(archive_path=self.archive_path,
-                                        dir_type='restart')
-        if len(restarts) > 0:
-            raise errors.PayuConfigError(
-                f"Pre-existing restarts are found in the archive \'{self.archive_path}\'.\n"
-                "A repeat run is expected to start from the initial conditions.\n"
-                "Please remove all restart directories before a repeat run."
-            )
-        return
 
     def check_payu_version(self):
         """Check current payu version is greater than minimum required

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -128,6 +128,10 @@ class Experiment(object):
 
         self.set_output_paths()
 
+        # If repeat is True, check for pre-existing restarts
+        if self.repeat:
+            self.check_restart_exists()
+
         if parent_info is None:
             parent_info = {}
 
@@ -470,6 +474,23 @@ class Experiment(object):
         for model in self.models:
             model.set_model_output_paths()
 
+    def check_restart_exists(self):
+        """Check if any restart directories already exist in the archive path. 
+        If so, raise an error to prevent removing previous restarts due to repeat: True."""
+        # Check if archive path exists
+        if not os.path.exists(self.archive_path):
+            return
+        
+        # Sorted list of restart directories in archive
+        restarts = list_sorted_archive_dirs(archive_path=self.archive_path,
+                                        dir_type='restart')
+        if len(restarts) > 0:
+            raise errors.PayuConfigError(
+                f"Pre-existing restarts are found in the archive \'{self.archive_path}\'.\n"
+                "A repeat run is expected to start from the initial conditions.\n"
+                "Please remove all restart directories before a repeat run."
+            )
+        return
 
     def check_payu_version(self):
         """Check current payu version is greater than minimum required

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -437,6 +437,31 @@ def test_repeat_flag_priority(monkeypatch, repeat_flag, repeat_env, repeat_confi
     expt = init_experiment(config, repeat=repeat_flag)
     assert expt.repeat == expected_repeat
 
+
+def test_check_restart_exists_repeat_true():
+    """Test that an error is raised if repeat is True and restarts exist in the archive."""
+    # Make an archive directory with a restart
+    make_expt_archive_dir(type='restart', index=9)
+
+    with pytest.raises(errors.PayuConfigError, match="Pre-existing restarts are found in the archive"):
+        init_experiment(config_orig, repeat=True)
+
+
+def test_check_restart_exists_repeat_false(monkeypatch):
+    """Test that no error is raised if repeat is False and restarts exist in the archive."""
+    # Make an archive directory with a restart
+    make_expt_archive_dir(type='restart', index=9)
+
+    # Set repeat:False in config.yaml
+    config = copy.deepcopy(config_orig)
+    config['repeat'] = False
+
+    # Remove environment variable PAYU_REPEAT
+    monkeypatch.delenv('PAYU_REPEAT', raising=False)
+
+    init_experiment(config)
+
+
 def test_set_prior_restart_path_no_restarts_in_archive():
     """Test that prior restart path is set to None if no restarts in archive."""
     expt = init_experiment(config_orig)


### PR DESCRIPTION
Previously, payu removes all existing restarts if `repeat: True`. Even though this is under the assumption that a repeat run always starts from initial condition, this behavior might be dangerous.

This PR adds a check on existing restarts when `repeat: True`, and raise an error if restarts exist.

Closes #845 