### PR TITLE
Handle empty-string timestamp, as well as other invalid string and None.

### DIFF
--- a/payu/schedulers/pbs.py
+++ b/payu/schedulers/pbs.py
@@ -59,7 +59,15 @@ def check_pbsnode_file(pbsnodes_json_path):
             # Check if the file is recent (modified within the last 7 days)
             with pbsnodes_json_path.open() as f:
                 pbsnodes_json = json.load(f)
-            timestamp = datetime.fromtimestamp(pbsnodes_json.get("timestamp", 0))
+        
+            try:
+                # Convert timestamp to float
+                raw_timestamp = float(pbsnodes_json.get("timestamp"))
+            except (ValueError, TypeError):
+                # Convert None, empty string or invalid string to 0
+                raw_timestamp = 0
+
+            timestamp = datetime.fromtimestamp(raw_timestamp)
 
             if (datetime.now() - timestamp) < timedelta(days=expire_day):
                 refresh_cache_file = False

--- a/test/test_pbs.py
+++ b/test/test_pbs.py
@@ -70,6 +70,9 @@ def test_get_queue_node_shape_no_matching_topology(monkeypatch):
     [
         (True, 0, 1),  # No timestamp
         (True, 100, 1),  # Old timestamp
+        (True, None, 1),  # None timestamp
+        (True, "invalid", 1),  # Invalid timestamp
+        (True, "", 1),  # Empty timestamp
         (True, 9999999999, 0),  # Recent timestamp
         (False, 0, 1),  # File doesn't exist
     ]


### PR DESCRIPTION
This PR addresses the issue of empty-string timestamp. It also handles other invalid strings and `None` as timestamp.

Closes #791 

Unit tests: added `""` and `None` as timestamp.

Manual tests:
- On a newly cloned OM2 configuration, ran `payu run -n 2` successfully.
- Changed the timestamp to `""` in the cached PBS file and ran `payu run`.
     - The timestamp was updated.
     - The cached PBS file was updated to include current job information.