### PR TITLE
Link manifest option to the config section.

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -257,6 +257,8 @@ configuration.
    This overrides the default of using the control directory name (see :ref:`experiment_names`).
    The experiment name is generated as ``<experiment_prefix>-<branch_name>-<UUID>``.
 
+
+.. _manifests-config:
 Manifests
 ---------
 

--- a/docs/source/manifests.rst
+++ b/docs/source/manifests.rst
@@ -86,7 +86,7 @@ change the update hashes are saved in the manifest. These changes in the
 manifest files are then tracked with git.
 
 There are some configuration options available to change this default 
-behaviour.
+behaviour (see the :ref:`manifests-config` section for details).
 
 
 

--- a/docs/source/manifests.rst
+++ b/docs/source/manifests.rst
@@ -86,7 +86,7 @@ change the update hashes are saved in the manifest. These changes in the
 manifest files are then tracked with git.
 
 There are some configuration options available to change this default 
-behaviour (see the :ref:`manifests-config` section for details).
+behaviour (see the :ref:`manifests-config` section in :ref:`config` for details).
 
 
 


### PR DESCRIPTION
This PR puts a link in the "manifest option" chapter and refers it to the manifest section in "configuring your experiment".

Closes #831 