### PR TITLE
Fix handling of init_run=0 in collate workflow

### DIFF
--- a/payu/cli.py
+++ b/payu/cli.py
@@ -165,7 +165,8 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     # Set the run counters
     if init_run is not None:
         init_run = int(init_run)
-        assert init_run >= 0
+        if init_run < 0:
+            raise errors.PayuRuntimeError("Run number is negative.")
         payu_env_vars['PAYU_CURRENT_RUN'] = init_run
 
     if n_runs:

--- a/payu/cli.py
+++ b/payu/cli.py
@@ -163,7 +163,7 @@ def set_env_vars(init_run=None, n_runs=None, lab_path=None, dir_path=None,
     payu_env_vars['PAYU_PATH'] = payu_binpath
 
     # Set the run counters
-    if init_run:
+    if init_run is not None:
         init_run = int(init_run)
         assert init_run >= 0
         payu_env_vars['PAYU_CURRENT_RUN'] = init_run

--- a/payu/experiment.py
+++ b/payu/experiment.py
@@ -268,10 +268,7 @@ class Experiment(object):
         assert self.archive_path
 
         current_counter = os.environ.get('PAYU_CURRENT_RUN')
-        if current_counter:
-            self.counter = int(current_counter)
-        else:
-            self.counter = None
+        self.counter = int(current_counter) if current_counter is not None else None
 
         self.n_runs = int(os.environ.get('PAYU_N_RUNS', 1))
 

--- a/payu/subcommands/collate_cmd.py
+++ b/payu/subcommands/collate_cmd.py
@@ -114,7 +114,7 @@ def runcmd(model_type=None, config_path=None, init_run=None,
 
     # Submit the collation job and write queue job file
     job_id = cli.submit_job('payu-collate', pbs_config, pbs_vars, expt=expt, 
-                current_run = int(init_run) if init_run else None, type='collate', 
+                current_run = int(init_run) if init_run is not None else None, type='collate',
                 dry_run=dry_run, depends_on=depends_on)
     return job_id
     

--- a/payu/subcommands/postscript_cmd.py
+++ b/payu/subcommands/postscript_cmd.py
@@ -53,7 +53,7 @@ def runcmd(model_type=None, config_path=None, init_run=None, lab_path=None, dry_
                         config={"scheduler": expt.scheduler_name},
                         vars=expt.set_userscript_env_vars(),
                         expt=expt,
-                        current_run=int(init_run) if init_run else None,
+                        current_run=int(init_run) if init_run is not None else None,
                         type="postscript",
                         dry_run=dry_run,
                         depends_on=depends_on,

--- a/payu/subcommands/sync_cmd.py
+++ b/payu/subcommands/sync_cmd.py
@@ -84,7 +84,7 @@ def runcmd(model_type=None, config_path=None, init_run=None, lab_path=None, dir_
 
     # Submit PBS job with expt = None so no job file is written
     job_id = cli.submit_job('payu-sync', pbs_config, pbs_vars, expt=expt, 
-                   current_run=int(init_run) if init_run else None, type='sync',
+                   current_run=int(init_run) if init_run is not None else None, type='sync',
                    dry_run=dry_run, depends_on=depends_on)
     return job_id
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -32,6 +32,19 @@ def parse_args(parser, cmd):
     log_level = args.pop("log_level")
     return run_cmd, args
 
+
+def test_set_env_vars_preserves_zero_init_run(monkeypatch):
+    monkeypatch.setattr(payu.cli, "is_conda", lambda: True)
+    env_vars = payu.cli.set_env_vars(init_run=0)
+    assert env_vars["PAYU_CURRENT_RUN"] == 0
+
+
+def test_set_env_vars_rejects_negative_init_run(monkeypatch):
+    monkeypatch.setattr(payu.cli, "is_conda", lambda: True)
+    with pytest.raises(errors.PayuRuntimeError, match="Run number is negative"):
+        payu.cli.set_env_vars(init_run=-1)
+
+
 def test_parse(parser):
 
     arguments = shlex.split("payu -h")
@@ -552,5 +565,3 @@ def test_submit_job_error_msg_from_hpcpy():
             payu.cli.submit_job(config={"scheduler": "pbs"}, script="submit_script.sh")
             assert "Error occurred while submitting a job to scheduler pbs" in str(exc_info.value)
             assert "Error: HPCpy submission failed" in str(exc_info.value)
-
-    

--- a/test/test_subcommands.py
+++ b/test/test_subcommands.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+import pytest
+from payu.subcommands import collate_cmd, postscript_cmd, sync_cmd
+
+
+@pytest.mark.parametrize(
+    "command_mod, config",
+    [
+        (collate_cmd, {"collate": {}}),
+        (postscript_cmd, {"postscript": "postscript.sh"}),
+        (sync_cmd, {"sync": {}}),
+    ],
+)
+def test_runcmd_preserves_zero_init_run(monkeypatch, command_mod, config):
+    experiment = MagicMock()
+    experiment.scheduler_name = "pbs"
+    experiment.set_userscript_env_vars.return_value = {}
+
+    monkeypatch.setattr(command_mod, "read_config", lambda _: config.copy())
+    monkeypatch.setattr(command_mod, "Laboratory", MagicMock())
+    monkeypatch.setattr(
+        command_mod,
+        "Experiment",
+        MagicMock(return_value=experiment),
+    )
+    monkeypatch.setattr(command_mod.cli, "set_env_vars", MagicMock(return_value={}))
+    submit_job = MagicMock(return_value="12")
+    monkeypatch.setattr(command_mod.cli, "submit_job", submit_job)
+
+    assert command_mod.runcmd(init_run=0) == "12"
+    assert submit_job.call_args.kwargs["current_run"] == 0

--- a/test/test_subcommands.py
+++ b/test/test_subcommands.py
@@ -24,8 +24,8 @@ def test_runcmd_preserves_zero_init_run(monkeypatch, command_mod, config):
         MagicMock(return_value=experiment),
     )
     monkeypatch.setattr(command_mod.cli, "set_env_vars", MagicMock(return_value={}))
-    submit_job = MagicMock(return_value="12")
+    submit_job = MagicMock(return_value="1000-gadi.pbs")
     monkeypatch.setattr(command_mod.cli, "submit_job", submit_job)
 
-    assert command_mod.runcmd(init_run=0) == "12"
+    assert command_mod.runcmd(init_run=0) == "1000-gadi.pbs"
     assert submit_job.call_args.kwargs["current_run"] == 0


### PR DESCRIPTION
closes #850 

Now this changes the checks to test against `None` preserving 0 as a valid run number.