### PR TITLE
Use furo as ReadTheDoc theme

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,7 +77,7 @@ jobs:
           cache: 'pip' # caching pip dependencies
 
       - name: Install payu and test dependencies
-        run: python3 -m pip install '.[test]'
+        run: python3 -m pip install '.[test, docs]'
 
       - name: Check payu installed correctly
         run: payu list

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,4 +30,6 @@ python:
   install:
     - method: pip
       path: . # Installs payu
+      extra_requirements:
+        - docs
 #    - requirements: docs/requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,7 +57,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinxdoc'
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,12 @@ test = [
     "pytest-cov",
     "pylint",
     "Sphinx",
+    "furo",
     "pytest-cov",
     "mnctools",
     "freezegun"
 ]
-mitgcm = ["mnctools>=0.2"]
+mitgcm = ["mnctools>=0.2"] 
 
 [project.scripts]
 payu = "payu.cli:parse"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,11 @@ test = [
     "pytest-cov",
     "pylint",
     "Sphinx",
-    "furo",
-    "pytest-cov",
     "mnctools",
     "freezegun"
 ]
 mitgcm = ["mnctools>=0.2"] 
+docs = ["furo"]
 
 [project.scripts]
 payu = "payu.cli:parse"


### PR DESCRIPTION
This PR switches the ReadTheDocs theme to [furo](https://furo.readthedocs.io/index.html). 

Closes #858 