### PR TITLE
Add validation of parent uuid and check against the designated restart.

### DIFF
--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -380,11 +380,11 @@ class Metadata:
         model_name = self.metadata_config.get('model', default_model_name)
         return model_name
 
-    def get_parent_experiment(self, prior_restart_path: Path) -> None:
+    def get_parent_experiment(self, prior_restart_path: Path) -> str:
         """Searches UUID in the metadata in the parent directory that
         contains the restart"""
         if prior_restart_path is None:
-            return
+            return None
 
         # Resolve to absolute path
         prior_restart_path = prior_restart_path.resolve()
@@ -396,7 +396,7 @@ class Metadata:
             # Check for metadata file in the archive of the restart directory
             metadata_filepath = Path(prior_restart_path).parent / METADATA_FILENAME
             if not metadata_filepath.exists():
-                return
+                return None
 
         # Read metadata file
         parent_metadata = YAML().load(metadata_filepath)
@@ -432,19 +432,31 @@ class Metadata:
         parent_branch_time = parent_info.get('parent_branch_time', None)
         parent_hash = parent_info.get('parent_hash', None)
 
-        # Update parent UUID field
-        # If parent uuid is None, get it from the restart path
-        parent_experiment_from_restart = parent_experiment is None
-        if parent_experiment_from_restart:
-            parent_experiment = self.get_parent_experiment(restart_path)
+        # Get the uuid from the restart path, could be None if not exists
+        restart_uuid = self.get_parent_experiment(restart_path)
 
-        if parent_experiment in (None, HARD_SWEPT_UUID, self.uuid):
-            # Remove parent_experiment entry if it is None/HARD_SWEPT_UUID/current_UUID
-            metadata.pop(PARENT_UUID_FIELD, None)
+        # Update parent UUID field
+        if parent_experiment is not None:
+            # Compare the parent_experiment UUID with the restart_uuid
+            if restart_uuid and restart_uuid != parent_experiment:
+                raise errors.PayuBranchError(
+                    f"The parent experiment UUID '{parent_experiment}' does not match "
+                    f"the UUID of the given restart directory '{restart_path}': '{restart_uuid}'. \n"
+                    f"Suggest fix: leave out the `-p` option to use the UUID of the restarts.")
         else:
-            # Validate the parent UUID before adding it to metadata
-            self.validate_parent_uuid(parent_experiment, restart_path, parent_experiment_from_restart)
+            # If parent_experiment is None, use restart_uuid
+            parent_experiment = restart_uuid
+
+        # Validate the parent_experiment UUID
+        if self.validate_parent_uuid(parent_experiment):
             metadata[PARENT_UUID_FIELD] = parent_experiment
+        else:
+            # Remove parent_experiment entry if it is 
+            # None/HARD_SWEPT_UUID/current_UUID/missing_text(from restart_metadata)
+            warnings.warn(
+                f"The parent experiment UUID '{parent_experiment}' is not informative.\n"
+                "Skipped adding it to the metadata file.")
+            metadata.pop(PARENT_UUID_FIELD, None)
 
         # Update parent branch time
         if restart_path and parent_branch_time:
@@ -465,13 +477,14 @@ class Metadata:
         return metadata
 
     def validate_parent_uuid(self, 
-                            parent_experiment: str, 
-                            restart_path: Path = None,
-                            parent_experiment_from_restart: bool = False) -> None:
+                            parent_experiment: str) -> bool:
         """Validate the parent experiment UUID.
-        The UUID must be a valid UUID4. 
-        If a restart path is provided and contains a UUID, the parent UUID must match it.
+        Return False if it is not None, HARD_SWEPT_UUID, current UUID, or missing_text.
+        The UUID must be a valid UUID4.
         """
+        if parent_experiment in (None, HARD_SWEPT_UUID, self.uuid, missing_text):
+            return False
+        
         # Check UUID4 format
         if not is_uuid4(parent_experiment):
             raise errors.PayuBranchError(
@@ -479,17 +492,7 @@ class Metadata:
                 "Please provide a valid UUID4 format for the parent experiment."
             )
 
-        # Skip further matching check if no restart or parent uuid reads from restart path
-        if restart_path is None or parent_experiment_from_restart:
-            return
-        
-        # If restart_path is provided, check if parent_experiment matches the UUID of the restart directory
-        restart_uuid = self.get_parent_experiment(restart_path)
-        if restart_uuid and restart_uuid != parent_experiment:
-            raise errors.PayuBranchError(
-                f"The parent experiment UUID '{parent_experiment}' does not match "
-                f"the UUID of the given restart directory '{restart_path}': '{restart_uuid}'. \n"
-                f"Suggest fix: leave out the `-p` option to use the UUID of the restarts.")
+        return True
 
 
     def write_restart_provenance(self, 

--- a/payu/metadata.py
+++ b/payu/metadata.py
@@ -389,11 +389,14 @@ class Metadata:
         # Resolve to absolute path
         prior_restart_path = prior_restart_path.resolve()
 
-        # Check for pre-existing metadata file
-        base_output_directory = Path(prior_restart_path).parent
-        metadata_filepath = base_output_directory / METADATA_FILENAME
+        # Check for restart_metadata.yaml in the restart directory
+        metadata_filepath = prior_restart_path / f"restart_{METADATA_FILENAME}"
+
         if not metadata_filepath.exists():
-            return
+            # Check for metadata file in the archive of the restart directory
+            metadata_filepath = Path(prior_restart_path).parent / METADATA_FILENAME
+            if not metadata_filepath.exists():
+                return
 
         # Read metadata file
         parent_metadata = YAML().load(metadata_filepath)
@@ -430,13 +433,18 @@ class Metadata:
         parent_hash = parent_info.get('parent_hash', None)
 
         # Update parent UUID field
-        if parent_experiment is None:
+        # If parent uuid is None, get it from the restart path
+        parent_experiment_from_restart = parent_experiment is None
+        if parent_experiment_from_restart:
             parent_experiment = self.get_parent_experiment(restart_path)
-        if parent_experiment and parent_experiment != self.uuid:
-            metadata[PARENT_UUID_FIELD] = parent_experiment
-        else:
-            # Remove parent_experiment if entry exists in metadata
+
+        if parent_experiment in (None, HARD_SWEPT_UUID, self.uuid):
+            # Remove parent_experiment entry if it is None/HARD_SWEPT_UUID/current_UUID
             metadata.pop(PARENT_UUID_FIELD, None)
+        else:
+            # Validate the parent UUID before adding it to metadata
+            self.validate_parent_uuid(parent_experiment, restart_path, parent_experiment_from_restart)
+            metadata[PARENT_UUID_FIELD] = parent_experiment
 
         # Update parent branch time
         if restart_path and parent_branch_time:
@@ -455,6 +463,34 @@ class Metadata:
             metadata.pop(PARENT_HASH_FIELD, None)
 
         return metadata
+
+    def validate_parent_uuid(self, 
+                            parent_experiment: str, 
+                            restart_path: Path = None,
+                            parent_experiment_from_restart: bool = False) -> None:
+        """Validate the parent experiment UUID.
+        The UUID must be a valid UUID4. 
+        If a restart path is provided and contains a UUID, the parent UUID must match it.
+        """
+        # Check UUID4 format
+        if not is_uuid4(parent_experiment):
+            raise errors.PayuBranchError(
+                f"The parent experiment UUID {parent_experiment} is not a valid UUID4 format.\n"
+                "Please provide a valid UUID4 format for the parent experiment."
+            )
+
+        # Skip further matching check if no restart or parent uuid reads from restart path
+        if restart_path is None or parent_experiment_from_restart:
+            return
+        
+        # If restart_path is provided, check if parent_experiment matches the UUID of the restart directory
+        restart_uuid = self.get_parent_experiment(restart_path)
+        if restart_uuid and restart_uuid != parent_experiment:
+            raise errors.PayuBranchError(
+                f"The parent experiment UUID '{parent_experiment}' does not match "
+                f"the UUID of the given restart directory '{restart_path}': '{restart_uuid}'. \n"
+                f"Suggest fix: leave out the `-p` option to use the UUID of the restarts.")
+
 
     def write_restart_provenance(self, 
                                 restart_path: Path, 
@@ -636,3 +672,10 @@ def add_restart_field(restart_metadata, field_name, value):
         restart_metadata[field_name] = value.strftime('%Y-%m-%dT%H:%M:%S')
     else:
         restart_metadata[field_name] = value
+
+def is_uuid4(value: str) -> bool:
+    """Check if a string is a valid UUID4"""
+    try:
+        return uuid.UUID(value).version == 4
+    except:
+        return False

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -128,6 +128,29 @@ def init_metadata():
         return metadata
     return _init_metadata
 
+@pytest.fixture()
+def set_up_restart_metadata():
+    """A fixture to set up a restart directory outside archive, with restart_metadata inside"""
+    restart_path = archive_dir / "restart000"
+    restart_path.mkdir(parents=True, exist_ok=True)
+    with open(restart_path / 'restart_metadata.yaml', 'w') as file:
+        YAML().dump({UUID_FIELD: RESTART_METADATA_UUID}, file)
+
+    yield
+
+    shutil.rmtree(restart_path)
+
+@pytest.fixture()
+def set_up_archive_metadata():
+    """ A fixture to set up metadata file in archive"""
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    with open(archive_dir / 'metadata.yaml', 'w') as file:
+        YAML().dump({UUID_FIELD: METADATA_UUID}, file)
+
+    yield
+
+    shutil.rmtree(archive_dir)
+
 @patch("payu.metadata.GitRepository")
 @pytest.mark.parametrize(
     "uuid, experiment_name, previous_metadata, expected_metadata",
@@ -759,19 +782,23 @@ def test_add_restart_field(value, expected_value):
 
 
 @pytest.mark.parametrize(
-    "parent_experiment, raise_error",
+    "parent_experiment, raise_error, expected_value",
     [
         # Test with a valid UUID4 format
-        (TEST_UUID, False),
+        (TEST_UUID, False, True),
         # Test with an invalid UUID format
-        ("mock_parent_uuid", True),
+        ("mock_parent_uuid", True, None),
         # Test with an hash-like string
-        ("b6962f8d005a75a4f1158e9a2cf53d1003e465d0", True),
+        ("b6962f8d005a75a4f1158e9a2cf53d1003e465d0", True, None),
         # Test with emtpy string
-        ("", True)
+        ("", True, None),
+        # Test with None
+        (None, False, False),
+        # Test with HARD_SWEPT_UUID
+        (HARD_SWEPT_UUID, False, False)
     ]
 )
-def test_validate_parent_uuid_format(init_metadata, parent_experiment, raise_error):
+def test_validate_parent_uuid_format(init_metadata, parent_experiment, raise_error, expected_value):
     """Test that validate_parent_uuid checks the uuid format"""
     # Initialise Metadata
     metadata = init_metadata()
@@ -779,16 +806,12 @@ def test_validate_parent_uuid_format(init_metadata, parent_experiment, raise_err
     if raise_error:
         with pytest.raises(errors.PayuBranchError, 
                            match=f"The parent experiment UUID {parent_experiment} is not a valid UUID4 format."):
-            metadata.validate_parent_uuid(parent_experiment=parent_experiment, 
-                                        restart_path=None, 
-                                        parent_experiment_from_restart=False)
+            metadata.validate_parent_uuid(parent_experiment=parent_experiment)
     else:
-        metadata.validate_parent_uuid(parent_experiment=parent_experiment, 
-                         restart_path=None,
-                         parent_experiment_from_restart=False)
+        assert metadata.validate_parent_uuid(parent_experiment=parent_experiment) == expected_value
 
 
-def test_validate_parent_uuid_against_metadata(init_metadata):
+def test_validate_parent_uuid_against_metadata(init_metadata, set_up_archive_metadata):
     """Test that validate_parent_uuid checks if parent_experiment matches with archive metadata"""
     # Initialise Metadata
     metadata = init_metadata()
@@ -797,55 +820,54 @@ def test_validate_parent_uuid_against_metadata(init_metadata):
     restart_path = archive_dir / "restart000"
     restart_path.mkdir(parents=True, exist_ok=True)
 
-    # parent uuid is required to match the metadata uuid
-    metadata.validate_parent_uuid(parent_experiment=METADATA_UUID, 
+    # parent uuid is required to match the archive metadata uuid
+    metadata.update_parent_info(metadata.read_file(), 
+                                parent_info={'parent_experiment': METADATA_UUID},
                                 restart_path=restart_path)
 
     # Error should be raised if parent_experiment and archive metadata don't match
     with pytest.raises(errors.PayuBranchError, 
                 match=f"The parent experiment UUID '{TEST_UUID}' does not match the UUID "
                     f"of the given restart directory '{restart_path}': '{METADATA_UUID}'."):
-        metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
-                                        restart_path=restart_path)
+        metadata.update_parent_info(metadata.read_file(), 
+                                parent_info={'parent_experiment': TEST_UUID},
+                                restart_path=restart_path)
     shutil.rmtree(restart_path)
 
 
-def test_validate_parent_uuid_against_metadata(init_metadata):
+def test_validate_parent_uuid_against_restart_metadata(init_metadata, set_up_restart_metadata, set_up_archive_metadata):
     """Test that validate_parent_uuid checks if parent_experiment matches with restart metadata"""
     # Initialise Metadata
     metadata = init_metadata()
-
-    # Setup a restart directory outside archive, with restart_metadata inside
     restart_path = archive_dir / "restart000"
-    restart_path.mkdir(parents=True, exist_ok=True)
-    with open(restart_path / 'restart_metadata.yaml', 'w') as file:
-        YAML().dump({UUID_FIELD: RESTART_METADATA_UUID}, file)
 
     # payu prioritise the restart_metadata.yaml over the archive metadata.yaml
-    metadata.validate_parent_uuid(parent_experiment=RESTART_METADATA_UUID, 
-                                  restart_path=restart_path)
+    metadata.update_parent_info(metadata.read_file(), 
+                                parent_info={'parent_experiment': RESTART_METADATA_UUID},
+                                restart_path=restart_path)
 
-    # Test with non-matching parent_experiment and restart_metadata
+    # Test error is raised when not matching
     with pytest.raises(errors.PayuBranchError, 
-                match=f"The parent experiment UUID '{TEST_UUID}' does not match the UUID "
+                match=f"The parent experiment UUID '{METADATA_UUID}' does not match the UUID "
                     f"of the given restart directory '{restart_path}': '{RESTART_METADATA_UUID}'."):
-        metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
-                                      restart_path=restart_path, 
-                                      parent_experiment_from_restart=False)
+        metadata.update_parent_info(metadata.read_file(), 
+                                parent_info={'parent_experiment': METADATA_UUID},
+                                restart_path=restart_path)
 
-    shutil.rmtree(restart_path)
 
 def test_validate_parent_uuid_no_restart_path_or_no_metadata(init_metadata):
     # Initialise Metadata
     metadata = init_metadata()
 
     # No restart is provided, should only validate the UUID4 format
-    metadata.validate_parent_uuid(parent_experiment=TEST_UUID)
+    data = metadata.update_parent_info(metadata.read_file(), 
+                                parent_info={'parent_experiment': TEST_UUID},
+                                restart_path=None)
+    assert data[PARENT_UUID_FIELD] == TEST_UUID
 
-    # parent_experiment_from_restart is True, should only validate the UUID4 format
-    metadata.get_parent_experiment = MagicMock()
-    metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
-                              restart_path=archive_dir / "restart000", 
-                              parent_experiment_from_restart=True)
-    metadata.get_parent_experiment.assert_not_called()
-    
+    # parent_experiment is set to HARD_SWEPT_UUID, should not be added to metadata
+    with pytest.warns(UserWarning, match=f"The parent experiment UUID '{HARD_SWEPT_UUID}' is not informative."):
+        data = metadata.update_parent_info(metadata.read_file(), 
+                                    parent_info={'parent_experiment': HARD_SWEPT_UUID},
+                                    restart_path=None)
+        assert PARENT_UUID_FIELD not in data

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -494,7 +494,7 @@ def test_update_file_with_template_metadata_values(init_metadata, mock_git_repo)
     # Expect commented template values for non-null fields
     expected_metadata = f"""
 # {DO_NOT_EDIT_COMMENT}
-{UUID_FIELD}: cb793e91-6168-4ed2-a70c-f6f9ccf1659
+{UUID_FIELD}: {METADATA_UUID}
 
 # {CAN_EDIT_COMMENT}
 name: ctrldir-branch-cb793e91
@@ -803,8 +803,8 @@ def test_validate_parent_uuid_against_metadata(init_metadata):
 
     # Error should be raised if parent_experiment and archive metadata don't match
     with pytest.raises(errors.PayuBranchError, 
-                match=f"The parent experiment UUID {TEST_UUID} does not match the UUID "
-                    f"of the given restart directory {restart_path}: {METADATA_UUID}."):
+                match=f"The parent experiment UUID '{TEST_UUID}' does not match the UUID "
+                    f"of the given restart directory '{restart_path}': '{METADATA_UUID}'."):
         metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
                                         restart_path=restart_path)
     shutil.rmtree(restart_path)
@@ -827,8 +827,8 @@ def test_validate_parent_uuid_against_metadata(init_metadata):
 
     # Test with non-matching parent_experiment and restart_metadata
     with pytest.raises(errors.PayuBranchError, 
-                match=f"The parent experiment UUID {TEST_UUID} does not match the UUID "
-                    f"of the given restart directory {restart_path}: {RESTART_METADATA_UUID}."):
+                match=f"The parent experiment UUID '{TEST_UUID}' does not match the UUID "
+                    f"of the given restart directory '{restart_path}': '{RESTART_METADATA_UUID}'."):
         metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
                                       restart_path=restart_path, 
                                       parent_experiment_from_restart=False)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -847,5 +847,5 @@ def test_validate_parent_uuid_no_restart_path_or_no_metadata(init_metadata):
     metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
                               restart_path=archive_dir / "restart000", 
                               parent_experiment_from_restart=True)
-    assert metadata.get_parent_experiment.not_called
+    metadata.get_parent_experiment.assert_not_called()
     

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import cftime
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import MagicMock, patch, Mock
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 import jsonschema
@@ -31,6 +31,10 @@ config.pop("metadata")
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore::payu.git_utils.PayuGitWarning")
+
+METADATA_UUID = "cb793e91-6168-4ed2-a70c-f6f9ccf19999"
+RESTART_METADATA_UUID = "0000b928-c6b6-482c-ae34-520000000c89"
+TEST_UUID = "3d18b3b6-dd19-49a9-8d9e-c7fa8582f136"
 
 
 def setup_module(module):
@@ -110,7 +114,7 @@ def mock_git_repo():
 def init_metadata():
     """Fixture to create an initial metadata file for testing"""
     def _init_metadata(experiment_name="ctrldir-branch-cb793e91",
-                       uuid="cb793e91-6168-4ed2-a70c-f6f9ccf1659"):
+                       uuid=METADATA_UUID):
         # Setup config
         test_config = config.copy()
         test_config['model'] = "test-model"
@@ -603,18 +607,18 @@ def test_update_file_given_metadata_file(tmp_path, metadata_input, metadata_expe
     [   
         # restart_path and branch_off_time provided - PARENT_BRANCH_TIME_FIELD should be updated
         (Path("/path/to/restart000/"), 
-        "parent_expt_uuid", "2026-07-24T12:00:00", "parent_hash_value",
-        "parent_expt_uuid", "2026-07-24T12:00:00", "parent_hash_value"),
+        TEST_UUID, "2026-07-24T12:00:00", "parent_hash_value",
+        TEST_UUID, "2026-07-24T12:00:00", "parent_hash_value"),
 
         # restart_path provided, but no branch_off_time - should not have PARENT_BRANCH_TIME_FIELD
         (Path("/path/to/restart000/"), 
-        "parent_expt_uuid", None, "parent_hash_value",
-        "parent_expt_uuid", None, "parent_hash_value"),
+        TEST_UUID, None, "parent_hash_value",
+        TEST_UUID, None, "parent_hash_value"),
         
         # branch_off_time alone, without a restart_path, should not have PARENT_BRANCH_TIME_FIELD
         (None, 
-        "parent_expt_uuid", "2026-07-24T12:00:00", "parent_hash_value",
-        "parent_expt_uuid", None, "parent_hash_value"),
+        TEST_UUID, "2026-07-24T12:00:00", "parent_hash_value",
+        TEST_UUID, None, "parent_hash_value"),
 
         # No parent_experiment or restart path given - should not have any parent_info fields
         (None, 
@@ -687,7 +691,7 @@ def test_wipe_uuid():
     "parent_info",
     [
         # Test with parent info provided
-        {"parent_experiment": "mock_parent_expt_uuid"},
+        {"parent_experiment": TEST_UUID},
         # Test without parent info
         {}
     ]
@@ -752,3 +756,96 @@ def test_add_restart_field(value, expected_value):
 
     add_restart_field(restart_metadata, field_name, value)
     assert restart_metadata[field_name] == expected_value
+
+
+@pytest.mark.parametrize(
+    "parent_experiment, raise_error",
+    [
+        # Test with a valid UUID4 format
+        (TEST_UUID, False),
+        # Test with an invalid UUID format
+        ("mock_parent_uuid", True),
+        # Test with an hash-like string
+        ("b6962f8d005a75a4f1158e9a2cf53d1003e465d0", True),
+        # Test with emtpy string
+        ("", True)
+    ]
+)
+def test_validate_parent_uuid_format(init_metadata, parent_experiment, raise_error):
+    """Test that validate_parent_uuid checks the uuid format"""
+    # Initialise Metadata
+    metadata = init_metadata()
+
+    if raise_error:
+        with pytest.raises(errors.PayuBranchError, 
+                           match=f"The parent experiment UUID {parent_experiment} is not a valid UUID4 format."):
+            metadata.validate_parent_uuid(parent_experiment=parent_experiment, 
+                                        restart_path=None, 
+                                        parent_experiment_from_restart=False)
+    else:
+        metadata.validate_parent_uuid(parent_experiment=parent_experiment, 
+                         restart_path=None,
+                         parent_experiment_from_restart=False)
+
+
+def test_validate_parent_uuid_against_metadata(init_metadata):
+    """Test that validate_parent_uuid checks if parent_experiment matches with archive metadata"""
+    # Initialise Metadata
+    metadata = init_metadata()
+
+    # Setup restart in archive
+    restart_path = archive_dir / "restart000"
+    restart_path.mkdir(parents=True, exist_ok=True)
+
+    # parent uuid is required to match the metadata uuid
+    metadata.validate_parent_uuid(parent_experiment=METADATA_UUID, 
+                                restart_path=restart_path)
+
+    # Error should be raised if parent_experiment and archive metadata don't match
+    with pytest.raises(errors.PayuBranchError, 
+                match=f"The parent experiment UUID {TEST_UUID} does not match the UUID "
+                    f"of the given restart directory {restart_path}: {METADATA_UUID}."):
+        metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
+                                        restart_path=restart_path)
+    shutil.rmtree(restart_path)
+
+
+def test_validate_parent_uuid_against_metadata(init_metadata):
+    """Test that validate_parent_uuid checks if parent_experiment matches with restart metadata"""
+    # Initialise Metadata
+    metadata = init_metadata()
+
+    # Setup a restart directory outside archive, with restart_metadata inside
+    restart_path = archive_dir / "restart000"
+    restart_path.mkdir(parents=True, exist_ok=True)
+    with open(restart_path / 'restart_metadata.yaml', 'w') as file:
+        YAML().dump({UUID_FIELD: RESTART_METADATA_UUID}, file)
+
+    # payu prioritise the restart_metadata.yaml over the archive metadata.yaml
+    metadata.validate_parent_uuid(parent_experiment=RESTART_METADATA_UUID, 
+                                  restart_path=restart_path)
+
+    # Test with non-matching parent_experiment and restart_metadata
+    with pytest.raises(errors.PayuBranchError, 
+                match=f"The parent experiment UUID {TEST_UUID} does not match the UUID "
+                    f"of the given restart directory {restart_path}: {RESTART_METADATA_UUID}."):
+        metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
+                                      restart_path=restart_path, 
+                                      parent_experiment_from_restart=False)
+
+    shutil.rmtree(restart_path)
+
+def test_validate_parent_uuid_no_restart_path_or_no_metadata(init_metadata):
+    # Initialise Metadata
+    metadata = init_metadata()
+
+    # No restart is provided, should only validate the UUID4 format
+    metadata.validate_parent_uuid(parent_experiment=TEST_UUID)
+
+    # parent_experiment_from_restart is True, should only validate the UUID4 format
+    metadata.get_parent_experiment = MagicMock()
+    metadata.validate_parent_uuid(parent_experiment=TEST_UUID, 
+                              restart_path=archive_dir / "restart000", 
+                              parent_experiment_from_restart=True)
+    assert metadata.get_parent_experiment.not_called
+    

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -138,7 +138,7 @@ def set_up_restart_metadata():
 
     yield
 
-    shutil.rmtree(restart_path)
+    shutil.rmtree(restart_path, ignore_errors=True)
 
 @pytest.fixture()
 def set_up_archive_metadata():
@@ -149,7 +149,7 @@ def set_up_archive_metadata():
 
     yield
 
-    shutil.rmtree(archive_dir)
+    shutil.rmtree(archive_dir, ignore_errors=True)
 
 @patch("payu.metadata.GitRepository")
 @pytest.mark.parametrize(

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -795,7 +795,9 @@ def test_add_restart_field(value, expected_value):
         # Test with None
         (None, False, False),
         # Test with HARD_SWEPT_UUID
-        (HARD_SWEPT_UUID, False, False)
+        (HARD_SWEPT_UUID, False, False),
+        # Test with missing_text UUID
+        (missing_text, False, False)
     ]
 )
 def test_validate_parent_uuid_format(init_metadata, parent_experiment, raise_error, expected_value):


### PR DESCRIPTION
This PR adds validation of parent experiment uuid before adding it to metadata.
1. Validate it is in UUID4 format. Raise an error if not.
2. Validate that the user-provided parent experiment UUID (`-p` flag) matches the UUID recorded in the restart metadata:
    - read `experiment_uuid` from `restart_metadata.yaml` if it exists.
    - Otherwise, check `metadata.yaml` in the parent directory of the restart (assuming the restart is still in the archive).
3. For UUID_SWEPT_BY_HARD_SWEEP, skip adding to metadata.

Closes #782 