### PR TITLE
Reset output path after setting the correct counter in postscript

### DIFF
--- a/payu/subcommands/postscript_cmd.py
+++ b/payu/subcommands/postscript_cmd.py
@@ -45,6 +45,7 @@ def runcmd(model_type=None, config_path=None, init_run=None, lab_path=None, dry_
     lab = Laboratory(model_type, config_path, lab_path)
     expt = Experiment(lab)
     expt.set_counters(keep_run_number=True)
+    expt.set_output_paths() # Reset the output path after resetting the run number
     
     # Submit through HPCpy
     # Job name is set to "payu_postscript"


### PR DESCRIPTION
This PR resets the output path in the `postscript_cmd.py` after calling `set_counter()`.

Closes #861 